### PR TITLE
fix(ui-shell): remove close icon

### DIFF
--- a/src/ui-shell/header/header-action.component.ts
+++ b/src/ui-shell/header/header-action.component.ts
@@ -20,7 +20,6 @@ import {
 			[title]="title"
 			(click)="onClick()">
 			<ng-content></ng-content>
-			<svg ibmIconClose20 class="bx--navigation-menu-panel-collapse-icon"></svg>
 		</button>
 	`
 })

--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -1,4 +1,12 @@
-import { Component, Input } from "@angular/core";
+import {
+	Component,
+	Input,
+	Optional,
+	Output,
+	EventEmitter
+} from "@angular/core";
+import { DomSanitizer } from "@angular/platform-browser";
+import { Router } from "@angular/router";
 import { I18n } from "../../i18n/i18n.module";
 
 /**
@@ -18,13 +26,17 @@ import { I18n } from "../../i18n/i18n.module";
 			role="banner"
 			[attr.aria-label]="brand + ' ' + name">
 			<a
+				*ngIf="!skipTo"
 				class="bx--skip-to-content"
 				[href]="skipTo"
 				tabindex="0">
 				{{ i18n.get("UI_SHELL.SKIP_TO") | async }}
 			</a>
 			<ng-content select="ibm-hamburger"></ng-content>
-			<a class="bx--header__name" href="#">
+			<a
+				class="bx--header__name"
+				href="#"
+				(click)="navigate($event)">
 				<span class="bx--header__name--prefix">{{brand}}&nbsp;</span>
 				{{name}}
 			</a>
@@ -46,5 +58,46 @@ export class Header {
 	 */
 	@Input() brand = "IBM";
 
-	constructor(public i18n: I18n) { }
+	/**
+	 * Optional link for the header
+	 */
+	@Input() set href(v: string) {
+		this._href = v;
+	}
+
+	get href() {
+		return this.domSanitizer.bypassSecurityTrustUrl(this._href) as string;
+	}
+
+	/**
+	 * Array of commands to send to the router when the link is activated
+	 * See: https://angular.io/api/router/Router#navigate
+	 */
+	@Input() route: any[];
+
+	/**
+	 * Router options. Used in conjunction with `route`
+	 * See: https://angular.io/api/router/Router#navigate
+	 */
+	@Input() routeExtras: any;
+
+	/**
+	 * Emits the navigation status promise when the link is activated
+	 */
+	@Output() navigation = new EventEmitter<Promise<boolean>>();
+
+	protected _href = "javascript:void(0)";
+
+	constructor(
+		public i18n: I18n,
+		protected domSanitizer: DomSanitizer,
+		@Optional() protected router: Router) { }
+
+	navigate(event) {
+		if (this.router && this.route) {
+			event.preventDefault();
+			const status = this.router.navigate(this.route, this.routeExtras);
+			this.navigation.emit(status);
+		}
+	}
 }

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -237,8 +237,12 @@ storiesOf("UI Shell", module)
 				</ibm-header-navigation>
 				<ibm-header-global>
 					<ibm-header-action #firstAction title="action">
-						<svg class="bx--navigation-menu-panel-expand-icon"
-							width="20" height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
+						<svg
+							width="20"
+							height="20"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 32 32"
+							aria-hidden="true">
 							<path
 								d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12
 								12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86
@@ -250,9 +254,11 @@ storiesOf("UI Shell", module)
 					</ibm-header-action>
 					<ibm-header-action #secondAction title="action">
 						<svg
-							class="bx--navigation-menu-panel-expand-icon"
 							width="20"
-							height="20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" aria-hidden="true">
+							height="20"
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 32 32"
+							aria-hidden="true">
 							<path
 								d="M8.24 25.14L7 26.67a14 14 0 0 0 4.18 2.44l.68-1.88a12
 								12 0 0 1-3.62-2.09zm-4.05-7.07l-2 .35A13.89 13.89 0 0 0 3.86


### PR DESCRIPTION
- removes the close icon (consumers can add it back with an ngIf on their end, not needed with the updated carbon styles)
- updates the header to take a route