### PR TITLE
Fix button overwriting class attribute. Fixes #89

### DIFF
--- a/src/button/button.directive.ts
+++ b/src/button/button.directive.ts
@@ -30,7 +30,7 @@ export class Button implements OnInit {
 	 */
 	@Input() size: "normal" | "sm" = "normal";
 	// a whole lot of HostBindings ... this way we don't have to touch the elementRef directly
-	@HostBinding("class") btnClass = "bx--btn";
+	@HostBinding("class.bx--btn") baseClass = true;
 	@HostBinding("class.bx--btn--primary") primary = true;
 	@HostBinding("class.bx--btn--secondary") secondary = false;
 	@HostBinding("class.bx--btn--tertiary") tertiary = false;


### PR DESCRIPTION
Closes IBM/carbon-components-angular #89

Updated the button directive to bind to `bx.bx--btn` instead of just `class`. This way a consumer of the library can apply their own styles on top of the base button.

#### Changelog
**Changed**
* Button directive class binding behavior
