### PR TITLE
Ui shell hamburger optional

### DIFF
--- a/src/ui-shell/hamburger.component.ts
+++ b/src/ui-shell/hamburger.component.ts
@@ -1,0 +1,24 @@
+import { Component } from "@angular/core";
+import { I18n } from "../i18n/i18n.module";
+
+/**
+ * A slide-out hamburger menu
+ *
+ * TODO: This is a stub component, and needs to be implemented.
+ */
+@Component({
+	selector: "ibm-hamburger",
+	template: `
+		<button
+			class="bx--header__menu-trigger bx--header__action"
+			[attr.aria-label]="i18n.get('UI_SHELL.HEADER.MENU') | async"
+			[attr.title]="i18n.get('UI_SHELL.HEADER.MENU') | async">
+			<svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+				<path d="M4 6h24v2H4zm0 18h24v2H4zm0-9h24v2H4z" />
+			</svg>
+		</button>
+	`
+})
+export class Hamburger {
+	constructor(public i18n: I18n) { }
+}

--- a/src/ui-shell/header.component.spec.ts
+++ b/src/ui-shell/header.component.spec.ts
@@ -1,0 +1,79 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+
+import { I18nModule } from "../i18n/i18n.module";
+import { Header } from "./header.component";
+import { Hamburger } from "./ui-shell.module";
+
+/**
+ * Testing component for projecting an ibm-hamburger component
+ * inside of an ibm-header component.
+ *
+ * @class HamburgerTest
+ */
+@Component({
+	selector: "ibm-hamburger-test",
+	template: `
+		<ibm-header>
+			<ibm-hamburger></ibm-hamburger>
+		</ibm-header>
+	`
+})
+class HamburgerTest { }
+
+describe("UI Shell Header", () => {
+	let component: Header;
+	let fixture: ComponentFixture<Header>;
+	let element: HTMLElement;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [Hamburger, HamburgerTest, Header],
+			imports: [I18nModule],
+			providers: []
+		});
+
+		fixture = TestBed.createComponent(Header);
+		component = fixture.componentInstance;
+		element = fixture.debugElement.query(By.css(".bx--header")).nativeElement;
+		fixture.detectChanges();
+	});
+
+	it("should work", () => {
+		expect(component instanceof Header).toBe(true);
+	});
+
+	it("should have a default brand of 'IBM'", () => {
+		const brandElement = element.querySelector(".bx--header__name--prefix");
+		expect(brandElement).toBeDefined();
+		expect(brandElement.textContent.trim()).toEqual("IBM");
+	});
+
+	it("should be able to set a custom brand", () => {
+		const brand = "Foo Brand";
+		component.brand = brand;
+		fixture.detectChanges();
+
+		const brandElement = element.querySelector(".bx--header__name--prefix");
+		expect(brandElement).toBeDefined();
+		expect(brandElement.textContent.trim()).toEqual(brand);
+	});
+
+	it("should be able to set a custom name", () => {
+		const name = "Foo Name";
+		component.name = name;
+		fixture.detectChanges();
+
+		const nameElement = element.querySelector(".bx--header__name");
+		expect(nameElement).toBeDefined();
+		expect(nameElement.textContent).toContain(name);
+	});
+
+	it("should project a hamburger component", () => {
+		const headerWithHamburger = TestBed.createComponent(HamburgerTest);
+		const element = headerWithHamburger.nativeElement;
+
+		expect(element.querySelector("header > ibm-hamburger")).toBeDefined();
+	});
+});

--- a/src/ui-shell/header.component.ts
+++ b/src/ui-shell/header.component.ts
@@ -14,14 +14,7 @@ import { I18n } from "./../i18n/i18n.module";
 				tabindex="0">
 				{{ i18n.get("UI_SHELL.SKIP_TO") | async }}
 			</a>
-			<button
-				class="bx--header__menu-trigger bx--header__action"
-				[attr.aria-label]="i18n.get('UI_SHELL.HEADER.MENU') | async"
-				[attr.title]="i18n.get('UI_SHELL.HEADER.MENU') | async">
-				<svg aria-hidden="true" width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-					<path d="M4 6h24v2H4zm0 18h24v2H4zm0-9h24v2H4z" />
-				</svg>
-			</button>
+			<ng-content select="ibm-hamburger"></ng-content>
 			<a class="bx--header__name" href="#">
 				<span class="bx--header__name--prefix">{{brand}}&nbsp;</span>
 				{{name}}

--- a/src/ui-shell/ui-shell.module.ts
+++ b/src/ui-shell/ui-shell.module.ts
@@ -10,6 +10,8 @@ import { HeaderNavigation } from "./header-navigation.component";
 import { HeaderGlobal } from "./header-global.component";
 import { HeaderAction } from "./header-action.component";
 
+import { Hamburger } from "./hamburger.component";
+
 import { SideNav } from "./sidenav.component";
 import { SideNavHeader } from "./sidenav-header.component";
 import { SideNavItem } from "./sidenav-item.component";
