### PR TITLE
Dropdown enhancements

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -264,7 +264,7 @@ export class ComboBox implements OnChanges, OnInit, AfterViewInit, AfterContentI
 				this.updateSelected();
 			});
 
-			this.view.blur.pipe(filter(v => v === "top")).subscribe(() => {
+			this.view.blurIntent.pipe(filter(v => v === "top")).subscribe(() => {
 				this.elementRef.nativeElement.querySelector(".bx--text-input").focus();
 			});
 		}

--- a/src/dropdown/abstract-dropdown-view.class.ts
+++ b/src/dropdown/abstract-dropdown-view.class.ts
@@ -27,7 +27,7 @@ export class AbstractDropdownView {
 	 * ArrowUp -> emit event
 	 *
 	 * It's recommended that the implementing view include a specific type union of possible blurs
-	 * ex. `@Output() blur = new EventEmitter<"top" | "bottom">();`
+	 * ex. `@Output() blurIntent = new EventEmitter<"top" | "bottom">();`
 	 */
 	@Output() blurIntent: EventEmitter<any>;
 	/**

--- a/src/dropdown/abstract-dropdown-view.class.ts
+++ b/src/dropdown/abstract-dropdown-view.class.ts
@@ -29,7 +29,7 @@ export class AbstractDropdownView {
 	 * It's recommended that the implementing view include a specific type union of possible blurs
 	 * ex. `@Output() blur = new EventEmitter<"top" | "bottom">();`
 	 */
-	@Output() blur: EventEmitter<any>;
+	@Output() blurIntent: EventEmitter<any>;
 	/**
 	 * Specifies whether or not the `DropdownList` supports selecting multiple items as opposed to single
 	 * item selection.

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -126,8 +126,10 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	 * ex.
 	 * ArrowUp -> focus first item
 	 * ArrowUp -> emit event
+	 *
+	 * When this event fires focus should be placed on some element outside of the list - blurring the list as a result
 	 */
-	@Output() blur = new EventEmitter<"top" | "bottom">();
+	@Output() blurIntent = new EventEmitter<"top" | "bottom">();
 	/**
 	 * Maintains a reference to the view DOM element for the unordered list of items within the `DropdownList`.
 	 */
@@ -407,13 +409,13 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 				if (this.hasNextElement()) {
 					this.getNextElement().focus();
 				} else {
-					this.blur.emit("bottom");
+					this.blurIntent.emit("bottom");
 				}
 			} else if (event.key === "ArrowUp" || event.key === "Up") {
 				if (this.hasPrevElement()) {
 					this.getPrevElement().focus();
 				} else {
-					this.blur.emit("top");
+					this.blurIntent.emit("top");
 				}
 			}
 		}


### PR DESCRIPTION
includes:

- fix(combobox): use blur event to focus input
  - lets us cleanly move focus between the list and the input
- fix(dropdown-list): element iterators should operate on the displayItems
  - `getNextElement` and related methods now operate on the visiable `disaplayItems` instead of the entire list. Also moves to a `ViewChildren` query instead of manually querying the DOM (!!)
- feat(AbstractDropdownView): add blur event to view spec
  - adds `blur` as a requirement for the view. Implementing classes should specify what blurs they'll emit (top, bottom, end, start, whatever makes sense for the type of view)