### PR TITLE
Add light style to Input Component

### DIFF
--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding } from "@angular/core";
+import { Directive, HostBinding, Input } from "@angular/core";
 
 /**
  * A directive for applying styling to an input element.
@@ -16,4 +16,5 @@ import { Directive, HostBinding } from "@angular/core";
 })
 export class TextInput {
 	@HostBinding("class.bx--text-input") inputClass = true;
+	@HostBinding("class.bx--text-input--light") @Input() light = false;
 }

--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -15,6 +15,13 @@ import { Directive, HostBinding, Input } from "@angular/core";
 	selector: "[ibmText]"
 })
 export class TextInput {
+	/**
+	 * `light` or `dark` input theme
+	 */
+	@Input() theme: "light" | "dark" = "dark";
+
 	@HostBinding("class.bx--text-input") inputClass = true;
-	@HostBinding("class.bx--text-input--light") @Input() light = false;
+	@HostBinding("class.bx--text-input--light") get isLightTheme() {
+		return this.theme === "light";
+	}
 }

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -25,7 +25,7 @@ storiesOf("Input", module).addDecorator(
 	}))
 	.add("Light Input", () => ({
 		template: `
-			<input ibmText [theme]="'light'" aria-label="input" placeholder="Optional placeholder text"/>
+			<input ibmText theme="light" aria-label="input" placeholder="Optional placeholder text"/>
 		`
 	}))
 	.add("TextArea", () => ({

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -1,6 +1,6 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { action } from "@storybook/addon-actions";
-import { withKnobs, boolean } from "@storybook/addon-knobs/angular";
+import { withKnobs } from "@storybook/addon-knobs/angular";
 
 import { InputModule } from "../";
 
@@ -22,8 +22,19 @@ storiesOf("Input", module).addDecorator(
 		template: `
 			<input ibmText aria-label="input" placeholder="Optional placeholder text"/>
 		`
-	})).add("TextArea", () => ({
+	}))
+	.add("Light Input", () => ({
+		template: `
+			<input ibmText [light]="true" aria-label="input" placeholder="Optional placeholder text"/>
+		`
+	}))
+	.add("TextArea", () => ({
 		template: `
 		<textarea ibmTextArea aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
+		`
+	}))
+	.add("Light TextArea", () => ({
+		template: `
+		<textarea ibmTextArea [light]="true" aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
 		`
 	}));

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -25,7 +25,7 @@ storiesOf("Input", module).addDecorator(
 	}))
 	.add("Light Input", () => ({
 		template: `
-			<input ibmText [light]="true" aria-label="input" placeholder="Optional placeholder text"/>
+			<input ibmText [theme]="'light'" aria-label="input" placeholder="Optional placeholder text"/>
 		`
 	}))
 	.add("TextArea", () => ({
@@ -35,6 +35,6 @@ storiesOf("Input", module).addDecorator(
 	}))
 	.add("Light TextArea", () => ({
 		template: `
-		<textarea ibmTextArea [light]="true" aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
+		<textarea ibmTextArea [theme]="'light'" aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
 		`
 	}));

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -35,6 +35,6 @@ storiesOf("Input", module).addDecorator(
 	}))
 	.add("Light TextArea", () => ({
 		template: `
-		<textarea ibmTextArea [theme]="'light'" aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
+		<textarea ibmTextArea theme="light" aria-label="textarea" placeholder="Optional placeholder text" rows="4" cols="50"></textarea>
 		`
 	}));

--- a/src/input/text-area.directive.ts
+++ b/src/input/text-area.directive.ts
@@ -15,6 +15,13 @@ import { Directive, HostBinding, Input } from "@angular/core";
 	selector: "[ibmTextArea]"
 })
 export class TextArea {
+	/**
+	 * `light` or `dark` input theme
+	 */
+	@Input() theme: "light" | "dark" = "dark";
+
 	@HostBinding("class.bx--text-area") baseClass = true;
-	@HostBinding("class.bx--text-area--light") @Input() light = false;
+	@HostBinding("class.bx--text-area--light") get isLightTheme() {
+		return this.theme === "light";
+	}
 }

--- a/src/input/text-area.directive.ts
+++ b/src/input/text-area.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, HostBinding } from "@angular/core";
+import { Directive, HostBinding, Input } from "@angular/core";
 
 /**
  * A directive for applying styling to a textarea element.
@@ -16,4 +16,5 @@ import { Directive, HostBinding } from "@angular/core";
 })
 export class TextArea {
 	@HostBinding("class.bx--text-area") baseClass = true;
+	@HostBinding("class.bx--text-area--light") @Input() light = false;
 }


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Add support for light style for Input component:
http://www.carbondesignsystem.com/components/text-input/code#skip-to-content
(select `field-02` to see the light design)

#### Changelog

**Changed**

* Add @Input for light to apply light CSS to both Text Input and Text Area

Text Input:
<img width="953" alt="screen shot 2018-10-26 at 22 10 48" src="https://user-images.githubusercontent.com/22054715/47592729-6b9dd000-d96c-11e8-8f45-65c878fb99ce.png">

Text Area:
<img width="951" alt="screen shot 2018-10-26 at 22 11 14" src="https://user-images.githubusercontent.com/22054715/47592738-75273800-d96c-11e8-890b-c74bc3df94c5.png">
