### PR TITLE
Add styles for Select component

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -29,7 +29,10 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 	template: `
 		<div class="bx--form-item">
 			<div
-				[ngClass]="{'bx--select--inline': display === 'inline'}"
+				[ngClass]="{
+					'bx--select--inline': display === 'inline',
+					'bx--select--light': theme === 'light'
+				}"
 				class="bx--select">
 				<label [attr.for]="id" class="bx--label">{{label}}</label>
 				<select
@@ -76,6 +79,10 @@ export class Select implements ControlValueAccessor {
 	 * Set to true to disable component.
 	 */
 	@Input() disabled = false;
+	/**
+	 * `light` or `dark` select theme
+	 */
+	@Input() theme: "light" | "dark" = "dark";
 	/**
 	 * emits the selected options `value`
 	 */

--- a/src/select/select.stories.ts
+++ b/src/select/select.stories.ts
@@ -44,7 +44,7 @@ storiesOf("Select", module).addDecorator(
 	}))
 	.add("Light", () => ({
 		template: `
-		<ibm-select [theme]="'light'">
+		<ibm-select theme="light">
 			<option value="" disabled selected hidden>Choose an option</option>
           <option value="solong">A much longer option that is worth having around to check how text flows</option>
           <optgroup label="Category 1">

--- a/src/select/select.stories.ts
+++ b/src/select/select.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { action } from "@storybook/addon-actions";
-import { withKnobs, boolean } from "@storybook/addon-knobs/angular";
+import { withKnobs } from "@storybook/addon-knobs/angular";
 
 import { SelectModule } from "../";
 
@@ -29,6 +29,22 @@ storiesOf("Select", module).addDecorator(
 	.add("Inline", () => ({
 		template: `
 		<ibm-select display="inline">
+			<option value="" disabled selected hidden>Choose an option</option>
+          <option value="solong">A much longer option that is worth having around to check how text flows</option>
+          <optgroup label="Category 1">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+          </optgroup>
+          <optgroup label="Category 2">
+              <option value="option1">Option 1</option>
+              <option value="option2">Option 2</option>
+          </optgroup>
+		</ibm-select>
+	`
+	}))
+	.add("Light", () => ({
+		template: `
+		<ibm-select [theme]="'light'">
 			<option value="" disabled selected hidden>Choose an option</option>
           <option value="solong">A much longer option that is worth having around to check how text flows</option>
           <optgroup label="Category 1">


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

add styles for Select component, for issue #163 

#### Changelog

**Changed**

* `light` and `inline` styles as per Carbon design:
http://www.carbondesignsystem.com/components/select/code

Inline:
<img width="954" alt="screen shot 2018-10-26 at 17 31 26" src="https://user-images.githubusercontent.com/22054715/47579812-008cd300-d945-11e8-8c4c-6d90c333aadc.png">

Light:
<img width="951" alt="screen shot 2018-10-26 at 17 31 14" src="https://user-images.githubusercontent.com/22054715/47579830-0bdffe80-d945-11e8-82e9-ef5eeea06e97.png">
