### PR TITLE
chore(lint): introduce lint-staged and Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,195 +1,200 @@
+plugins: stylelint-prettier
+extends: stylelint-config-prettier
 rules:
-  # Colors
-  color-named: never
-  color-no-hex: true
+    # Prettier
+    prettier/prettier: true
 
-  # Fonts
-  font-family-name-quotes: always-where-recommended
-  font-family-no-duplicate-names: true
-  font-weight-notation: numeric
+    # Colors
+    color-named: never
+    color-no-hex: true
 
-  # Functions
-  function-blacklist:
-  - [mix, red, green, blue, rgb, rgba, lighten, darken]
-  - message: "Please use Matter's m_color() function instead"
-  function-calc-no-unspaced-operator: true
-  function-comma-newline-after: always-multi-line
-  function-comma-newline-before: never-multi-line
-  function-comma-space-after: always
-  function-comma-space-before: never
-  function-linear-gradient-no-nonstandard-direction: true
-  function-max-empty-lines: 0
-  function-name-case: lower
-  function-parentheses-newline-inside: never-multi-line
-  function-parentheses-space-inside: never
-  function-url-no-scheme-relative: true
-  function-url-quotes: always
-  function-whitespace-after: always
+    # Fonts
+    font-family-name-quotes: always-where-recommended
+    font-family-no-duplicate-names: true
+    font-weight-notation: numeric
 
-  # Strings
-  string-no-newline: true
-  string-quotes: double
+    # Functions
+    function-blacklist:
+        - [mix, red, green, blue, rgb, rgba, lighten, darken]
+        - message: "Please use Matter's m_color() function instead"
+    function-calc-no-unspaced-operator: true
+    function-comma-newline-after: always-multi-line
+    function-comma-newline-before: never-multi-line
+    function-comma-space-after: always
+    function-comma-space-before: never
+    function-linear-gradient-no-nonstandard-direction: true
+    function-max-empty-lines: 0
+    function-name-case: lower
+    function-parentheses-newline-inside: never-multi-line
+    function-parentheses-space-inside: never
+    function-url-no-scheme-relative: true
+    function-url-quotes: always
+    function-whitespace-after: always
 
-  # Numbers
-  number-leading-zero: always
-  number-max-precision: null
-  number-no-trailing-zeros: true
+    # Strings
+    string-no-newline: true
+    string-quotes: double
 
-  # Time
-  time-min-milliseconds: 100
+    # Numbers
+    number-leading-zero: always
+    number-max-precision: null
+    number-no-trailing-zeros: true
 
-  # Units
-  unit-case: lower
-  unit-no-unknown: true
+    # Time
+    time-min-milliseconds: 100
 
-  # Values
-  value-keyword-case: lower
-  value-list-comma-newline-after: always-multi-line
-  value-list-comma-newline-before: never-multi-line
-  value-list-comma-space-after: always
-  value-list-comma-space-before: never
-  value-list-max-empty-lines: 0
-  value-no-vendor-prefix: true
+    # Units
+    unit-case: lower
+    unit-no-unknown: true
 
-  # Properties
-  custom-property-empty-line-before: always
-  custom-property-pattern: null
-  property-case: lower
-  property-no-unknown: true
-  property-no-vendor-prefix: true
-  shorthand-property-no-redundant-values: true
+    # Values
+    value-keyword-case: lower
+    value-list-comma-newline-after: always-multi-line
+    value-list-comma-newline-before: never-multi-line
+    value-list-comma-space-after: always
+    value-list-comma-space-before: never
+    value-list-max-empty-lines: 0
+    value-no-vendor-prefix: true
 
