### PR TITLE
V2 - feat(pagination): Added possibility to define the options for the items per page select

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -71,11 +71,12 @@ import { ExperimentalService } from "./../experimental.module";
 						[(ngModel)]="itemsPerPage"
 						class="bx--select-input"
 						aria-describedby="false">
-						<option class="bx--select-option" value="10">10</option>
-						<option class="bx--select-option" value="20">20</option>
-						<option class="bx--select-option" value="30">30</option>
-						<option class="bx--select-option" value="40">40</option>
-						<option class="bx--select-option" value="50">50</option>
+						<option
+							class="bx--select-option"
+							*ngFor="let option of itemsPerPageOptions"
+							[value]="option">
+								{{ option }}
+						</option>
 					</select>
 					<!-- old icon -->
 					<svg
@@ -320,6 +321,13 @@ export class Pagination {
 			this.ofLastPagesText = new BehaviorSubject(value.OF_LAST_PAGES);
 		}
 	}
+
+	/**
+	 * Options for items per page select
+	 *
+	 * A default array of options will be defined: [10, 20, 30, 40, 50]
+	 */
+	@Input() itemsPerPageOptions: number[] = [10, 20, 30, 40, 50];
 
 	/**
 	 * Emits the new page number.


### PR DESCRIPTION
Closes IBM/carbon-components-angular#550

This pull requests adds the possibility to define the options for the items per page select, they were always defined as 10, 20, 30, 40, 50, now a user can define whatever numbers they want.

#### Changelog

**New**

* Now is possible to set the options for the items per page select on pagination