### PR TITLE
fix(table): Fix expandable row width issue

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -334,7 +334,7 @@ import { I18n } from "./../i18n/i18n.module";
 				*ngIf="model.rowsExpanded[i]"
 				class="bx--expandable-row-v2"
 				[attr.data-child-row]="(model.rowsExpanded[i] ? 'true' : null)">
-					<td [attr.colspan]="model.data.length + 2">
+					<td [attr.colspan]="model.header.length + 2">
 						<ng-container *ngIf="!firstExpandedTemplateInRow(row)">{{firstExpandedDataInRow(row)}}</ng-container>
 						<ng-template
 							[ngTemplateOutlet]="firstExpandedTemplateInRow(row)"

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -334,7 +334,7 @@ import { I18n } from "./../i18n/i18n.module";
 				*ngIf="model.rowsExpanded[i]"
 				class="bx--expandable-row-v2"
 				[attr.data-child-row]="(model.rowsExpanded[i] ? 'true' : null)">
-					<td [attr.colspan]="model.header.length + 2">
+					<td [attr.colspan]="row.length + 2">
 						<ng-container *ngIf="!firstExpandedTemplateInRow(row)">{{firstExpandedDataInRow(row)}}</ng-container>
 						<ng-template
 							[ngTemplateOutlet]="firstExpandedTemplateInRow(row)"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#280
Closes IBM/carbon-components-angular#275

Expandable rows had a colspan related to the number of rows in the table, not the number of columns.

#### Changelog

**Changed**

* Fix issue by setting the right colspan (replaced `this.data.length` by `row.length`).