-  # Declarations
-  keyframe-declaration-no-important: true
-  declaration-bang-space-after: never
-  declaration-bang-space-before: always
-  declaration-block-no-duplicate-properties: true
-  declaration-block-no-redundant-longhand-properties: true
-  declaration-block-no-shorthand-property-overrides: true
-  declaration-block-semicolon-newline-after: always
-  declaration-block-semicolon-newline-before: never-multi-line
-  declaration-block-semicolon-space-after: always-single-line
-  declaration-block-semicolon-space-before: never
-  declaration-block-single-line-max-declarations: 0
-  declaration-block-trailing-semicolon: always
-  declaration-colon-newline-after: always-multi-line
-  declaration-colon-space-after: always
-  declaration-colon-space-before: never
-  declaration-empty-line-before: null
-  declaration-no-important: true
+    # Properties
+    custom-property-empty-line-before: always
+    custom-property-pattern: null
+    property-case: lower
+    property-no-unknown: true
+    property-no-vendor-prefix: true
+    shorthand-property-no-redundant-values: true
 
-  # Blocks
-  block-closing-brace-empty-line-before: never
-  block-closing-brace-newline-after: always
-  block-closing-brace-newline-before: always
-  block-closing-brace-space-after: null
-  block-closing-brace-space-before: null
-  block-no-empty: true
-  block-opening-brace-newline-after: null
-  block-opening-brace-newline-before: null
-  block-opening-brace-space-after: always-single-line
-  block-opening-brace-space-before: always
+    # Declarations
+    keyframe-declaration-no-important: true
+    declaration-bang-space-after: never
+    declaration-bang-space-before: always
+    declaration-block-no-duplicate-properties: true
+    declaration-block-no-redundant-longhand-properties: true
+    declaration-block-no-shorthand-property-overrides: true
+    declaration-block-semicolon-newline-after: always
+    declaration-block-semicolon-newline-before: never-multi-line
+    declaration-block-semicolon-space-after: always-single-line
+    declaration-block-semicolon-space-before: never
+    declaration-block-single-line-max-declarations: 0
+    declaration-block-trailing-semicolon: always
+    declaration-colon-newline-after: always-multi-line
+    declaration-colon-space-after: always
+    declaration-colon-space-before: never
+    declaration-empty-line-before: null
+    declaration-no-important: true
 
-  # Selectors
-  selector-attribute-brackets-space-inside: never
-  selector-attribute-operator-space-after: never
-  selector-attribute-operator-space-before: never
-  selector-attribute-quotes: always
-  selector-class-pattern:
-  - ([a-z\-\_]+)
-  - resolveNestedSelectors: true
-  - message: "Class must contain only lowercase letters, hypens, and underscores"
-  selector-combinator-space-after: always
-  selector-combinator-space-before: always
-  selector-descendant-combinator-no-non-space: true
-  selector-id-pattern: null
-  selector-list-comma-newline-after: always
-  selector-list-comma-newline-before: never-multi-line
-  selector-list-comma-space-after: always-single-line
-  selector-list-comma-space-before: never
-  selector-max-attribute: null
-  selector-max-class: null
-  selector-max-combinators: null
-  selector-max-compound-selectors: null
-  selector-max-empty-lines: 0
-  selector-max-id: 0
-  selector-max-specificity: null
-  selector-max-type: null
-  selector-max-universal: 1
-  selector-nested-pattern: null
-  selector-no-qualifying-type:
-  - true
-  - ignore: [attribute, class]
-  selector-no-vendor-prefix: true
-  selector-pseudo-class-case: lower
-  selector-pseudo-class-no-unknown: true
-  selector-pseudo-class-parentheses-space-inside: never
-  selector-pseudo-element-case: lower
-  selector-pseudo-element-colon-notation: double
-  selector-pseudo-element-no-unknown: true
-  selector-type-case: lower
-  selector-type-no-unknown:
-  - true
-  - ignore: custom-elements
-  - ignoreTypes: /^n-/
-  - message: "Custom elements must start with 'n-'"
+    # Blocks
+    block-closing-brace-empty-line-before: never
+    block-closing-brace-newline-after: always
+    block-closing-brace-newline-before: always
+    block-closing-brace-space-after: null
+    block-closing-brace-space-before: null
+    block-no-empty: true
+    block-opening-brace-newline-after: null
+    block-opening-brace-newline-before: null
+    block-opening-brace-space-after: always-single-line
+    block-opening-brace-space-before: always
 