@@ -22,6 +24,8 @@ export {
 	HeaderNavigation,
 	HeaderGlobal,
 	HeaderAction,
+
+	Hamburger,
 
 	SideNav,
 	SideNavHeader,
@@ -38,12 +42,14 @@ export {
 		HeaderGlobal,
 		HeaderAction,
 
+		Hamburger,
+
 		SideNav,
 		SideNavHeader,
 		SideNavItem,
 		SideNavMenu
 	],
-	imports: [ CommonModule, I18nModule ],
+	imports: [CommonModule, I18nModule],
 	exports: [
 		Header,
 		HeaderItem,
@@ -52,10 +58,12 @@ export {
 		HeaderGlobal,
 		HeaderAction,
 
+		Hamburger,
+
 		SideNav,
 		SideNavHeader,
 		SideNavItem,
 		SideNavMenu
 	]
 })
-export class UIShellModule {}
+export class UIShellModule { }

--- a/src/ui-shell/ui-shell.module.ts
+++ b/src/ui-shell/ui-shell.module.ts
@@ -18,15 +18,14 @@ import { SideNavItem } from "./sidenav-item.component";
 import { SideNavMenu } from "./sidenav-menu.component";
 
 export {
+	// Header
 	Header,
 	HeaderItem,
 	HeaderMenu,
 	HeaderNavigation,
 	HeaderGlobal,
 	HeaderAction,
-
 	Hamburger,
-
 	SideNav,
 	SideNavHeader,
 	SideNavItem,
@@ -41,9 +40,7 @@ export {
 		HeaderNavigation,
 		HeaderGlobal,
 		HeaderAction,
-
 		Hamburger,
-
 		SideNav,
 		SideNavHeader,
 		SideNavItem,
@@ -57,9 +54,7 @@ export {
 		HeaderNavigation,
 		HeaderGlobal,
 		HeaderAction,
-
 		Hamburger,
-
 		SideNav,
 		SideNavHeader,
 		SideNavItem,

--- a/src/ui-shell/ui-shell.module.ts
+++ b/src/ui-shell/ui-shell.module.ts
@@ -18,7 +18,6 @@ import { SideNavItem } from "./sidenav-item.component";
 import { SideNavMenu } from "./sidenav-menu.component";
 
 export {
-	// Header
 	Header,
 	HeaderItem,
 	HeaderMenu,

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -1,4 +1,5 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
+import { withKnobs, select } from "@storybook/addon-knobs/angular";
 
 import { UIShellModule } from "./ui-shell.module";
 
@@ -10,9 +11,11 @@ storiesOf("UI Shell", module)
 			]
 		})
 	)
+	.addDecorator(withKnobs)
 	.add("Header", () => ({
 		template: `
-			<ibm-header (menuClicked)="menuClicked()" name="[Platform]">
+			<ibm-header name="[Platform]">
+				<ibm-hamburger *ngIf="hasHamburger"></ibm-hamburger>
 				<ibm-header-navigation>
 					<ibm-header-item>Catalog</ibm-header-item>
 					<ibm-header-item>Docs</ibm-header-item>
@@ -50,6 +53,7 @@ storiesOf("UI Shell", module)
 			</ibm-header>
 		`,
 		props: {
+			hasHamburger: select("Show Hamburger", { "Yes": true, "No": false }, true),
 			menuClicked: () => { }
 		}
 	}))
@@ -126,7 +130,8 @@ storiesOf("UI Shell", module)
 	}))
 	.add("Together", () => ({
 		template: `
-			<ibm-header (menuClicked)="menuClicked()" name="[Platform]">
+			<ibm-header name="[Platform]">
+				<ibm-hamburger *ngIf="hasHamburger"></ibm-hamburger>
 				<ibm-header-navigation>
 					<ibm-header-item>Catalog</ibm-header-item>
 					<ibm-header-item>Docs</ibm-header-item>
@@ -215,7 +220,7 @@ storiesOf("UI Shell", module)
 			</ibm-sidenav>
 		`,
 		props: {
-			menuClicked: () => { },
+			hasHamburger: select("Show Hamburger", { "Yes": true, "No": false }, true),
 			options: [
 				{
 					content: "Option 1",

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { withKnobs, select } from "@storybook/addon-knobs/angular";
+import { withKnobs, boolean } from "@storybook/addon-knobs/angular";
 
 import { UIShellModule } from "./ui-shell.module";
 
@@ -53,7 +53,7 @@ storiesOf("UI Shell", module)
 			</ibm-header>
 		`,
 		props: {
-			hasHamburger: select("Show Hamburger", { "Yes": true, "No": false }, true),
+			hasHamburger: boolean("Show Hamburger", true),
 			menuClicked: () => { }
 		}
 	}))
@@ -220,7 +220,7 @@ storiesOf("UI Shell", module)
 			</ibm-sidenav>
 		`,
 		props: {
-			hasHamburger: select("Show Hamburger", { "Yes": true, "No": false }, true),
+			hasHamburger: boolean("Show Hamburger", true),
 			options: [
 				{
 					content: "Option 1",


### PR DESCRIPTION
Closes IBM/carbon-components-angular#452

Make the hamburger menu optional in `ui-shell` by passing `ibm-hamburger` component as a content child of `ibm-header`

#### Changelog

**New**

* Added stub `ibm-hamburger` component, using the hamburger button template from `ibm-header`
* Added a few simple tests for the `ibm-header` component

**Changed**

* Updated the storyboard for `ui-shell` by adding the `ibm-hamburger` as a content child to all `ibm-header` components
* Updated the storyboard for `ui-shell` by adding a Knob to show/hide the `ibm-hamburger` component