### PR TITLE
Fix content-switcher button being unselected

### DIFF
--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -58,7 +58,7 @@ export class ContentSwitcherOption {
 
 	@HostListener("blur", ["$event"])
 	onBlur(event) {
-		if (event.relatedTarget && event.relatedTarget.className === "bx--content-switcher-btn") {
+		if (event.relatedTarget && event.relatedTarget.classList.contains("bx--content-switcher-btn")) {
 			this.active = false;
 		}
 	}

--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -58,7 +58,7 @@ export class ContentSwitcherOption {
 
 	@HostListener("blur", ["$event"])
 	onBlur(event) {
-		if (event.relatedTarget) {
+		if (event.relatedTarget && event.relatedTarget.className === "bx--content-switcher-btn") {
 			this.active = false;
 		}
 	}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#450

Fix for "if I click on one of the content switcher buttons and then click on a button separate from the content switcher, the content switcher button I selected becomes unselected" part of IBM/carbon-components-angular#450 issue