-  # Media
-  custom-media-pattern: null
-  media-feature-colon-space-after: always
-  media-feature-colon-space-before: never
-  media-feature-name-case: lower
-  media-feature-name-no-unknown: true
-  media-feature-name-no-vendor-prefix: true
-  media-feature-parentheses-space-inside: never
-  media-feature-range-operator-space-after: always
-  media-feature-range-operator-space-before: always
-  media-query-list-comma-newline-after: never-multi-line
-  media-query-list-comma-newline-before: never-multi-line
-  media-query-list-comma-space-after: always
-  media-query-list-comma-space-before: never
+    # Selectors
+    selector-attribute-brackets-space-inside: never
+    selector-attribute-operator-space-after: never
+    selector-attribute-operator-space-before: never
+    selector-attribute-quotes: always
+    selector-class-pattern:
+        - ([a-z\-\_]+)
+        - resolveNestedSelectors: true
+        - message: "Class must contain only lowercase letters, hypens, and underscores"
+    selector-combinator-space-after: always
+    selector-combinator-space-before: always
+    selector-descendant-combinator-no-non-space: true
+    selector-id-pattern: null
+    selector-list-comma-newline-after: always
+    selector-list-comma-newline-before: never-multi-line
+    selector-list-comma-space-after: always-single-line
+    selector-list-comma-space-before: never
+    selector-max-attribute: null
+    selector-max-class: null
+    selector-max-combinators: null
+    selector-max-compound-selectors: null
+    selector-max-empty-lines: 0
+    selector-max-id: 0
+    selector-max-specificity: null
+    selector-max-type: null
+    selector-max-universal: 1
+    selector-nested-pattern: null
+    selector-no-qualifying-type:
+        - true
+        - ignore: [attribute, class]
+    selector-no-vendor-prefix: true
+    selector-pseudo-class-case: lower
+    selector-pseudo-class-no-unknown: true
+    selector-pseudo-class-parentheses-space-inside: never
+    selector-pseudo-element-case: lower
+    selector-pseudo-element-colon-notation: double
+    selector-pseudo-element-no-unknown: true
+    selector-type-case: lower
+    selector-type-no-unknown:
+        - true
+        - ignore: custom-elements
+        - ignoreTypes: /^n-/
+        - message: "Custom elements must start with 'n-'"
 
-  # At-rule
-  at-rule-empty-line-before:
-  - always
-  - except: [after-same-name, first-nested]
-  - ignore: [after-comment]
-  at-rule-name-case: lower
-  at-rule-name-newline-after: always-multi-line
-  at-rule-name-space-after: always
-  at-rule-no-unknown:
-  - true
-  - ignoreAtRules: ["extend", "include"]
-  at-rule-no-vendor-prefix: true
-  at-rule-semicolon-newline-after: always
-  at-rule-semicolon-space-before: never
+    # Media
+    custom-media-pattern: null
+    media-feature-colon-space-after: always
+    media-feature-colon-space-before: never
+    media-feature-name-case: lower
+    media-feature-name-no-unknown: true
+    media-feature-name-no-vendor-prefix: true
+    media-feature-parentheses-space-inside: never
+    media-feature-range-operator-space-after: always
+    media-feature-range-operator-space-before: always
+    media-query-list-comma-newline-after: never-multi-line
+    media-query-list-comma-newline-before: never-multi-line
+    media-query-list-comma-space-after: always
+    media-query-list-comma-space-before: never
 
