### PR TITLE
fix(button): Fix button type on number spinner

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -1,10 +1,5 @@
 import { PaginationModel } from "./pagination.module";
-import {
-	Component,
-	Input,
-	Output,
-	EventEmitter
-} from "@angular/core";
+import { Component, Input, Output, EventEmitter } from "@angular/core";
 
 import { range } from "../common/utils";
 import { I18n } from "./../i18n/i18n.module";
@@ -37,112 +32,171 @@ import { ExperimentalService } from "./../experimental.module";
 @Component({
 	selector: "ibm-pagination",
 	template: `
-	<div
-		class="bx--pagination"
-		[ngClass]="{
-			'bx--skeleton': skeleton
-		}">
-		<!-- left skeleton div -->
-		<div *ngIf="skeleton" class="bx--pagination__left">
-			<p class="bx--skeleton__text" style="width: 70px"></p>
-			<p class="bx--skeleton__text" style="width: 35px"></p>
-			<p class="bx--skeleton__text" style="width: 105px"></p>
-		</div>
-
-		<div *ngIf="!skeleton" class="bx--pagination__left">
-			<label class="bx--pagination__text" [for]="itemsPerPageSelectId">
-				{{itemsPerPageText | async}}
-			</label>
-			<div class="bx--form-item">
-				<div class="bx--select bx--select--inline"
-					[ngClass]="{
-						'bx--select__item-count': isExperimental
-					}">
-					<label
-						[for]="itemsPerPageSelectId"
-						class="bx--label bx--visually-hidden">
-						{{itemsPerPageText | async}}
-					</label>
-					<select
-						[id]="itemsPerPageSelectId"
-						[(ngModel)]="itemsPerPage"
-						class="bx--select-input"
-						aria-describedby="false">
-						<option class="bx--select-option" value="10">10</option>
-						<option class="bx--select-option" value="20">20</option>
-						<option class="bx--select-option" value="30">30</option>
-						<option class="bx--select-option" value="40">40</option>
-						<option class="bx--select-option" value="50">50</option>
-					</select>
-					<ibm-icon-chevron-down16
-						style="display: inherit;"
-						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText | async">
-					</ibm-icon-chevron-down16>
-				</div>
-			</div>
-
-			<span class="bx--pagination__text">
-				<span *ngIf="!isExperimental">|&nbsp;</span>
-				{{totalItemsText | i18nReplace:{start: startItemIndex, end: endItemIndex, total: model.totalDataLength } | async}}
-			</span>
-		</div>
-
-		<!-- right skeleton div -->
-		<div *ngIf="skeleton" class="bx--pagination__right bx--pagination--inline">
-			<p class="bx--skeleton__text" style="width: 70px"></p>
-		</div>
-
-		<div *ngIf="!skeleton" class="bx--pagination__right"
+		<div
+			class="bx--pagination"
 			[ngClass]="{
-				'bx--pagination--inline': !isExperimental
-			}">
-
-			<div class="bx--form-item">
-				<div class="bx--select bx--select--inline"
-				[ngClass]="{
-					'bx--select__page-number' : isExperimental
-				}">
-					<label [for]="currentPageSelectId" class="bx--label bx--visually-hidden">{{itemsPerPageText | async}}</label>
-					<select [id]="currentPageSelectId" class="bx--select-input" aria-describedby="false" [(ngModel)]="currentPage">
-						<option *ngFor="let i of range(lastPage + 1, 1)" class="bx--select-option" [value]="i">{{i}}</option>
-					</select>
-					<ibm-icon-chevron-down16
-						style="display: inherit;"
-						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText | async">
-					</ibm-icon-chevron-down16>
-				</div>
+				'bx--skeleton': skeleton
+			}"
+		>
+			<!-- left skeleton div -->
+			<div *ngIf="skeleton" class="bx--pagination__left">
+				<p class="bx--skeleton__text" style="width: 70px"></p>
+				<p class="bx--skeleton__text" style="width: 35px"></p>
+				<p class="bx--skeleton__text" style="width: 105px"></p>
 			</div>
 
-			<span class="bx--pagination__text">
-				{{ofLastPagesText | i18nReplace: {last: lastPage} | async}}
-			</span>
-			<button
-				class="bx--pagination__button bx--pagination__button--backward"
-				[ngClass]="{
-					'bx--pagination__button--no-index': currentPage <= 1
-				}"
-				tabindex="0"
-				[attr.aria-label]="backwardText | async"
-				(click)="selectPage.emit(previousPage)"
-				[disabled]="(currentPage <= 1 ? true : null)">
-				<ibm-icon-caret-left16></ibm-icon-caret-left16>
-			</button>
+			<div *ngIf="!skeleton" class="bx--pagination__left">
+				<label
+					class="bx--pagination__text"
+					[for]="itemsPerPageSelectId"
+				>
+					{{ itemsPerPageText | async }}
+				</label>
+				<div class="bx--form-item">
+					<div
+						class="bx--select bx--select--inline"
+						[ngClass]="{
+							'bx--select__item-count': isExperimental
+						}"
+					>
+						<label
+							[for]="itemsPerPageSelectId"
+							class="bx--label bx--visually-hidden"
+						>
+							{{ itemsPerPageText | async }}
+						</label>
+						<select
+							[id]="itemsPerPageSelectId"
+							[(ngModel)]="itemsPerPage"
+							class="bx--select-input"
+							aria-describedby="false"
+						>
+							<option class="bx--select-option" value="10"
+								>10</option
+							>
+							<option class="bx--select-option" value="20"
+								>20</option
+							>
+							<option class="bx--select-option" value="30"
+								>30</option
+							>
+							<option class="bx--select-option" value="40"
+								>40</option
+							>
+							<option class="bx--select-option" value="50"
+								>50</option
+							>
+						</select>
+						<ibm-icon-chevron-down16
+							style="display: inherit;"
+							innerClass="bx--select__arrow"
+							[ariaLabel]="optionsListText | async"
+						>
+						</ibm-icon-chevron-down16>
+					</div>
+				</div>
 
-			<button
-				class="bx--pagination__button bx--pagination__button--forward"
+				<span class="bx--pagination__text">
+					<span *ngIf="!isExperimental">|&nbsp;</span>
+					{{
+						totalItemsText
+							| i18nReplace
+								: {
+										start: startItemIndex,
+										end: endItemIndex,
+										total: model.totalDataLength
+								  }
+							| async
+					}}
+				</span>
+			</div>
+
+			<!-- right skeleton div -->
+			<div
+				*ngIf="skeleton"
+				class="bx--pagination__right bx--pagination--inline"
+			>
+				<p class="bx--skeleton__text" style="width: 70px"></p>
+			</div>
+
+			<div
+				*ngIf="!skeleton"
+				class="bx--pagination__right"
 				[ngClass]="{
-					'bx--pagination__button--no-index': currentPage >= lastPage
+					'bx--pagination--inline': !isExperimental
 				}"
-				tabindex="0"
-				[attr.aria-label]="forwardText | async"
-				(click)="selectPage.emit(nextPage)"
-				[disabled]="(currentPage >= lastPage ? true : null)">
-				<ibm-icon-caret-right16></ibm-icon-caret-right16>
-			</button>
+			>
+				<div class="bx--form-item">
+					<div
+						class="bx--select bx--select--inline"
+						[ngClass]="{
+							'bx--select__page-number': isExperimental
+						}"
+					>
+						<label
+							[for]="currentPageSelectId"
+							class="bx--label bx--visually-hidden"
+							>{{ itemsPerPageText | async }}</label
+						>
+						<select
+							[id]="currentPageSelectId"
+							class="bx--select-input"
+							aria-describedby="false"
+							[(ngModel)]="currentPage"
+						>
+							<option
+								*ngFor="let i of range(lastPage + 1, 1)"
+								class="bx--select-option"
+								[value]="i"
+								>{{ i }}</option
+							>
+						</select>
+						<ibm-icon-chevron-down16
+							style="display: inherit;"
+							innerClass="bx--select__arrow"
+							[ariaLabel]="optionsListText | async"
+						>
+						</ibm-icon-chevron-down16>
+					</div>
+				</div>
+
+				<span class="bx--pagination__text">
+					{{
+						ofLastPagesText
+							| i18nReplace: { last: lastPage }
+							| async
+					}}
+				</span>
+				<button
+					class="bx--pagination__button bx--pagination__button--backward"
+					[ngClass]="{
+						'bx--pagination__button--no-index': currentPage <= 1
+					}"
+					type="button"
+					tabindex="0"
+					[attr.aria-label]="backwardText | async"
+					(click)="selectPage.emit(previousPage)"
+					[disabled]="currentPage <= 1 ? true : null"
+				>
+					<ibm-icon-caret-left16></ibm-icon-caret-left16>
+				</button>
+
+				<button
+					class="bx--pagination__button bx--pagination__button--forward"
+					[ngClass]="{
+						'bx--pagination__button--no-index':
+							currentPage >= lastPage
+					}"
+					type="button"
+					tabindex="0"
+					[attr.aria-label]="forwardText | async"
+					(click)="selectPage.emit(nextPage)"
+					[disabled]="currentPage >= lastPage ? true : null"
+				>
+					<ibm-icon-caret-right16></ibm-icon-caret-right16>
+				</button>
+			</div>
 		</div>
-	</div>
 	`
 })
 export class Pagination {
@@ -174,12 +228,14 @@ export class Pagination {
 	 * ```
 	 */
 	@Input()
-	set translations (value) {
+	set translations(value) {
 		if (value.ITEMS_PER_PAGE) {
 			this.itemsPerPageText = new BehaviorSubject(value.ITEMS_PER_PAGE);
 		}
 		if (value.OPEN_LIST_OF_OPTIONS) {
-			this.optionsListText = new BehaviorSubject(value.OPEN_LIST_OF_OPTIONS);
+			this.optionsListText = new BehaviorSubject(
+				value.OPEN_LIST_OF_OPTIONS
+			);
 		}
 		if (value.BACKWARD) {
 			this.backwardText = new BehaviorSubject(value.BACKWARD);
@@ -227,18 +283,24 @@ export class Pagination {
 	 * The last page number to display in the pagination view.
 	 */
 	get lastPage(): number {
-		const last = Math.ceil(this.model.totalDataLength / this.model.pageLength);
+		const last = Math.ceil(
+			this.model.totalDataLength / this.model.pageLength
+		);
 		return last > 0 ? last : 1;
 	}
 
 	get startItemIndex() {
-		return this.endItemIndex > 0 ? (this.currentPage - 1) * this.model.pageLength + 1 : 0;
+		return this.endItemIndex > 0
+			? (this.currentPage - 1) * this.model.pageLength + 1
+			: 0;
 	}
 
 	get endItemIndex() {
 		const projectedEndItemIndex = this.currentPage * this.model.pageLength;
 
-		return projectedEndItemIndex < this.model.totalDataLength ? projectedEndItemIndex : this.model.totalDataLength;
+		return projectedEndItemIndex < this.model.totalDataLength
+			? projectedEndItemIndex
+			: this.model.totalDataLength;
 	}
 
 	/**
@@ -260,8 +322,12 @@ export class Pagination {
 		return this.experimental.isExperimental;
 	}
 
-	itemsPerPageSelectId = `pagination-select-items-per-page-${Pagination.paginationCounter}`;
-	currentPageSelectId = `pagination-select-current-page-${Pagination.paginationCounter}`;
+	itemsPerPageSelectId = `pagination-select-items-per-page-${
+		Pagination.paginationCounter
+	}`;
+	currentPageSelectId = `pagination-select-current-page-${
+		Pagination.paginationCounter
+	}`;
 
 	itemsPerPageText = this.i18n.get("PAGINATION.ITEMS_PER_PAGE");
 	optionsListText = this.i18n.get("PAGINATION.OPEN_LIST_OF_OPTIONS");
@@ -271,7 +337,10 @@ export class Pagination {
 	totalPagesText = this.i18n.get("PAGINATION.TOTAL_PAGES");
 	ofLastPagesText = this.i18n.get("PAGINATION.OF_LAST_PAGES");
 
-	constructor(protected i18n: I18n, protected experimental: ExperimentalService) {
+	constructor(
+		protected i18n: I18n,
+		protected experimental: ExperimentalService
+	) {
 		Pagination.paginationCounter++;
 	}
 


### PR DESCRIPTION
Fix the type on the buttons in the number spinner.

The was originally fixed by
https://github.com/IBM/carbon-components-angular/pull/517

This was broken by
https://github.com/IBM/carbon-components-angular/pull/524

A button with no type attribute acts as type="submit", and will attempt to submit form data when clicked. Without this change, this component is useless inside an angular form as clicking the spinner buttons will submit the form.
