### PR TITLE
docs: updates hmtl typo to html, addresses #456

### DIFF
--- a/src/button/button.directive.ts
+++ b/src/button/button.directive.ts
@@ -10,7 +10,7 @@ import {
  *
  * Example:
  *
- * ```hmtl
+ * ```html
  * <button ibmButton>A button</button>
  * <button ibmButton="secondary">A secondary button</button>
  * ```


### PR DESCRIPTION
Closes IBM/carbon-components-angular#456

The doc block for `button.directive.ts` contained a typo in an HTML code block

#### Changelog

**Changed**

* Fixed "hmtl" typo in doc block in `button.directive.ts`