### PR TITLE
fix(dialog): position wrong due to scroll x/y

### DIFF
--- a/src/dialog/dialog.component.ts
+++ b/src/dialog/dialog.component.ts
@@ -216,7 +216,6 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 				pos = this.addGap[placement](position.findRelative(reference, target, placement));
 			} else {
 				pos = this.addGap[placement](position.findAbsolute(reference, target, placement));
-				pos = position.addOffset(pos, window.scrollY, window.scrollX);
 			}
 			return pos;
 		};


### PR DESCRIPTION
closes #399 

I can't actually find any specific justification for keeping this, and from what I can tell it's already handled elsewhere in dialog/position ... so away it goes!