### PR TITLE
chore: run pages deploy on the v9 branch

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,7 +13,7 @@ npm run build
 npm run semantic-release
 
 # deploy to gh pages
-if [[ $TRAVIS_BRANCH == "master" ]]; then
+if [[ $TRAVIS_BRANCH == "v9" ]]; then
 	mkdir pages
 	cd pages
 


### PR DESCRIPTION
And ensure the latest v2 releases are published under `/v2`