### PR TITLE
fix(toggle): Support checked input

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -137,14 +137,14 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Reflects whether the checkbox state is indeterminate.
 	 * @readonly
 	 */
-	@Input() get indeterminate() {
+	get indeterminate() {
 		return this._indeterminate;
 	}
 
 	/**
 	 * Set the checkbox's indeterminate state to match the parameter and transition the view to reflect the change.
 	 */
-	set indeterminate(indeterminate: boolean) {
+	@Input() set indeterminate(indeterminate: boolean) {
 		let changed = this._indeterminate !== indeterminate;
 		this._indeterminate = indeterminate;
 
@@ -161,14 +161,14 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Returns value `true` if state is selected for the checkbox.
 	 * @readonly
 	 */
-	@Input() get checked() {
+	get checked() {
 		return this._checked;
 	}
 
 	/**
 	 * Updating the state of a checkbox to match the state of the parameter passed in.
 	 */
-	set checked (checked: boolean) {
+	@Input() set checked (checked: boolean) {
 		if (checked !== this.checked) {
 			if (this._indeterminate) {
 				Promise.resolve().then(() => {

--- a/src/switch/switch.component.spec.ts
+++ b/src/switch/switch.component.spec.ts
@@ -64,4 +64,10 @@ describe("Switch", () => {
 		expect(labelElement.innerHTML).toContain("bx--toggle__check");
 	});
 
+	it("should match the input checked value", () => {
+		component.checked = true;
+		fixture.detectChanges();
+		expect(buttonElement.attributes.getNamedItem("aria-checked").value).toEqual("true");
+	});
+
 });

--- a/src/switch/switch.component.ts
+++ b/src/switch/switch.component.ts
@@ -51,14 +51,19 @@ export class SwitchChange {
 	template: `
 		<input
 			class="bx--toggle"
+			type="checkbox"
 			[ngClass]="{
 				'bx--toggle--small': size === 'sm'
 			}"
 			[id]="id"
-			type="checkbox"
-			(click)="onClick($event)"
+			[value]="value"
+			[name]="name"
+			[required]="required"
+			[checked]="checked"
 			[disabled]="disabled"
-			[attr.aria-checked]="checked">
+			[attr.aria-checked]="checked"
+			(change)="onChange($event)"
+			(click)="onClick($event)">
 		<label *ngIf="size === 'md'" class="bx--toggle__label" [for]="id">
 			<span class="bx--toggle__text--left">Off</span>
 			<span class="bx--toggle__appearance"></span>

--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -1,18 +1,15 @@
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ComponentFixture, TestBed, fakeAsync, tick, async } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
-import { DebugElement } from "@angular/core";
 import { StaticIconModule } from "../icon/static-icon.module";
 
 import { Toggle } from "./toggle.component";
-import { Checkbox } from "../checkbox/checkbox.module";
 
 describe("Toggle", () => {
 	let component: Toggle;
 	let fixture: ComponentFixture<Toggle>;
 	let labelElement: HTMLElement;
 	let buttonElement: HTMLElement;
-	let svgElement: HTMLElement;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -62,6 +59,12 @@ describe("Toggle", () => {
 		labelElement = fixture.debugElement.query(By.css("label")).nativeElement;
 		expect(fixture.debugElement.query(By.css("svg")).nativeElement).not.toBeNull();
 		expect(labelElement.innerHTML).toContain("bx--toggle__check");
+	});
+
+	it("should match the input checked value", () => {
+		component.checked = true;
+		fixture.detectChanges();
+		expect(buttonElement.attributes.getNamedItem("aria-checked").value).toEqual("true");
 	});
 
 });

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -2,7 +2,10 @@ import { Checkbox } from "../checkbox/checkbox.component";
 import {
 	ChangeDetectorRef,
 	Component,
-	Input
+	Input,
+	Output,
+	EventEmitter,
+	ChangeDetectionStrategy
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -53,14 +56,19 @@ export class ToggleChange {
 	template: `
 		<input
 			class="bx--toggle"
+			type="checkbox"
 			[ngClass]="{
 				'bx--toggle--small': size === 'sm'
 			}"
 			[id]="id"
-			type="checkbox"
-			(click)="onClick($event)"
+			[value]="value"
+			[name]="name"
+			[required]="required"
+			[checked]="checked"
 			[disabled]="disabled"
-			[attr.aria-checked]="checked">
+			[attr.aria-checked]="checked"
+			(change)="onChange($event)"
+			(click)="onClick($event)">
 		<label *ngIf="size === 'md'" class="bx--toggle__label" [for]="id">
 			<span class="bx--toggle__text--left">Off</span>
 			<span class="bx--toggle__appearance"></span>

--- a/src/toggle/toggle.stories.ts
+++ b/src/toggle/toggle.stories.ts
@@ -11,18 +11,20 @@ storiesOf("Toggle", module).addDecorator(
 	.addDecorator(withKnobs)
 	.add("Basic", () => ({
 		template: `
-			<ibm-toggle [disabled]="disabled"></ibm-toggle>
+			<ibm-toggle [disabled]="disabled" [checked]="checked"></ibm-toggle>
 		`,
 		props: {
-			disabled: boolean("disabled", false)
+			disabled: boolean("disabled", false),
+			checked: boolean("checked", false)
 		}
 
 	}))
 	.add("Small", () => ({
 		template: `
-			<ibm-toggle [disabled]="disabled" size="sm"></ibm-toggle>
+			<ibm-toggle [disabled]="disabled" [checked]="checked" size="sm"></ibm-toggle>
 		`,
 		props: {
-			disabled: boolean("disabled", false)
+			disabled: boolean("disabled", false),
+			checked: boolean("checked", false)
 		}
 	}));


### PR DESCRIPTION
Closes IBM/carbon-components-angular#176

Input `checked` was not effective on toggle/switch component.

#### Changelog

**Changed**

* Moved incorrectly positioned `@Input` decorators in `Checkbox` component.
* Added `[checked]="checked"` on tag `input` along with other attributes.
* Added `checked` knob to Toggle's storybook.
