### PR TITLE
Use the correct href when not displaying a skeleton

### DIFF
--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -8,7 +8,7 @@ import {
 	selector: "ibm-breadcrumb-item",
 	template: `
 	<a class="bx--link"
-		href="{{skeleton ? href : '/#'}}"
+		href="{{skeleton ? '/#' : href}}"
 		*ngIf="skeleton || href; else content">
 		<ng-container *ngTemplateOutlet="content"></ng-container>
 	</a>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#394

Use the correct href when not displaying a skeleton

#### Changelog

**Changed**

* Use the correct href when not displaying a skeleton

