### PR TITLE
fix(tabs): Redefine tab selection area

### DIFF
--- a/src/tabs/tab-headers.component.spec.ts
+++ b/src/tabs/tab-headers.component.spec.ts
@@ -1,0 +1,26 @@
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { StaticIconModule } from "../icon/static-icon.module";
+
+import { TabHeaders } from "./tab-headers.component";
+
+describe("TabHeadersComponent", () => {
+	let component: TabHeaders;
+	let fixture: ComponentFixture<TabHeaders>;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [TabHeaders],
+			imports: [BrowserAnimationsModule, StaticIconModule],
+			providers: []
+		});
+
+		fixture = TestBed.createComponent(TabHeaders);
+		component = fixture.componentInstance;
+	});
+
+	it("should work", () => {
+		expect(component instanceof TabHeaders).toBe(true);
+	});
+
+});

--- a/src/tabs/tab-headers.component.spec.ts
+++ b/src/tabs/tab-headers.component.spec.ts
@@ -22,5 +22,4 @@ describe("TabHeadersComponent", () => {
 	it("should work", () => {
 		expect(component instanceof TabHeaders).toBe(true);
 	});
-
 });

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -53,12 +53,12 @@ import { Tab } from "./tab.component";
 						'bx--tabs__nav-item--selected': tab.active
 					}"
 					class="bx--tabs__nav-item"
-					role="presentation">
+					role="presentation"
+					(click)="selectTab(tabref, tab, i)">
 					<a
 						[attr.aria-selected]="tab.active"
 						[attr.tabindex]="(tab.active?0:-1)"
 						[attr.aria-controls]="tab.id"
-						(click)="selectTab(tabref, tab, i)"
 						(focus)="onTabFocus(tabref, i)"
 						draggable="false"
 						id="{{tab.id}}-header"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#201

Tab selection was only triggered by clicking on the tab title, not the entire heading area.

#### Changelog

**Changed**

* Move `(click)="selectTab(tabref, tab, i)"` from `<a>` to `<li>` tag.