-  # Comments
-  comment-empty-line-before:
-  - always
-  - except: ["first-nested"]
-  - ignore: ["after-comment", "stylelint-commands"]
-  comment-no-empty: true
-  comment-whitespace-inside: always
+    # At-rule
+    at-rule-empty-line-before:
+        - always
+        - except: [after-same-name, first-nested]
+        - ignore: [after-comment]
+    at-rule-name-case: lower
+    at-rule-name-newline-after: always-multi-line
+    at-rule-name-space-after: always
+    at-rule-no-unknown:
+        - true
+        - ignoreAtRules: ["extend", "include"]
+    at-rule-no-vendor-prefix: true
+    at-rule-semicolon-newline-after: always
+    at-rule-semicolon-space-before: never
 
-  # Disallows
-  no-descending-specificity: null
-  no-duplicate-selectors: true
-  no-empty-source: true
-  no-eol-whitespace: true
-  no-extra-semicolons: true
-  no-invalid-double-slash-comments: null
-  no-missing-end-of-source-newline: true
-  no-unknown-animations: true
+    # Comments
+    comment-empty-line-before:
+        - always
+        - except: ["first-nested"]
+        - ignore: ["after-comment", "stylelint-commands"]
+    comment-no-empty: true
+    comment-whitespace-inside: always
 
-  # Misc
-  indentation: tab
-  length-zero-no-unit: true
-  max-empty-lines: 1
-  max-line-length: null
-  max-nesting-depth:
-  - 2
-  - ignore: ["blockless-at-rules"]
-  rule-empty-line-before:
-  - always
-  - except: [after-single-line-comment, first-nested]
+    # Disallows
+    no-descending-specificity: null
+    no-duplicate-selectors: true
+    no-empty-source: true
+    no-eol-whitespace: true
+    no-extra-semicolons: true
+    no-invalid-double-slash-comments: null
+    no-missing-end-of-source-newline: true
+    no-unknown-animations: true
+
+    # Misc
+    indentation: tab
+    length-zero-no-unit: true
+    max-empty-lines: 1
+    max-line-length: null
+    max-nesting-depth:
+        - 2
+        - ignore: ["blockless-at-rules"]
+    rule-empty-line-before:
+        - always
+        - except: [after-single-line-comment, first-nested]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,35 +2,33 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "8"
+    - "8"
 addons:
-  chrome: stable
+    chrome: stable
 before_install:
-  - "google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
+    - "google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &"
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "sleep 3"
-  - "sudo chown root /opt/google/chrome/chrome-sandbox"
-  - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
+    - "export DISPLAY=:99.0"
+    - "sh -e /etc/init.d/xvfb start"
+    - "sleep 3"
+    - "sudo chown root /opt/google/chrome/chrome-sandbox"
+    - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 script: "npm run lint && npm test"
 deploy:
-  -
-    provider: script
-    script: "bash ./scripts/deploy.sh"
-    skip_cleanup: true
-    true:
-      branch: master
-  -
-    allow-empty-commit: true
-    email: carbon@us.ibm.com
-    github-token: $GH_TOKEN
-    keep-history: true
-    local-dir: pages
-    name: carbon-bot
-    provider: pages
-    skip_cleanup: true
-    true:
-      branch: master
+    - provider: script
+      script: "bash ./scripts/deploy.sh"
+      skip_cleanup: true
+      true:
+          branch: master
+    - allow-empty-commit: true
+      email: carbon@us.ibm.com
+      github-token: $GH_TOKEN
+      keep-history: true
+      local-dir: pages
+      name: carbon-bot
+      provider: pages
+      skip_cleanup: true
+      true:
+          branch: master
 notifications:
-  email: false
+    email: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,23 @@
         }
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      },
+      "dependencies": {
+        "any-observable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+          "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+          "dev": true
+        }
+      }
+    },
     "@semantic-release/commit-analyzer": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-6.1.0.tgz",
