### PR TITLE
fix(i18n): set now does a deep merge

### DIFF
--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { BehaviorSubject } from "rxjs";
 import { map } from "rxjs/operators";
+import { merge } from "./../utils/object";
 
 const EN = require("./en.json");
 
@@ -33,28 +34,6 @@ export const replace = (subject, variables) => subject.pipe(
 		return str;
 	})
 );
-
-// custom deep object merge
-const merge = (target, ...objects) => {
-	for (const object of objects) {
-		for (const key in object) {
-			if (object.hasOwnProperty(key)) {
-				// since we're dealing just with JSON this simple check should be enough
-				if (object[key] instanceof Object) {
-					if (!target[key]) {
-						target[key] = {};
-					}
-					// recursivly merge into the target
-					// most translations only run 3 or 4 levels deep, so no stack explosions
-					target[key] = merge(target[key], object[key]);
-				} else {
-					target[key] = object[key];
-				}
-			}
-		}
-	}
-	return target;
-};
 
 /**
  * The I18n service is a minimal internal singleton service used to supply our components with translated strings.

--- a/src/i18n/i18n.spec.ts
+++ b/src/i18n/i18n.spec.ts
@@ -61,4 +61,11 @@ describe("i18n service", () => {
 			done();
 		});
 	});
+
+	it("should keep the default translation strings", () => {
+		service.set({ "BANNER": { "TEST": "TEST" } });
+
+		expect(service.get().BANNER.CLOSE_BUTTON).toBe(EN.BANNER.CLOSE_BUTTON);
+		expect(service.get().BANNER.TEST).toBe("TEST");
+	});
 });

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,21 @@
+// custom deep object merge
+export const merge = (target, ...objects) => {
+	for (const object of objects) {
+		for (const key in object) {
+			if (object.hasOwnProperty(key)) {
+				// since we're dealing just with JSON this simple check should be enough
+				if (object[key] instanceof Object) {
+					if (!target[key]) {
+						target[key] = {};
+					}
+					// recursivly merge into the target
+					// most translations only run 3 or 4 levels deep, so no stack explosions
+					target[key] = merge(target[key], object[key]);
+				} else {
+					target[key] = object[key];
+				}
+			}
+		}
+	}
+	return target;
+};


### PR DESCRIPTION
closes #301 

`Object.assign` only does a shallow merge, which of course means we'd lose any untranslated keys (potentially for whole components)