### PR TITLE
fix(i18n): allow for values to be overriden

### DIFF
--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -40,7 +40,7 @@ export const replace = (subject, variables) => subject.pipe(
  * can emit events from a centralized source **OR** an `Observable` that will emit events
  * from a component local source. The key example being on/off text in a `Toggle` - In some cases
  * we want the `Toggle` to use `I18n`s global translations, but in others we'd prefer to use a local
- * override. We don't ever need to return to an non-overriden state, but we do need the ability to
+ * override. We don't ever need to return to a non-overridden state, but we do need the ability to
  * switch _to_ an overridden sate.
  */
 export class Overridable {

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -54,7 +54,7 @@ export class Overridable {
 	}
 
 	/**
-	 * The translation subject. Returns either a stream of overriden values, or our base translation values.
+	 * The translation subject. Returns either a stream of overridden values, or our base translation values.
 	 *
 	 * @readonly
 	 */

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -58,6 +58,10 @@ export class Overridable {
 		return this._value;
 	}
 
+	public set value(v: string | Observable<string>) {
+		this.override(v);
+	}
+
 	/**
 	 * The translation subject. Returns either a stream of overridden values, or our base translation values.
 	 *

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -71,7 +71,7 @@ export class Overridable {
 	 */
 	protected _value: string | Observable<string>;
 	/**
-	 * Subject of overriden values. Initialized with our default value.
+	 * Subject of overridden values. Initialized with our default value.
 	 */
 	protected $override: BehaviorSubject<string>;
 	/**

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -216,7 +216,7 @@ export class I18n {
 	}
 
 	/**
-	 * Helper method that returns an observable from the interal cache based on path
+	 * Helper method that returns an observable from the internal cache based on the path
 	 *
 	 * @param path looks like `"NOTIFICATION.CLOSE_BUTTON"`
 	 */

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -79,7 +79,7 @@ export class Overridable {
 	 */
 	protected baseTranslation: Observable<string> = this.i18n.get(this.path);
 	/**
-	 * A boolean to flip between overriden and non-overriden states.
+	 * A boolean to flip between overridden and non-overridden states.
 	 */
 	protected isOverridden = false;
 

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -85,7 +85,7 @@ export class Overridable {
 
 	constructor(protected path: string, protected i18n: I18n) {
 		/**
-		 * ensure `$override` is initlized with the correct default value
+		 * ensure `$override` is initialized with the correct default value
 		 * in some cases `_value` can get changed for an `Observable` before `$override` is created
 		 */
 		const value = this.i18n.getValueFromPath(this.path) as string;

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -1,5 +1,10 @@
 import { Injectable } from "@angular/core";
-import { BehaviorSubject, Observable, isObservable, iif } from "rxjs";
+import {
+	BehaviorSubject,
+	Observable,
+	isObservable,
+	iif
+} from "rxjs";
 import { map } from "rxjs/operators";
 import { merge } from "../utils/object";
 

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -67,7 +67,7 @@ export class Overridable {
 	}
 
 	/**
-	 * Overriden value. Accessed by the readonly getter `value` and set through `override`
+	 * Overridden value. Accessed by the readonly getter `value` and set through `override`
 	 */
 	protected _value: string | Observable<string>;
 	/**

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -27,9 +27,7 @@ export const replace = (subject, variables) => subject.pipe(
 		const keys = Object.keys(variables);
 		for (const key of keys) {
 			const value = variables[key];
-			while (str.includes(`{{${key}}}`)) {
-				str = str.replace(`{{${key}}}`, value);
-			}
+			str = str.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), value);
 		}
 		return str;
 	})

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -69,7 +69,7 @@ export class Overridable {
 	/**
 	 * Overriden value. Accessed by the readonly getter `value` and set through `override`
 	 */
-	protected _value = this.i18n.getValueFromPath(this.path) as string;
+	protected _value: string | Observable<string>;
 	/**
 	 * Subject of overriden values. Initialized with our default value.
 	 */
@@ -90,6 +90,7 @@ export class Overridable {
 		 */
 		const value = this.i18n.getValueFromPath(this.path) as string;
 		this.$override = new BehaviorSubject<string>(value);
+		this._value = value;
 	}
 	/**
 	 * Takes a string or an `Observable` that emits strings.
@@ -97,14 +98,13 @@ export class Overridable {
 	 */
 	override(value: string | Observable<string>) {
 		this.isOverridden = true;
+		this._value = value;
 		if (isObservable(value)) {
 			value.subscribe(v => {
 				this.$override.next(v);
-				this._value = v;
 			});
 		} else {
 			this.$override.next(value);
-			this._value = value;
 		}
 	}
 }
@@ -173,7 +173,7 @@ export class I18n {
 	 * Returns an instance of `Overridable` that can be used to optionally override the value provided by `I18n`
 	 * @param path looks like `"NOTIFICATION.CLOSE_BUTTON"`
 	 */
-	public getOverrideable(path: string) {
+	public getOverridable(path: string) {
 		return new Overridable(path, this);
 	}
 

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -75,7 +75,7 @@ export class Overridable {
 	 */
 	protected $override: BehaviorSubject<string>;
 	/**
-	 * Our base non-overriden translation.
+	 * Our base non-overridden translation.
 	 */
 	protected baseTranslation: Observable<string> = this.i18n.get(this.path);
 	/**

--- a/src/i18n/i18n.spec.ts
+++ b/src/i18n/i18n.spec.ts
@@ -1,4 +1,5 @@
 import { I18n } from "./i18n.service";
+import { isObservable, BehaviorSubject } from "rxjs";
 
 const EN = require("./en.json");
 
@@ -44,6 +45,15 @@ describe("i18n service", () => {
 		});
 	});
 
+	it("should replace variables ignoring spaces", done => {
+		service.set({ "TEST": "{{     foo         }} bar" });
+
+		service.replace(service.get("TEST"), { foo: "test" }).subscribe(value => {
+			expect(value).toBe("test bar");
+			done();
+		});
+	});
+
 	it("should replace multiple of the same variable", done => {
 		service.set({ "TEST": "{{foo}} {{foo}}" });
 
@@ -67,5 +77,80 @@ describe("i18n service", () => {
 
 		expect(service.get().BANNER.CLOSE_BUTTON).toBe(EN.BANNER.CLOSE_BUTTON);
 		expect(service.get().BANNER.TEST).toBe("TEST");
+	});
+
+	it("should return a whole subtree as observables", () => {
+		service.set({"TEST": { "ONE": "ONE", "TWO": "TWO", "THREE": "THREE"}});
+
+		const multiple = service.getMultiple("TEST");
+		expect(multiple.ONE).toBeDefined();
+		expect(multiple.TWO).toBeDefined();
+		expect(multiple.THREE).toBeDefined();
+		expect(isObservable(multiple.ONE)).toBeTruthy();
+	});
+
+	it("should return nested subtrees", () => {
+		service.set({
+			"TEST": {
+				"ONE": "ONE",
+				"TWO": "TWO",
+				"THREE": {
+					"SUB_THREE": "SUB_THREE"
+				}
+			}
+		});
+
+		const multiple = service.getMultiple("TEST");
+		expect(multiple.ONE).toBeDefined();
+		expect(multiple.TWO).toBeDefined();
+		expect(multiple.THREE).toBeDefined();
+		expect(multiple.THREE.SUB_THREE).toBeDefined();
+		expect(isObservable(multiple.ONE)).toBeTruthy();
+		expect(isObservable(multiple.THREE.SUB_THREE)).toBeTruthy();
+	});
+
+	it("should return an Overridable", done => {
+		service.set({ "TEST": "foo" });
+
+		const overridable = service.getOverridable("TEST");
+
+		expect(overridable.value).toBe("foo");
+		overridable.subject.subscribe(value => {
+			expect(value).toBe("foo");
+			done();
+		});
+	});
+
+	it("should override a value", done => {
+		service.set({ "TEST": "foo" });
+
+		const overridable = service.getOverridable("TEST");
+
+		expect(overridable.value).toBe("foo");
+
+		overridable.override("bar");
+
+		expect(overridable.value).toBe("bar");
+		overridable.subject.subscribe(value => {
+			expect(value).toBe("bar");
+			done();
+		});
+	});
+
+	it("should override with an observable", done => {
+		service.set({ "TEST": "foo" });
+
+		const overridable = service.getOverridable("TEST");
+		const subject = new BehaviorSubject("bar");
+
+		expect(overridable.value).toBe("foo");
+
+		overridable.override(subject);
+
+		expect(overridable.value).toBe(subject);
+		overridable.subject.subscribe(value => {
+			expect(value).toBe("bar");
+			done();
+		});
 	});
 });

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -308,15 +308,15 @@ export class Pagination {
 	itemsPerPageSelectId = `pagination-select-items-per-page-${Pagination.paginationCounter}`;
 	currentPageSelectId = `pagination-select-current-page-${Pagination.paginationCounter}`;
 
-	itemsPerPageText = this.i18n.getOverrideable("PAGINATION.ITEMS_PER_PAGE");
-	optionsListText = this.i18n.getOverrideable("PAGINATION.OPEN_LIST_OF_OPTIONS");
-	backwardText = this.i18n.getOverrideable("PAGINATION.BACKWARD");
-	forwardText = this.i18n.getOverrideable("PAGINATION.FORWARD");
-	totalItemsText = this.i18n.getOverrideable("PAGINATION.TOTAL_ITEMS");
-	totalItemsUnknownText = this.i18n.getOverrideable("PAGINATION.TOTAL_ITEMS_UNKNOWN");
-	totalPagesText = this.i18n.getOverrideable("PAGINATION.TOTAL_PAGES");
-	pageText = this.i18n.getOverrideable("PAGINATION.PAGE");
-	ofLastPagesText = this.i18n.getOverrideable("PAGINATION.OF_LAST_PAGES");
+	itemsPerPageText = this.i18n.getOverridable("PAGINATION.ITEMS_PER_PAGE");
+	optionsListText = this.i18n.getOverridable("PAGINATION.OPEN_LIST_OF_OPTIONS");
+	backwardText = this.i18n.getOverridable("PAGINATION.BACKWARD");
+	forwardText = this.i18n.getOverridable("PAGINATION.FORWARD");
+	totalItemsText = this.i18n.getOverridable("PAGINATION.TOTAL_ITEMS");
+	totalItemsUnknownText = this.i18n.getOverridable("PAGINATION.TOTAL_ITEMS_UNKNOWN");
+	totalPagesText = this.i18n.getOverridable("PAGINATION.TOTAL_PAGES");
+	pageText = this.i18n.getOverridable("PAGINATION.PAGE");
+	ofLastPagesText = this.i18n.getOverridable("PAGINATION.OF_LAST_PAGES");
 
 	protected _pageOptions = [];
 

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -8,6 +8,17 @@ import {
 
 import { I18n } from "./../i18n/i18n.module";
 import { ExperimentalService } from "./../experimental.module";
+import { merge } from "./../utils/object";
+
+export interface PaginationTranslations {
+	ITEMS_PER_PAGE: string;
+	OPEN_LIST_OF_OPTIONS: string;
+	BACKWARD: string;
+	FORWARD: string;
+	TOTAL_ITEMS: string;
+	TOTAL_PAGES: string;
+	OF_LAST_PAGES: string;
+}
 
 /**
  * Use pagination when you have multiple pages of data to handle.
@@ -53,7 +64,7 @@ import { ExperimentalService } from "./../experimental.module";
 
 		<div *ngIf="!skeleton" class="bx--pagination__left">
 			<label class="bx--pagination__text" [for]="itemsPerPageSelectId">
-				{{itemsPerPageText | async}}
+				{{itemsPerPageText.subject | async}}
 			</label>
 			<div class="bx--form-item">
 				<div class="bx--select bx--select--inline"
@@ -74,18 +85,18 @@ import { ExperimentalService } from "./../experimental.module";
 					<ibm-icon-chevron-down16
 						style="display: inherit;"
 						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText | async">
+						[ariaLabel]="optionsListText.subject | async">
 					</ibm-icon-chevron-down16>
 				</div>
 			</div>
 
 			<span *ngIf="!pagesUnknown" class="bx--pagination__text">
 				<span *ngIf="!isExperimental">|&nbsp;</span>
-				{{totalItemsText | i18nReplace:{start: startItemIndex, end: endItemIndex, total: model.totalDataLength } | async}}
+				{{totalItemsText.subject | i18nReplace:{start: startItemIndex, end: endItemIndex, total: model.totalDataLength } | async}}
 			</span>
 			<span *ngIf="pagesUnknown" class="bx--pagination__text">
 				<span *ngIf="!isExperimental">|&nbsp;</span>
-				{{totalItemsUnknownText | i18nReplace:{start: startItemIndex, end: endItemIndex } | async}}
+				{{totalItemsUnknownText.subject | i18nReplace:{start: startItemIndex, end: endItemIndex } | async}}
 			</span>
 		</div>
 
@@ -104,7 +115,7 @@ import { ExperimentalService } from "./../experimental.module";
 				[ngClass]="{
 					'bx--select__page-number' : isExperimental
 				}">
-					<label [for]="currentPageSelectId" class="bx--label bx--visually-hidden">{{itemsPerPageText | async}}</label>
+					<label [for]="currentPageSelectId" class="bx--label bx--visually-hidden">{{itemsPerPageText.subject | async}}</label>
 					<input
 						*ngIf="pageOptions.length > pageSelectThreshold"
 						style="padding-right: 1rem; margin-right: 1rem;"
@@ -125,16 +136,16 @@ import { ExperimentalService } from "./../experimental.module";
 						*ngIf="pageOptions.length <= 1000"
 						style="display: inherit;"
 						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText | async">
+						[ariaLabel]="optionsListText.subject | async">
 					</ibm-icon-chevron-down16>
 				</div>
 			</div>
 
 			<span *ngIf="!pageInputDisabled && !pagesUnknown" class="bx--pagination__text">
-				{{ofLastPagesText | i18nReplace: {last: lastPage} | async}}
+				{{ofLastPagesText.subject | i18nReplace: {last: lastPage} | async}}
 			</span>
 			<span *ngIf="!pageInputDisabled && pagesUnknown" class="bx--pagination__text">
-				{{pageText | async}} {{currentPage}}
+				{{pageText.subject | async}} {{currentPage}}
 			</span>
 			<button
 				class="bx--pagination__button bx--pagination__button--backward"
@@ -142,7 +153,7 @@ import { ExperimentalService } from "./../experimental.module";
 					'bx--pagination__button--no-index': currentPage <= 1 || disabled
 				}"
 				tabindex="0"
-				[attr.aria-label]="backwardText | async"
+				[attr.aria-label]="backwardText.subject | async"
 				(click)="selectPage.emit(previousPage)"
 				[disabled]="(currentPage <= 1 || disabled ? true : null)">
 				<ibm-icon-caret-left16></ibm-icon-caret-left16>
@@ -154,7 +165,7 @@ import { ExperimentalService } from "./../experimental.module";
 					'bx--pagination__button--no-index': currentPage >= lastPage || disabled
 				}"
 				tabindex="0"
-				[attr.aria-label]="forwardText | async"
+				[attr.aria-label]="forwardText.subject | async"
 				(click)="selectPage.emit(nextPage)"
 				[disabled]="(currentPage >= lastPage || disabled ? true : null)">
 				<ibm-icon-caret-right16></ibm-icon-caret-right16>
@@ -205,34 +216,17 @@ export class Pagination {
 	 * ```
 	 */
 	@Input()
-	set translations (value) {
-		if (value.ITEMS_PER_PAGE) {
-			this.itemsPerPageText.next(value.ITEMS_PER_PAGE);
-		}
-		if (value.OPEN_LIST_OF_OPTIONS) {
-			this.optionsListText.next(value.OPEN_LIST_OF_OPTIONS);
-		}
-		if (value.BACKWARD) {
-			this.backwardText.next(value.BACKWARD);
-		}
-		if (value.FORWARD) {
-			this.forwardText.next(value.FORWARD);
-		}
-		if (value.TOTAL_ITEMS) {
-			this.totalItemsText.next(value.TOTAL_ITEMS);
-		}
-		if (value.TOTAL_ITEMS_UNKNOWN) {
-			this.totalItemsUnknownText.next(value.TOTAL_ITEMS_UNKNOWN);
-		}
-		if (value.TOTAL_PAGES) {
-			this.totalPagesText.next(value.TOTAL_PAGES);
-		}
-		if (value.PAGE) {
-			this.pageText.next(value.PAGE);
-		}
-		if (value.OF_LAST_PAGES) {
-			this.ofLastPagesText.next(value.OF_LAST_PAGES);
-		}
+	set translations (value: PaginationTranslations) {
+		const valueWithDefaults = merge(this.i18n.getMultiple("PAGINATION"), value);
+		this.itemsPerPageText.override(valueWithDefaults.ITEMS_PER_PAGE);
+		this.optionsListText.override(valueWithDefaults.OPEN_LIST_OF_OPTIONS);
+		this.backwardText.override(valueWithDefaults.BACKWARD);
+		this.forwardText.override(valueWithDefaults.FORWARD);
+		this.totalItemsText.override(valueWithDefaults.TOTAL_ITEMS);
+		this.totalItemsUnknownText.override(valueWithDefaults.TOTAL_ITEMS_UNKNOWN);
+		this.totalPagesText.override(valueWithDefaults.TOTAL_PAGES);
+		this.pageText.override(valueWithDefaults.PAGE);
+		this.ofLastPagesText.override(valueWithDefaults.OF_LAST_PAGES);
 	}
 
 	/**
@@ -314,15 +308,15 @@ export class Pagination {
 	itemsPerPageSelectId = `pagination-select-items-per-page-${Pagination.paginationCounter}`;
 	currentPageSelectId = `pagination-select-current-page-${Pagination.paginationCounter}`;
 
-	itemsPerPageText = this.i18n.get("PAGINATION.ITEMS_PER_PAGE");
-	optionsListText = this.i18n.get("PAGINATION.OPEN_LIST_OF_OPTIONS");
-	backwardText = this.i18n.get("PAGINATION.BACKWARD");
-	forwardText = this.i18n.get("PAGINATION.FORWARD");
-	totalItemsText = this.i18n.get("PAGINATION.TOTAL_ITEMS");
-	totalItemsUnknownText = this.i18n.get("PAGINATION.TOTAL_ITEMS_UNKNOWN");
-	totalPagesText = this.i18n.get("PAGINATION.TOTAL_PAGES");
-	pageText = this.i18n.get("PAGINATION.PAGE");
-	ofLastPagesText = this.i18n.get("PAGINATION.OF_LAST_PAGES");
+	itemsPerPageText = this.i18n.getOverrideable("PAGINATION.ITEMS_PER_PAGE");
+	optionsListText = this.i18n.getOverrideable("PAGINATION.OPEN_LIST_OF_OPTIONS");
+	backwardText = this.i18n.getOverrideable("PAGINATION.BACKWARD");
+	forwardText = this.i18n.getOverrideable("PAGINATION.FORWARD");
+	totalItemsText = this.i18n.getOverrideable("PAGINATION.TOTAL_ITEMS");
+	totalItemsUnknownText = this.i18n.getOverrideable("PAGINATION.TOTAL_ITEMS_UNKNOWN");
+	totalPagesText = this.i18n.getOverrideable("PAGINATION.TOTAL_PAGES");
+	pageText = this.i18n.getOverrideable("PAGINATION.PAGE");
+	ofLastPagesText = this.i18n.getOverrideable("PAGINATION.OF_LAST_PAGES");
 
 	protected _pageOptions = [];
 

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -641,11 +641,11 @@ export class Table implements AfterViewInit {
 		this.checkboxRowLabel.override(valueWithDefaults.CHECKBOX_ROW);
 }
 
-	checkboxHeaderLabel = this.i18n.getOverrideable("TABLE.CHECKBOX_HEADER");
-	checkboxRowLabel = this.i18n.getOverrideable("TABLE.CHECKBOX_ROW");
-	endOfDataText = this.i18n.getOverrideable("TABLE.END_OF_DATA");
-	scrollTopText = this.i18n.getOverrideable("TABLE.SCROLL_TOP");
-	filterTitle = this.i18n.getOverrideable("TABLE.FILTER");
+	checkboxHeaderLabel = this.i18n.getOverridable("TABLE.CHECKBOX_HEADER");
+	checkboxRowLabel = this.i18n.getOverridable("TABLE.CHECKBOX_ROW");
+	endOfDataText = this.i18n.getOverridable("TABLE.END_OF_DATA");
+	scrollTopText = this.i18n.getOverridable("TABLE.SCROLL_TOP");
+	filterTitle = this.i18n.getOverridable("TABLE.FILTER");
 
 	/**
 	 * Controls if all checkboxes are viewed as selected.
@@ -741,9 +741,9 @@ export class Table implements AfterViewInit {
 
 	protected _model: TableModel;
 
-	protected _expandButtonAriaLabel  = this.i18n.getOverrideable("TABLE.EXPAND_BUTTON");
-	protected _sortDescendingLabel = this.i18n.getOverrideable("TABLE.SORT_DESCENDING");
-	protected _sortAscendingLabel = this.i18n.getOverrideable("TABLE.SORT_ASCENDING");
+	protected _expandButtonAriaLabel  = this.i18n.getOverridable("TABLE.EXPAND_BUTTON");
+	protected _sortDescendingLabel = this.i18n.getOverridable("TABLE.SORT_DESCENDING");
+	protected _sortAscendingLabel = this.i18n.getOverridable("TABLE.SORT_ASCENDING");
 
 	protected columnResizeWidth: number;
 	protected columnResizeMouseX: number;

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -73,8 +73,8 @@ export class TableToolbar {
 	get cancelText(): { CANCEL: string } {
 		return { CANCEL: this._cancelText.value as string };
 	}
-	actionBarLabel = this.i18n.getOverrideable("TABLE_TOOLBAR.ACTION_BAR");
-	_cancelText = this.i18n.getOverrideable("TABLE_TOOLBAR.CANCEL");
+	actionBarLabel = this.i18n.getOverridable("TABLE_TOOLBAR.ACTION_BAR");
+	_cancelText = this.i18n.getOverridable("TABLE_TOOLBAR.CANCEL");
 
 	constructor(protected i18n: I18n) {}
 

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -46,10 +46,10 @@ import { I18n } from "../../i18n/i18n.module";
 			[ngClass]="{
 				'bx--batch-actions--active': selected
 			}"
-			[attr.aria-label]="actionBarLabel | async">
+			[attr.aria-label]="actionBarLabel.subject | async">
 			<div class="bx--action-list">
 				<ng-content select="ibm-table-toolbar-actions"></ng-content>
-				<button ibmButton="primary" class="bx--batch-summary__cancel" (click)="onCancel()">{{cancelText | async}}</button>
+				<button ibmButton="primary" class="bx--batch-summary__cancel" (click)="onCancel()">{{_cancelText.subject | async}}</button>
 			</div>
 			<div class="bx--batch-summary">
 				<p class="bx--batch-summary__para">
@@ -64,17 +64,17 @@ import { I18n } from "../../i18n/i18n.module";
 export class TableToolbar {
 	@Input() model: TableModel;
 
-	@Input() set ariaLabel (value) {
-		this.actionBarLabel.next(value.ACTION_BAR);
+	@Input() set ariaLabel (value: { ACTION_BAR: string }) {
+		this.actionBarLabel.override(value.ACTION_BAR);
 	}
-	@Input() set cancelText(value) {
-		this._cancelText.next(value.CANCEL);
+	@Input() set cancelText(value: { CANCEL: string }) {
+		this._cancelText.override(value.CANCEL);
 	}
-	get cancelText() {
-		return this._cancelText;
+	get cancelText(): { CANCEL: string } {
+		return { CANCEL: this._cancelText.value as string };
 	}
-	actionBarLabel = this.i18n.get("TABLE_TOOLBAR.ACTION_BAR");
-	_cancelText = this.i18n.get("TABLE_TOOLBAR.CANCEL");
+	actionBarLabel = this.i18n.getOverrideable("TABLE_TOOLBAR.ACTION_BAR");
+	_cancelText = this.i18n.getOverrideable("TABLE_TOOLBAR.CANCEL");
 
 	constructor(protected i18n: I18n) {}
 

--- a/src/tiles/expandable-tile.component.ts
+++ b/src/tiles/expandable-tile.component.ts
@@ -60,8 +60,8 @@ export class ExpandableTile implements AfterContentInit {
 	tileMaxHeight = 0;
 	element = this.elementRef.nativeElement;
 
-	expand = this.i18n.getOverrideable("TILES.EXPAND");
-	collapse = this.i18n.getOverrideable("TILES.COLLAPSE");
+	expand = this.i18n.getOverridable("TILES.EXPAND");
+	collapse = this.i18n.getOverridable("TILES.COLLAPSE");
 
 	constructor(protected i18n: I18n, protected elementRef: ElementRef) {}
 

--- a/src/tiles/expandable-tile.component.ts
+++ b/src/tiles/expandable-tile.component.ts
@@ -1,12 +1,16 @@
 import {
 	Component,
-	HostBinding,
 	Input,
-	ViewChild,
 	ElementRef,
 	AfterContentInit
 } from "@angular/core";
 import { I18n } from "./../i18n/i18n.module";
+import { merge } from "./../utils/object";
+
+export interface ExpandableTileTranslations {
+	EXPAND: string;
+	COLLAPSE: string;
+}
 
 @Component({
 	selector: "ibm-expandable-tile",
@@ -18,13 +22,13 @@ import { I18n } from "./../i18n/i18n.module";
 			role="button"
 			tabindex="0"
 			(click)="onClick()">
-			<button [attr.aria-label]="(expanded ? collapse : expand) | async" class="bx--tile__chevron">
+			<button [attr.aria-label]="(expanded ? collapse : expand).subject | async" class="bx--tile__chevron">
 				<svg *ngIf="!expanded" width="12" height="7" viewBox="0 0 12 7" role="img">
-					<title>{{expand | async}}</title>
+					<title>{{expand.subject | async}}</title>
 					<path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z"/>
 				</svg>
 				<svg *ngIf="expanded" width="12" height="7" viewBox="0 0 12 7" role="img">
-					<title>{{collapse | async}}</title>
+					<title>{{collapse.subject | async}}</title>
 					<path fill-rule="nonzero" d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z"/>
 				</svg>
 			</button>
@@ -47,20 +51,17 @@ export class ExpandableTile implements AfterContentInit {
 	 * ```
 	 */
 	@Input()
-	set translations (value) {
-		if (value.EXPAND) {
-			this.expand.next(value.EXPAND);
-		}
-		if (value.COLLAPSE) {
-			this.collapse.next(value.COLLAPSE);
-		}
+	set translations(value: ExpandableTileTranslations) {
+		const valueWithDefaults = merge(this.i18n.getMultiple("TILES"), value);
+		this.expand.override(valueWithDefaults.EXPAND);
+		this.collapse.override(valueWithDefaults.COLLAPSE);
 	}
 
 	tileMaxHeight = 0;
 	element = this.elementRef.nativeElement;
 
-	expand = this.i18n.get("TILES.EXPAND");
-	collapse = this.i18n.get("TILES.COLLAPSE");
+	expand = this.i18n.getOverrideable("TILES.EXPAND");
+	collapse = this.i18n.getOverrideable("TILES.COLLAPSE");
 
 	constructor(protected i18n: I18n, protected elementRef: ElementRef) {}
 

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -160,11 +160,11 @@ export class Toggle extends Checkbox {
 		Toggle.toggleCount++;
 	}
 
-	getOffText() {
+	getOffText(): Observable<string> {
 		return this._offValues.subject;
 	}
 
-	getOnText() {
+	getOnText(): Observable<string> {
 		return this._onValues.subject;
 	}
 

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -10,6 +10,7 @@ import {
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
 import { I18n } from "../i18n/i18n.module";
+import { Observable } from "rxjs";
 
 /**
  * Defines the set of states for a toggle component.
@@ -105,7 +106,7 @@ export class Toggle extends Checkbox {
 	 * Text that is set on the left side of the toggle.
 	 */
 	@Input()
-	set offText(value: string) {
+	set offText(value: string | Observable<string>) {
 		this._offValues.override(value);
 	}
 
@@ -117,7 +118,7 @@ export class Toggle extends Checkbox {
 	 * Text that is set on the right side of the toggle.
 	 */
 	@Input()
-	set onText(value: string) {
+	set onText(value: string | Observable<string>) {
 		this._onValues.override(value);
 	}
 

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -150,8 +150,8 @@ export class Toggle extends Checkbox {
 	 */
 	@Output() change = new EventEmitter<ToggleChange>();
 
-	protected _offValues = this.i18n.getOverrideable("TOGGLE.OFF");
-	protected _onValues = this.i18n.getOverrideable("TOGGLE.ON");
+	protected _offValues = this.i18n.getOverridable("TOGGLE.OFF");
+	protected _onValues = this.i18n.getOverridable("TOGGLE.ON");
 	/**
 	 * Creates an instance of Toggle.
 	 */

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -78,13 +78,13 @@ export class ToggleChange {
 			[ngClass]="{
 				'bx--skeleton': skeleton
 			}">
-			<span class="bx--toggle__text--left">{{(!skeleton ? offText : null) | async }}</span>
+			<span class="bx--toggle__text--left">{{(!skeleton ? getOffText() : null) | async }}</span>
 			<span class="bx--toggle__appearance">
 				<svg *ngIf="size === 'sm'" class="bx--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
 					<path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"/>
 				</svg>
 			</span>
-			<span class="bx--toggle__text--right">{{(!skeleton ? onText : null) | async}}</span>
+			<span class="bx--toggle__text--right">{{(!skeleton ? getOnText() : null) | async}}</span>
 		</label>
 	`,
 	providers: [
@@ -106,11 +106,11 @@ export class Toggle extends Checkbox {
 	 */
 	@Input()
 	set offText(value: string) {
-		this._offText.next(value);
+		this._offValues.override(value);
 	}
 
 	get offText() {
-		return this._offText;
+		return this._offValues.value;
 	}
 
 	/**
@@ -118,11 +118,11 @@ export class Toggle extends Checkbox {
 	 */
 	@Input()
 	set onText(value: string) {
-		this._onText.next(value);
+		this._onValues.override(value);
 	}
 
 	get onText() {
-		return this._onText;
+		return this._onValues.value;
 	}
 	/**
 	 * Text that is set as the label of the toggle.
@@ -149,14 +149,22 @@ export class Toggle extends Checkbox {
 	 */
 	@Output() change = new EventEmitter<ToggleChange>();
 
-	protected _offText = this.i18n.get("TOGGLE.OFF");
-	protected _onText = this.i18n.get("TOGGLE.ON");
+	protected _offValues = this.i18n.getOverrideable("TOGGLE.OFF");
+	protected _onValues = this.i18n.getOverrideable("TOGGLE.ON");
 	/**
 	 * Creates an instance of Toggle.
 	 */
 	constructor(protected changeDetectorRef: ChangeDetectorRef, protected i18n: I18n) {
 		super(changeDetectorRef);
 		Toggle.toggleCount++;
+	}
+
+	getOffText() {
+		return this._offValues.subject;
+	}
+
+	getOnText() {
+		return this._onValues.subject;
 	}
 
 	/**

--- a/src/toggle/toggle.stories.ts
+++ b/src/toggle/toggle.stories.ts
@@ -24,6 +24,14 @@ storiesOf("Toggle", module).addDecorator(
 				[checked]="checked"
 				[size]="size">
 			</ibm-toggle>
+			<ibm-toggle
+				[label]="label"
+				[onText]="altOnText"
+				[offText]="altOffText"
+				[disabled]="disabled"
+				[checked]="checked"
+				[size]="size">
+			</ibm-toggle>
 		`,
 		props: {
 			disabled: boolean("Disabled", false),
@@ -31,7 +39,9 @@ storiesOf("Toggle", module).addDecorator(
 			size: select("Size", ["md", "sm"], "md"),
 			label: text("Label text", ""),
 			onText: text("On text", "On"),
-			offText: text("Off text", "Off")
+			offText: text("Off text", "Off"),
+			altOffText: text("Alternative off text", "Dark"),
+			altOnText: text("Alternative on text", "Light")
 		}
 	}))
 	.add("Skeleton", () => ({


### PR DESCRIPTION
Adds the notion of an "Overridable" to `I18N`. From the comments:

> Largely an internal usecase. There are situations where we want an `Observable` that can emit events from a centralized source **OR** an `Observable` that will emit events from a component local source. The key example being on/off text in a `Toggle` - In some cases we want the `Toggle` to use `I18n`s global translations, but in others we'd prefer to use a local override. We don't ever need to return to an non-overriden state, but we do need the ability to switch _to_ an overridden sate.