@@ -1948,7 +1965,7 @@
         },
         "style-loader": {
           "version": "0.20.3",
-          "resolved": "http://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
+          "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.20.3.tgz",
           "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
           "dev": true,
           "requires": {
@@ -4197,7 +4214,7 @@
     },
     "bl": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "dev": true,
       "optional": true,
@@ -4238,7 +4255,7 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
       "dev": true
     },
@@ -4638,7 +4655,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -4712,7 +4729,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -5112,7 +5129,7 @@
       "dependencies": {
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         }
@@ -5272,7 +5289,7 @@
     },
     "color": {
       "version": "0.11.4",
-      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
@@ -5694,7 +5711,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
           "dev": true
         },
@@ -6119,7 +6136,7 @@
     },
     "core-js": {
       "version": "2.5.5",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
       "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
       "dev": true
     },
@@ -6283,7 +6300,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -6299,7 +6316,7 @@
     },
     "css-loader": {
       "version": "0.28.11",
-      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.11.tgz",
       "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
       "dev": true,
       "requires": {
@@ -6383,7 +6400,7 @@
     },
     "css-select": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "dev": true,
       "requires": {
@@ -6618,7 +6635,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -7147,7 +7164,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -7338,7 +7355,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -7846,7 +7863,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -8535,8 +8552,14 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
     "fast-glob": {
@@ -8603,7 +8626,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }
@@ -8630,7 +8653,7 @@
     },
     "file-loader": {
       "version": "1.1.11",
-      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.11.tgz",
       "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
       "dev": true,
       "requires": {
@@ -8721,6 +8744,12 @@
         "findup-sync": "0.4.2",
         "merge": "^1.2.0"
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-root": {
       "version": "1.0.0",
@@ -8977,7 +9006,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -9799,6 +9828,12 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -9807,7 +9842,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -10540,7 +10575,7 @@
     },
     "gulp": {
       "version": "3.9.1",
-      "resolved": "http://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
       "dev": true,
       "requires": {
@@ -10586,7 +10621,7 @@
         },
         "semver": {
           "version": "4.3.6",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
           "dev": true
         },
@@ -11011,7 +11046,7 @@
     },
     "hoist-non-react-statics": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
       "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
       "dev": true
     },
@@ -11147,7 +11182,7 @@
     },
     "htmlparser2": {
       "version": "3.3.0",
-      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
       "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
       "dev": true,
       "requires": {
@@ -12294,7 +12329,7 @@
     },
     "isemail": {
       "version": "2.2.1",
-      "resolved": "http://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
       "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
       "dev": true
     },
@@ -12476,7 +12511,7 @@
     },
     "jasmine-core": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.1.0.tgz",
       "integrity": "sha1-pHheE11d9lAk38kiSVPfWFvSdmw=",
       "dev": true
     },
@@ -12494,6 +12529,24 @@
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-0.2.10.tgz",
       "integrity": "sha512-CpKJh9VRNhS+XqZtg1UMejETGEiqwCGDC/uwPEEQwc2nfdbSm73SIE29TplG2gLYuBOOTNDqxzG6A9NtEPLt0w==",
       "dev": true
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
+      "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.1.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^23.6.0"
+      }
     },
     "joi": {
       "version": "9.2.0",
@@ -13234,6 +13287,12 @@
         "pify": "^3.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -13325,6 +13384,132 @@
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "lint-staged": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz",
+      "integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "commander": "^2.14.1",
+        "cosmiconfig": "^5.0.2",
+        "debug": "^3.1.0",
+        "dedent": "^0.7.0",
+        "execa": "^0.9.0",
+        "find-parent-dir": "^0.3.0",
+        "is-glob": "^4.0.0",
+        "is-windows": "^1.0.2",
+        "jest-validate": "^23.5.0",
+        "listr": "^0.14.1",
+        "lodash": "^4.17.5",
+        "log-symbols": "^2.2.0",
+        "micromatch": "^3.1.8",
+        "npm-which": "^3.0.1",
+        "p-map": "^1.1.1",
+        "path-is-inside": "^1.0.2",
+        "pify": "^3.0.0",
+        "please-upgrade-node": "^3.0.2",
+        "staged-git-files": "1.1.1",
+        "string-argv": "^0.0.2",
+        "stringify-object": "^3.2.2"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+          "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
+          "dev": true,
+          "requires": {
+            "is-directory": "^0.3.1",
+            "js-yaml": "^3.9.0",
+            "parse-json": "^4.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "dedent": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+          "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+          "dev": true
+        },
+        "execa": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz",
+          "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+          "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          }
+        },
+        "listr": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.2.tgz",
+          "integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
+          "dev": true,
+          "requires": {
+            "@samverschueren/stream-to-observable": "^0.3.0",
+            "is-observable": "^1.1.0",
+            "is-promise": "^2.1.0",
+            "is-stream": "^1.1.0",
+            "listr-silent-renderer": "^1.1.1",
+            "listr-update-renderer": "^0.4.0",
+            "listr-verbose-renderer": "^0.4.0",
+            "p-map": "^1.1.1",
+            "rxjs": "^6.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         }
       }
