### PR TITLE
fix(datepicker): valueChange emits on change

### DIFF
--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -35,7 +35,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[placeholder]="placeholder"
 						[id]= "id"
 						[disabled]="disabled"
-						(change) = "onChange($event)"/>
+						(change)="onChange($event)"/>
 						<ibm-icon-calendar16
 							class="bx--date-picker__icon">
 						</ibm-icon-calendar16>

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -113,7 +113,16 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 
 	@Input() id = `datepicker-${DatePicker.datePickerCount++}`;
 
-	@Input() value: (Date | string)[] = [];
+	@Input() set value(v: (Date | string)[]) {
+		if (!v) {
+			v = [];
+		}
+		this._value = v;
+	}
+
+	get value() {
+		return this._value;
+	}
 
 	@Input() theme: "light" | "dark" = "dark";
 
@@ -155,6 +164,8 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 
 	@Output() valueChange: EventEmitter<any> = new EventEmitter();
 
+	protected _value = [];
+
 	protected _flatpickrOptions = {
 		allowInput: true
 	};
@@ -185,9 +196,6 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 
 	ngAfterViewInit() {
 		this.flatpickrInstance = flatpickr(`#${this.id}`, this.flatpickrOptions);
-		if (this.value === null) {
-			this.value = [];
-		}
 
 		if (this.value.length > 0) {
 			this.setDateValues(this.value);
@@ -204,9 +212,6 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 	 * @param value value recived from the model
 	 */
 	writeValue(value: (Date | string)[]) {
-		if (!value) {
-			value = [];
-		}
 		this.value = value;
 		this.setDateValues(this.value);
 	}

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -50,7 +50,8 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[disabled]="disabled"
 						[invalid]="invalid"
 						[invalidText]="invalidText"
-						[skeleton]="skeleton">
+						[skeleton]="skeleton"
+						(valueChange)="onValueChange($event)">
 					</ibm-date-picker-input>
 				</div>
 
@@ -65,7 +66,8 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[disabled]="disabled"
 						[invalid]="invalid"
 						[invalidText]="invalidText"
-						[skeleton]="skeleton">
+						[skeleton]="skeleton"
+						(valueChange)="onRangeValueChange($event)">
 					</ibm-date-picker-input>
 				</div>
 			</div>
@@ -161,9 +163,7 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 		mode: "single",
 		dateFormat: "m/d/Y",
 		plugins: this.plugins,
-		onChange: (selectedValue: any) => { this.doSelect(selectedValue); },
 		onOpen: () => { this.updateClassNames(); },
-		onValueUpdate: (event) => { this.doSelect(event); },
 		value: this.value
 	};
 
@@ -177,16 +177,19 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 			if (changes.value && this.didDateValueChange(changes.value.currentValue, changes.value.previousValue)) {
 				dates = changes.value.currentValue;
 			}
+			// only reset the flatpickr instance on Input changes
 			this.flatpickrInstance = flatpickr(`#${this.id}`, this.flatpickrOptions);
-			this.flatpickrInstance.setDate(dates);
 			this.setDateValues(dates);
 		}
 	}
 
 	ngAfterViewInit() {
 		this.flatpickrInstance = flatpickr(`#${this.id}`, this.flatpickrOptions);
+		if (this.value === null) {
+			this.value = [];
+		}
+
 		if (this.value.length > 0) {
-			this.flatpickrInstance.setDate(this.value);
 			this.setDateValues(this.value);
 		}
 	}
@@ -196,12 +199,68 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 		this.onTouched();
 	}
 
