### PR TITLE
fix(dropdown): improve multi-select value handling

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -319,7 +319,7 @@ export class Dropdown implements OnInit, AfterContentInit, OnDestroy {
 			this.view.propagateSelected([value]);
 		} else if (this.type === "single") {
 			if (this.value) {
-				// clone the specified item and update it's state
+				// clone the specified item and update its state
 				const newValue = Object.assign({}, this.view.getListItems().find(item => item[this.value] === value));
 				newValue.selected = true;
 				this.view.propagateSelected([newValue]);

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -329,7 +329,7 @@ export class Dropdown implements OnInit, AfterContentInit, OnDestroy {
 			}
 		} else {
 			if (this.value) {
-				// clone the items and update their state based on the recived value array
+				// clone the items and update their state based on the received value array
 				// this way we don't lose any additional metadata that may be passed in view the `items` Input
 				const newValues = Array.from(this.view.getListItems(), item => Object.assign({}, item));
 				for (const v of value) {

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -277,7 +277,14 @@ export class Dropdown implements OnInit, AfterContentInit, OnDestroy {
 		this.view.size = this.size;
 		this.view.select.subscribe(event => {
 			if (this.type === "multi") {
-				this.propagateChange(this.view.getSelected());
+				// if we have a `value` selector and selected items map them approperiatly
+				if (this.value && this.view.getSelected()) {
+					const values = this.view.getSelected().map(item => item[this.value]);
+					this.propagateChange(values);
+				// otherwise just pass up the values from `getSelected`
+				} else {
+					this.propagateChange(this.view.getSelected());
+				}
 			} else {
 				this.closeMenu();
 				if (event.item && event.item.selected) {
@@ -307,16 +314,36 @@ export class Dropdown implements OnInit, AfterContentInit, OnDestroy {
 	 * Propagates the injected `value`.
 	 */
 	writeValue(value: any) {
-		if (this.type === "single") {
+		// propagate null/falsey as an array (deselect everything)
+		if (!value) {
+			this.view.propagateSelected([value]);
+		} else if (this.type === "single") {
 			if (this.value) {
+				// clone the specified item and update it's state
 				const newValue = Object.assign({}, this.view.getListItems().find(item => item[this.value] === value));
 				newValue.selected = true;
 				this.view.propagateSelected([newValue]);
 			} else {
+				// pass the singular value as an array of ListItem
 				this.view.propagateSelected([value]);
 			}
 		} else {
-			this.view.propagateSelected(value);
+			if (this.value) {
+				// clone the items and update their state based on the recived value array
+				// this way we don't lose any additional metadata that may be passed in view the `items` Input
+				const newValues = Array.from(this.view.getListItems(), item => Object.assign({}, item));
+				for (const v of value) {
+					for (const newValue of newValues) {
+						if (newValue[this.value] === v) {
+							newValue.selected = true;
+						}
+					}
+				}
+				this.view.propagateSelected(newValues);
+			} else {
+				// we can safely assume we're passing an array of `ListItem`s
+				this.view.propagateSelected(value);
+			}
 		}
 	}
 

--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -77,6 +77,35 @@ storiesOf("Dropdown", module)
 			onClose: action("Multi-select dropdown closed")
 		}
 	}))
+	.add("Multi-select with ngModel", () => ({
+		template: `
+		<div style="width: 300px">
+			<ibm-dropdown
+				type="multi"
+				[label]="label"
+				[helperText]="helperText"
+				placeholder="Select"
+				[disabled]="disabled"
+				[(ngModel)]="model"
+				value="content">
+				<ibm-dropdown-list [items]="items"></ibm-dropdown-list>
+			</ibm-dropdown>
+			<span>{{model | json}}</span>
+		</div>
+		`,
+		props: {
+			disabled: boolean("disabled", false),
+			label: text("Label", "Dropdown label"),
+			helperText: text("Helper text", "Optional helper text."),
+			items: [
+				{ content: "one" },
+				{ content: "two" },
+				{ content: "three" },
+				{ content: "four" }
+			],
+			model: null
+		}
+	}))
 	.add("With ngModel", () => ({
 		template: `
 		<div style="width: 300px">

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -366,6 +366,10 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	 * Transforms array input list of items to the correct state by updating the selected item(s).
 	 */
 	propagateSelected(value: Array<ListItem>): void {
+		// if we get a non-array, log out an error (since it is one)
+		if (!Array.isArray(value)) {
+			console.error(`${this.constructor.name}.propagateSelected expects an Array<ListItem>, got ${JSON.stringify(value)}`);
+		}
 		for (let newItem of value) {
 			// copy the item
 			let tempNewItem: string | ListItem = Object.assign({}, newItem);


### PR DESCRIPTION
The multi-select codepaths didn't handle the `value` input _at all_, now they do 🎉 

Also added some error reporting to `propagateSelected` since there was a chance we could pass it `null`s and blow it up.