@@ -13673,7 +13858,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -14173,7 +14358,7 @@
         },
         "form-data": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.0.0.tgz",
           "integrity": "sha1-bwrrrcxdoWwT4ezBETfYX5uIOyU=",
           "dev": true,
           "optional": true,
@@ -14577,7 +14762,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -14679,7 +14864,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -15145,7 +15330,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         }
@@ -18618,6 +18803,15 @@
         }
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.10"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -18625,6 +18819,17 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.9.0",
+        "npm-path": "^2.0.2",
+        "which": "^1.2.10"
       }
     },
     "npmlog": {
@@ -20427,7 +20632,7 @@
     },
     "postcss-import": {
       "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.1.0.tgz",
       "integrity": "sha512-5l327iI75POonjxkXgdRCUS+AlzAdBx4pOvMEhTKTCjb1p8IEeVR9yx3cPbmN7LIWJLbfnIXxAhoB4jpD0c/Cw==",
       "dev": true,
       "requires": {
@@ -21868,10 +22073,19 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.1.tgz",
+      "integrity": "sha512-4rgV2hyc/5Pk0XHH4VjJWHRgVjgRbpMfLQjREAhHBtyW1UvTFkjJEsueGYNYYZd9mn97K+1qv0EBwm11zoaSgA==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "4.0.2",
@@ -21889,9 +22103,27 @@
         "utila": "~0.4"
       }
     },
+    "pretty-format": {
+      "version": "23.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
+      "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
+      }
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -22557,7 +22789,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -22597,7 +22829,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -22890,7 +23122,7 @@
     },
     "regjsgen": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
       "dev": true
     },
@@ -23327,7 +23559,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -24640,6 +24872,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "staged-git-files": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+      "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
+      "dev": true
+    },
     "state-toggle": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
@@ -24811,6 +25049,12 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string-argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.0.2.tgz",
+      "integrity": "sha1-2sMECGkMIfPDYwo/86BYd73L1zY=",
+      "dev": true
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -24884,6 +25128,17 @@
         "is-hexadecimal": "^1.0.0"
       }
     },
+    "stringify-object": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.2.tgz",
+      "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "^2.0.1",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      }
+    },
     "stringstream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
@@ -24932,7 +25187,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -25351,6 +25606,21 @@
           "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
           "dev": true
         }
