### PR TITLE
chore(readme): remove useless app.module example

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cal-smith @zvonimirfras @magedhennawy
+* @cal-smith @zvonimirfras @magedhennawy @youda97

--- a/README.md
+++ b/README.md
@@ -31,28 +31,7 @@ Then we need to include carbon-components in `src/styles.scss`:
 
 > *Note:* For offline usage we'll need to set `$font-path: '~carbon-components/src/globals/fonts';` at the very top of our `src/styles.scss`. This will copy the fonts to our `dist` folder upon successful build. If you like the fonts to be a part of your `assets` folder and not pollute the `dist` folder then copy the fonts from `node_modules/carbon-components/src/globals/fonts` into our app's `src/assets/fonts` folder and add `$font-path: '/assets/fonts/';` at the very top of our `src/styles.scss`.
 
-Then set up our translations in `src/app/app.module.ts`:
-
-```ts
-import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
-
-import { AppComponent } from './app.component';
-
-@NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [
-	BrowserModule,
-  ],
-  providers: [],
-  bootstrap: [AppComponent]
-})
-export class AppModule { }
-```
-
-_Finally_ we can run `npm start` and start building out our application!
+That's it! Now we can run `npm start` and start building out our application!
 
 > *Note:* This isn't the only way to bootstrap a `carbon-components-angular` application, but the combination of `@angular/cli` and the `carbon-components` scss is our recommended setup.
 


### PR DESCRIPTION
Since we don't have to configure translations by default anymore we can drop the whole app.module example

Also adds @youda97 as a code owner so I don't have to manually add him to the reviewer list 😀 