### PR TITLE
feat(clickable-tile): Add support for target attribute

### DIFF
--- a/src/tiles/clickable-tile.component.ts
+++ b/src/tiles/clickable-tile.component.ts
@@ -30,6 +30,7 @@ import {
 		(click)="onClick($event)"
 		(keydown)="onKeyDown($event)"
 		[href]="href"
+		[target]="target"
 		[attr.aria-disabled]="disabled">
 		<ng-content></ng-content>
 	</a>`
@@ -41,6 +42,13 @@ export class ClickableTile {
 	 * @memberof ClickableTile
 	 */
 	@Input() href: string;
+
+	/**
+	 * Sets the `target` attribute on the `ibm-clickable-tile` element.
+	 * @type {string}
+	 * @memberof ClickableTile
+	 */
+	@Input() target: string;
 
 	/**
 	 * Set to `true` to disable the clickable tile.

--- a/src/tiles/tiles.stories.ts
+++ b/src/tiles/tiles.stories.ts
@@ -36,8 +36,8 @@ storiesOf("Tiles", module)
 	}))
 	.add("Clickable", () => ({
 		template: `
-		<ibm-clickable-tile href="#">
-			clickable tile content goes here...
+		<ibm-clickable-tile href="https://www.carbondesignsystem.com/" target="_blank">
+			Click the tile to open the Carbon Design System
 		</ibm-clickable-tile>
 		`
 	}));


### PR DESCRIPTION
Closes IBM/carbon-components-angular#413

Add support for target attribute

#### Changelog

**New**

* Clickable tile now supports the `target` attribute