+      }
+    },
+    "stylelint-config-prettier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-4.0.0.tgz",
+      "integrity": "sha512-cwh3QbBC2+3zBeMvuxFjT8XsbSdyoyELOY9BZqMuvphUKEQ+srkPWoN60FlvRwLB014TOke4Y12KvTtfKnaHhg==",
+      "dev": true
+    },
+    "stylelint-prettier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.0.3.tgz",
+      "integrity": "sha512-yzlhOKg2AmzGmKfWN9LPONr7/8O15QkGLtofhDsbpiEHCXMS5fZbQ0lcjopOAm6iU7vzETRFbOSHrDNJCRepbA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "stylelint-webpack-plugin": {
@@ -25948,7 +26218,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -26026,7 +26296,7 @@
     },
     "tslint-loader": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslint-loader/-/tslint-loader-3.6.0.tgz",
       "integrity": "sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==",
       "dev": true,
       "requires": {
@@ -26782,7 +27052,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -27117,7 +27387,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -8,11 +8,18 @@
     "storybook": "start-storybook -s .storybook/public -p 6006",
     "docs:build": "compodoc src -p tsconfig.json",
     "docs:server": "compodoc src -p tsconfig.json -s -w",
-    "lint": "tslint src/**/*.ts && stylelint src/**/*.scss --config .stylelintrc.yml",
+    "lint": "npm run lint:script && npm run lint:styles",
+    "lint:script": "tslint src/**/*.ts",
+    "lint:script:staged": "tslint",
+    "lint:styles": "stylelint src/**/*.scss --config .stylelintrc.yml",
+    "lint:styles:staged": "stylelint --config .stylelintrc.yml",
+    "format": "prettier --write ./**/*.{js,scss,yml}",
+    "format:staged": "prettier --write",
     "test": "karma start",
     "test:watch": "karma start --auto-watch --no-single-run",
     "utils:add": "git subtree add --prefix=src/utils git@github.ibm.com:peretz/utils.git master --squash",
     "utils:update": "git subtree pull --prefix=src/utils git@github.ibm.com:peretz/utils.git master --squash",
+    "precommit": "lint-staged",
     "build-storybook": "build-storybook -c .storybook -s .storybook/public -o dist/docs/storybook",
     "semantic-release": "semantic-release",
     "commit": "git-cz"
@@ -47,6 +54,28 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog-components"
     }
+  },
+  "lint-staged": {
+    "*.ts": [
+      "npm run lint:script:staged",
+      "npm run format:staged",
+      "git add"
+    ],
+    "*.scss": [
+      "npm run lint:styles:staged",
+      "npm run format:staged",
+      "git add"
+    ],
+    "*.{js,css,md,yml}": [
+      "npm run format:staged",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "printWidth": 140,
+    "singleQuote": false,
+    "useTabs": true,
+    "trailingComma": "none"
   },
   "repository": {
     "type": "git",
@@ -122,8 +151,10 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-spec-reporter": "0.0.32",
     "karma-webpack": "3.0.0",
+    "lint-staged": "7.3.0",
     "node-sass": "4.9.3",
     "postcss-loader": "2.1.4",
+    "prettier": "1.15.1",
     "raw-loader": "0.5.1",
     "run-sequence": "2.2.0",
     "rxjs": "6.2.2",
@@ -131,6 +162,8 @@
     "semantic-release": "15.10.6",
     "style-loader": "0.21.0",
     "stylelint": "8.4.0",
+    "stylelint-config-prettier": "4.0.0",
+    "stylelint-prettier": "1.0.3",
     "stylelint-webpack-plugin": "0.10.4",
     "svgxuse": "1.2.6",
     "ts-helpers": "1.1.2",


### PR DESCRIPTION
(Please use Diff settings - Hide whitespace changes for easier review)

This change introduces `lint-staged` and Prettier. Prettier is not applied to TypeScript code yet, given current version of Prettier adds newlines to all decorators, and it doesn't seem to be what the team here wants.

Let me know if there are any changes/configs that drift from what the team here desires - Thanks!

#### Changelog

**New**

* `lint-staged` running:
    * TSLint for TypeScript files
    * StyleLint and Prettier for SCSS files
    * Prettier for JavaScript/CSS/Markdown/YAML files

**Changed**

* Several format change (esp. YAML files) upon Prettier