### PR TITLE
chore(test): skip type checking for tests

### DIFF
--- a/webpack.test.js
+++ b/webpack.test.js
@@ -5,7 +5,10 @@ module.exports = [{
 		rules: [
 			{
 				test: /\.ts$/,
-				loaders: ["ts-loader"]
+				loader: "ts-loader",
+				options: {
+					transpileOnly: true
+				}
 			},
 			{
 				test: /\.html$/,


### PR DESCRIPTION
#### Changelog

**Changed**

* `karma-webpack` config to disable type checking for tests, for faster running of test. (Wondering if it makes sense to everybody - Let me know if not!)