### PR TITLE
fix template tab display wrong

### DIFF
--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -36,7 +36,8 @@ import { Tab } from "./tab.component";
 					</ng-container>
 					<ng-template
 						*ngIf="getSelectedTab().headingIsTemplate"
-						[ngTemplateOutlet]="getSelectedTab().heading">
+						[ngTemplateOutlet]="getSelectedTab().heading"
+						[ngTemplateOutletContext]="{$implicit: getSelectedTab().context}">
 					</ng-template>
 				</a>
 				<svg width="10" height="5" viewBox="0 0 10 5">


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

{{When the tab is template and the window is resized to be changed to a dropdown list; The selection will not make the tab name change}}

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{Add template processing, when the tab is template}}

**Removed**

* {{removed thing}}
