### PR TITLE
Fix: NotificationService does not remove references to closed notifications

### DIFF
--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -144,6 +144,10 @@ export class NotificationService implements OnDestroy {
 				setTimeout( () => {
 					this.applicationRef.detachView(notificationRef.hostView);
 					notificationRef.destroy();
+					const index = this.notificationRefs.indexOf(notificationRef);
+					if (index != -1) {
+						this.notificationRefs.splice(index, 1);
+					}
 				}, 200);
 			}
 		}

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -145,7 +145,7 @@ export class NotificationService implements OnDestroy {
 					this.applicationRef.detachView(notificationRef.hostView);
 					notificationRef.destroy();
 					const index = this.notificationRefs.indexOf(notificationRef);
-					if (index != -1) {
+					if (index !== -1) {
 						this.notificationRefs.splice(index, 1);
 					}
 				}, 200);


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Fix for issue #587 `NotificationService` does not remove references to closed notifications

#### Changelog

**New**

* {{new thing}}

**Changed**

* `NotificationService` removes references to closed notifications

**Removed**

* {{removed thing}}
