### PR TITLE
Fix DAP issues for Modal

### DIFF
--- a/src/modal/alert-modal.component.ts
+++ b/src/modal/alert-modal.component.ts
@@ -58,7 +58,7 @@ import Modal from "./modal.decorator";
 @Component({
 	selector: "ibm-alert-modal",
 	template: `
-		<ibm-modal [modalType]="modalType">
+		<ibm-modal [modalType]="modalType" [modalLabel]="modalTitle">
 			<ibm-modal-header (closeSelect)="closeModal()">
 				<p class="bx--modal-header__label bx--type-delta">{{modalLabel}}</p>
       			<p class="bx--modal-header__heading bx--type-beta">{{modalTitle}}</p>

--- a/src/modal/modal-footer.component.ts
+++ b/src/modal/modal-footer.component.ts
@@ -8,7 +8,7 @@ import { Component } from "@angular/core";
 @Component({
 	selector: "ibm-modal-footer",
 	template: `
-		<footer role="contentinfo" class="bx--modal-footer">
+		<footer class="bx--modal-footer">
 			<ng-content></ng-content>
 		</footer>
 	`

--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -18,7 +18,7 @@ import { Component, Output, EventEmitter, Input } from "@angular/core";
 @Component({
 	selector: "ibm-modal-header",
 	template: `
-		<header class="{{modalType}} bx--modal-header" role="banner">
+		<header class="{{modalType}} bx--modal-header">
 			<div class="bx--modal-header">
 				<ng-content></ng-content>
 			</div>

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -90,10 +90,11 @@ import { cycleTabs } from "./../common/tab.service";
 			<div
 				class="bx--modal-container"
 				[@modalState]="modalState"
-				role="main"
+				role="dialog"
 				aria-modal="true"
 				tabindex="0"
 				style="z-index:1;"
+				[attr.aria-label]="modalLabel"
 				#modal>
 				<ng-content></ng-content>
 			</div>
@@ -125,6 +126,13 @@ export class ModalComponent implements AfterViewInit, OnInit, OnDestroy {
 	 * @memberof ModalComponent
 	 */
 	@Input() modalType = "default";
+
+	/**
+	 * Label for the modal.
+	 * @memberof ModalComponent
+	 */
+	@Input() modalLabel = "default";
+
 	/**
 	 * Emits event when click occurs within `n-overlay` element. This is to track click events occuring outside bounds of the `Modal` object.
 	 * @memberof ModalComponent

--- a/src/modal/modal.service.ts
+++ b/src/modal/modal.service.ts
@@ -86,7 +86,7 @@ export class ModalService {
 	 * @returns {ComponentRef<any>}
 	 * @memberof ModalService
 	 */
-	show(data: {modalType?: string, modalLabel?: string, modalTitle?: string, modalContent?: string, buttons?: []}) {
+	show(data: {modalType?: string, modalLabel?: string, modalTitle?: string, modalContent?: string, buttons?: any[]}) {
 		return this.create({
 			component: AlertModalComponent,
 			inputs: {

--- a/src/modal/modal.service.ts
+++ b/src/modal/modal.service.ts
@@ -87,7 +87,7 @@ export class ModalService {
 	 * @returns {ComponentRef<any>}
 	 * @memberof ModalService
 	 */
-show(data: AlertModalData) {
+	show(data: AlertModalData) {
 		return this.create({
 			component: AlertModalComponent,
 			inputs: {


### PR DESCRIPTION
Changes made: 
1. change role from main to dialog on div
2. add label for dialog role
3. remove banner and content-info per html 5 usage
4. Add any to service method for compiling. To resolve this: error TS1122: A tuple type element list cannot be empty.

Closes IBM/carbon-components-angular #114
fixes #158

Resolves the DAP violations for the modal

#### Changelog


**Changed**

* Changes to the various attributes on the modal to comply with accessibility


