### PR TITLE
Accordion DAP fixes

### DIFF
--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -36,7 +36,9 @@ export class AccordionItem {
 
 	@HostBinding("class.bx--accordion__item") itemClass = true;
 	@HostBinding("class.bx--accordion__item--active") @Input() expanded = false;
-	@HostBinding("style.display") @HostBinding("attr.role") itemType = "list-item";
+	@HostBinding("style.display") itemType = "list-item";
+	@HostBinding("attr.role") roleType = "heading";
+	@HostBinding("attr.aria-level") @Input() ariaLevel = 3;
 
 	constructor() {
 		AccordionItem.accordionItemCount++;

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -37,7 +37,7 @@ export class AccordionItem {
 	@HostBinding("class.bx--accordion__item") itemClass = true;
 	@HostBinding("class.bx--accordion__item--active") @Input() expanded = false;
 	@HostBinding("style.display") itemType = "list-item";
-	@HostBinding("attr.role") roleType = "heading";
+	@HostBinding("attr.role") role = "heading";
 	@HostBinding("attr.aria-level") @Input() ariaLevel = 3;
 
 	constructor() {


### PR DESCRIPTION
Closes IBM/carbon-components-angular #106

Fix DAP issues for Accordion
Set the role to heading and use aria-level per guidelines.
Defaulting level to 3 since must pages have heading level 1 already.
User can override.

#### Changelog

**Changed**

* Set the role to heading and use aria-level per guidelines.

