### PR TITLE
Set overflow menu option title to "" instead of null

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-option.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-option.component.ts
@@ -63,7 +63,7 @@ export class OverflowMenuOption implements AfterViewInit {
 	public tabIndex = -1;
 	// note: title must be a real attribute (i.e. not a getter) as of Angular@6 due to
 	// change after checked errors
-	public title = '';
+	public title = "";
 
 	constructor(protected elementRef: ElementRef) {}
 

--- a/src/dialog/overflow-menu/overflow-menu-option.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-option.component.ts
@@ -31,7 +31,7 @@ import {
 			(blur)="tabIndex = -1"
 			(click)="onClick($event)"
 			[disabled]="disabled"
-			[title]="title">
+			[attr.title]="title">
 			<ng-content></ng-content>
 		</button>
 	`
@@ -63,7 +63,7 @@ export class OverflowMenuOption implements AfterViewInit {
 	public tabIndex = -1;
 	// note: title must be a real attribute (i.e. not a getter) as of Angular@6 due to
 	// change after checked errors
-	public title = "";
+	public title = null;
 
 	constructor(protected elementRef: ElementRef) {}
 

--- a/src/dialog/overflow-menu/overflow-menu-option.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-option.component.ts
@@ -63,7 +63,7 @@ export class OverflowMenuOption implements AfterViewInit {
 	public tabIndex = -1;
 	// note: title must be a real attribute (i.e. not a getter) as of Angular@6 due to
 	// change after checked errors
-	public title = null;
+	public title = '';
 
 	constructor(protected elementRef: ElementRef) {}
 


### PR DESCRIPTION
Overflow menu option component has a default title value of null which causes null to be shown as title in the browser. Changing this to empty string to get no title which is intended there.