### PR TITLE
fix(overflow-menu): change after checked errors

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-option.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-option.component.ts
@@ -28,8 +28,8 @@ import {
 			class="bx--overflow-menu-options__btn"
 			role="menuitem"
 			[tabindex]="tabIndex"
-			(focus)="tabIndex = 0"
-			(blur)="tabIndex = -1"
+			(focus)="onFocus()"
+			(blur)="onBlur()"
 			(click)="onClick($event)"
 			[disabled]="disabled"
 			[attr.title]="title">
@@ -41,8 +41,8 @@ import {
 			class="bx--overflow-menu-options__btn"
 			role="menuitem"
 			[tabindex]="tabIndex"
-			(focus)="tabIndex = 0"
-			(blur)="tabIndex = -1"
+			(focus)="onFocus()"
+			(blur)="onBlur()"
 			(click)="onClick($event)"
 			[attr.disabled]="disabled"
 			[href]="href"
@@ -90,8 +90,16 @@ export class OverflowMenuOption implements AfterViewInit {
 
 	constructor(protected elementRef: ElementRef) {}
 
-	onClick(event) {
+	onClick() {
 		this.selected.emit();
+	}
+
+	onFocus() {
+		setTimeout(() => this.tabIndex = 0);
+	}
+
+	onBlur() {
+		setTimeout(() => this.tabIndex = -1);
 	}
 
 	ngAfterViewInit() {

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -170,13 +170,13 @@ export class Modal implements AfterViewInit, OnInit, OnDestroy {
 	ngAfterViewInit() {
 		const primaryFocusElement = this.modal.nativeElement.querySelector(this.selectorPrimaryFocus);
 		if (primaryFocusElement && primaryFocusElement.focus) {
-			primaryFocusElement.focus();
+			setTimeout(() => primaryFocusElement.focus());
 			return;
 		}
 		if (getFocusElementList(this.modal.nativeElement).length > 0) {
-			getFocusElementList(this.modal.nativeElement)[0].focus();
+			setTimeout(() => getFocusElementList(this.modal.nativeElement)[0].focus());
 		} else {
-			this.modal.nativeElement.focus();
+			setTimeout(() => this.modal.nativeElement.focus());
 		}
 	}
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#571

@cal-smith has a PR #674 for fixing #571 in v2. The Assess UX Redesign team has come across the same issue in v3. So I just cherry pick PR #674 (except the `package-lock.json`) and created this PR.

#### Changelog

See PR #674 . I just cherry pick that one except the `package-lock.json` file.

When I used these changes in my local node module for Carbon Components Angular with Assess I don't see the error in the console anymore.

Before:
![OverflowMenuOption](https://user-images.githubusercontent.com/22054715/63128360-aa108400-bfac-11e9-877d-6fc3cb9c33fd.gif)

After:
![OverflowMenuOption-fixed](https://user-images.githubusercontent.com/22054715/63128370-b1379200-bfac-11e9-95cd-e0e2e58748b0.gif)