-	doSelect(selectedValue) {
-		this.valueChange.emit(selectedValue);
-		this.propagateChange(selectedValue);
+	/**
+	 * Writes a value from the model to the component. Expects the value to be `null` or `(Date | string)[]`
+	 * @param value value recived from the model
+	 */
+	writeValue(value: (Date | string)[]) {
+		if (!value) {
+			value = [];
+		}
+		this.value = value;
+		this.setDateValues(this.value);
 	}
 
-	updateClassNames() {
+	registerOnChange(fn: any) {
+		this.propagateChange = fn;
+	}
+
+	registerOnTouched(fn: any) {
+		this.onTouched = fn;
+	}
+
+	onTouched: () => any = () => {};
+
+	propagateChange = (_: any) => {};
+
+	/**
+	 * Cleans up our flatpickr instance
+	 */
+	ngOnDestroy() {
+		if (!this.flatpickrInstance) { return; }
+		this.flatpickrInstance.destroy();
+	}
+
+	/**
+	 * Handles the `valueChange` event from the primary/single input
+	 */
+	onValueChange(event: string) {
+		if (this.flatpickrInstance) {
+			const date = this.flatpickrInstance.parseDate(event, this.dateFormat);
+			if (this.range) {
+				this.setDateValues([date, this.flatpickrInstance.selectedDates[1]]);
+			} else {
+				this.setDateValues([date]);
+			}
+			this.doSelect(this.flatpickrInstance.selectedDates);
+		}
+	}
+
+	/**
+	 * Handles the `valueChange` event from the range input
+	 */
+	onRangeValueChange(event: string) {
+		if (this.flatpickrInstance) {
+			const date = this.flatpickrInstance.parseDate(event, this.dateFormat);
+			this.setDateValues([this.flatpickrInstance.selectedDates[0], date]);
+			this.doSelect(this.flatpickrInstance.selectedDates);
+		}
+	}
+
+	/**
+	 * Carbon uses a number of specific classnames for parts of the flatpickr - this idempotent method applies them if needed.
+	 */
+	protected updateClassNames() {
 		if (!this.elementRef) { return; }
 
 		// get all the possible flatpickrs in the document - we need to add classes to (potentially) all of them
@@ -247,36 +306,51 @@ export class DatePicker implements OnDestroy, AfterViewInit, OnChanges {
 		});
 	}
 
-	public writeValue(value: any) {
-		this.value = value;
-	}
-
-	public registerOnChange(fn: any) {
-		this.propagateChange = fn;
-	}
-
-	public registerOnTouched(fn: any) {
-		this.onTouched = fn;
-	}
-
-	onTouched: () => any = () => {};
-
-	propagateChange = (_: any) => {};
-
-	ngOnDestroy() {
-		if (!this.flatpickrInstance) { return; }
-		this.flatpickrInstance.destroy();
-	}
-
+	/**
+	 * Applies the given date value array to both the flatpickr instance and the `input`(s)
+	 * @param dates the date values to apply
+	 */
 	protected setDateValues(dates: (Date | string)[]) {
-		const singleInput = this.elementRef.nativeElement.querySelector(`#${this.id}`);
-		const rangeInput = this.elementRef.nativeElement.querySelector(`#${this.id}-rangeInput`);
-		const singleDate = this.flatpickrInstance.parseDate(dates[0], this.dateFormat);
-		singleInput.value = this.flatpickrInstance.formatDate(singleDate, this.dateFormat);
-		if (rangeInput) {
-			const rangeDate = this.flatpickrInstance.parseDate(dates[1], this.dateFormat);
-			rangeInput.value = this.flatpickrInstance.formatDate(rangeDate, this.dateFormat);
+		if (this.flatpickrInstance) {
+			const singleInput = this.elementRef.nativeElement.querySelector(`#${this.id}`);
+			const rangeInput = this.elementRef.nativeElement.querySelector(`#${this.id}-rangeInput`);
+
+			// set the date on the instance
+			this.flatpickrInstance.setDate(dates);
+
+			// we can either set a date value or an empty string, so we start with an empty string
+			let singleDate = "";
+			// if date is a string, parse and format
+			if (typeof dates[0] === "string") {
+				singleDate = this.flatpickrInstance.parseDate(dates[0], this.dateFormat);
+				singleDate = this.flatpickrInstance.formatDate(singleDate, this.dateFormat);
+			// if date is not a string we can assume it's a Date and we should format
+			} else if (!!dates[0]) {
+				singleDate = this.flatpickrInstance.formatDate(dates[0], this.dateFormat);
+			}
+			// apply the value
+			singleInput.value = singleDate;
+
+			if (rangeInput) {
+				// we can either set a date value or an empty string, so we start with an empty string
+				let rangeDate = "";
+				// if date is a string, parse and format
+				if (typeof dates[1] === "string") {
+					rangeDate = this.flatpickrInstance.parseDate(dates[1].toString(), this.dateFormat);
+					rangeDate = this.flatpickrInstance.formatDate(rangeDate, this.dateFormat);
+				// if date is not a string we can assume it's a Date and we should format
+				} else if (!!dates[1]) {
+					rangeDate = this.flatpickrInstance.formatDate(dates[1], this.dateFormat);
+				}
+				// apply the value
+				rangeInput.value = rangeDate;
+			}
 		}
+	}
+
+	protected doSelect(selectedValue: (Date | string)[]) {
+		this.valueChange.emit(selectedValue);
+		this.propagateChange(selectedValue);
 	}
 
 	protected didDateValueChange(currentValue, previousValue) {

--- a/src/datepicker/datepicker.stories.ts
+++ b/src/datepicker/datepicker.stories.ts
@@ -21,6 +21,7 @@ import {
 	EventEmitter
 } from "@angular/core";
 import { DatePickerModule, DocumentationModule } from "../";
+import { ButtonModule } from "../forms/forms.module";
 
 @Component({
 	selector: "app-date-picker",
@@ -71,7 +72,10 @@ class DatePickerStory {
 			range: [
 				[
 					new Date(),
-					new Date().setMonth(new Date().getMonth() + 1)
+					new Date(
+						new Date().getFullYear(),
+						new Date().getMonth() + 1,
+						new Date().getDate())
 				],
 				Validators.required
 			]
@@ -86,7 +90,8 @@ storiesOf("Date Picker", module)
 				DatePickerModule,
 				FormsModule,
 				ReactiveFormsModule,
-				DocumentationModule
+				DocumentationModule,
+				ButtonModule
 			],
 			declarations: [
 				DatePickerStory
@@ -102,7 +107,8 @@ storiesOf("Date Picker", module)
 			[placeholder]="placeholder"
 			[disabled]="disabled"
 			[invalid]="invalid"
-			[invalidText]="invalidText">
+			[invalidText]="invalidText"
+			(valueChange)="valueChange($event)">
 		</ibm-date-picker-input>
 		`,
 		props: {
@@ -111,7 +117,8 @@ storiesOf("Date Picker", module)
 			placeholder: text("Placeholder text", "mm/dd/yyyy"),
 			invalidText: text("Form validation content", "Invalid date format"),
 			invalid: boolean("Show form validation", false),
-			disabled: boolean("Disabled", false)
+			disabled: boolean("Disabled", false),
+			valueChange: action("Date change fired!")
 		}
 	}))
 	.add("Single", () => ({
@@ -202,6 +209,59 @@ storiesOf("Date Picker", module)
 		`,
 		props: {
 			valueChange: action("Date change fired!")
+		}
+	}))
+	.add("With ngModel", () => ({
+		template: `
+			<div>
+				<ibm-date-picker
+					label="Date picker label"
+					[(ngModel)]="single">
+				</ibm-date-picker>
+				<button
+					ibmButton
+					(click)="single = null"
+					style="margin-top: 5px">
+					Send null
+				</button>
+				<button
+					ibmButton
+					(click)="single = [date]"
+					style="margin-left: 5px">
+					Send date
+				</button>
+				<br>
+				<code>{{ single | json }}</code>
+			</div>
+			<div style="margin-top: 15px;">
+				<ibm-date-picker
+					label="Date picker"
+					rangeLabel="Range label"
+					range="true"
+					[(ngModel)]="range">
+				</ibm-date-picker>
+				<button
+					ibmButton
+					(click)="range = null"
+					style="margin-top: 5px">
+					Send null
+				</button>
+				<button
+					ibmButton
+					(click)="range = rangeDates"
+					style="margin-left: 5px">
+					Send date
+				</button>
+				<br>
+				<code>{{ range | json }}</code>
+			</div>
+		`,
+		props: {
+			date: new Date(new Date().getFullYear(), 5, 15),
+			rangeDates: [
+				new Date(new Date().getFullYear(), 5, 15),
+				new Date(new Date().getFullYear(), 9, 19)
+			]
 		}
 	}))
 	.add("Skeleton", () => ({


### PR DESCRIPTION
The primary fix here is switching control of value propagation away from
flatpickr and instead handling it ourselves. This has an additional
benefit of simplifying value handling for ngModel, reactive forms,
double binding, etc.

closes #643