### PR TITLE
feat: add basic support for angular ivy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ doc/
 documentation/
 dist/
 a11y/results*
-dist-pkg

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ const dirs = {
 	DIST: "dist"
 };
 
-const licenseTemplate = `/*!
+const licenseTemplate = `/**
  *
  * carbon-angular v@PACKAGE_VERSION@ | @FILE_NAME@
  *
@@ -85,7 +85,7 @@ const buildReadme = () =>
 // =================================
 const build = gulp.series(buildAngular, buildI18n);
 
-const buildMeta = gulp.series(buildPackage, gulp.parallel(moveLicense, buildLicense, buildReadme));
+const buildMeta = gulp.parallel(moveLicense, buildLicense);
 
 module.exports = {
 	build,

--- a/ng-package.json
+++ b/ng-package.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "./node_modules/ng-packagr/ng-package.schema.json",
-	"dest": "./dist-pkg",
+	"dest": "./dist",
 	"lib": {
 		"entryFile": "src/index.ts"
 	},

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,6 +3,11 @@
 set -e # exit with nonzero exit code if anything fails
 
 rm -rf dist
+
+# run the angular/ng-packagr build
+ng build
+
+# run the classic buld - TODO remove with v4/Carbon v11
 gulp build
 ngc -p tsconfig-aot.json
 webpack --config webpack.build.js

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,7 +14,7 @@ npm run semantic-release
 
 # deploy to gh pages
 if [[ $TRAVIS_BRANCH == "master" ]]; then
-	mkdir pages
+	mkdir -p pages
 	cd pages
 
 	git init
@@ -29,7 +29,7 @@ if [[ $TRAVIS_BRANCH == "master" ]]; then
 	cp -R ../dist/docs/storybook/* ./
 
 	version=$(node -e 'const package = require("./../dist/package.json"); console.log(package.version);')
-	mkdir $version
+	mkdir -p $version
 	mkdir -p $version/documentation
 	cp -R ../dist/docs/documentation/* $version/documentation
 	cp -R ../dist/docs/storybook/* $version

--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -101,8 +101,6 @@ export class FileUploader implements OnInit {
 	@Input() skeleton = false;
 	/**
 	 * Sets the size of the button.
-	 *
-	 * @type {("sm" | "normal")}
 	 */
 	@Input() size: "sm" | "normal";
 	/**

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,9 +1,9 @@
-{
+export default {
 	"BANNER": {
 		"CLOSE_BUTTON": "Close alert banner"
 	},
 	"CALENDAR": {
-		"MONTHS":{
+		"MONTHS": {
 			"JANUARY": "January",
 			"FEBRUARY": "February",
 			"MARCH": "March",
@@ -17,7 +17,7 @@
 			"NOVEMBER": "November",
 			"DECEMBER": "December"
 		},
-		"SHORTWEEKDAYS":{
+		"SHORTWEEKDAYS": {
 			"SUNDAY": "Sun",
 			"MONDAY": "Mon",
 			"TUESDAY": "Tue",
@@ -155,4 +155,4 @@
 			"TOGGLE_CLOSE": "Close"
 		}
 	}
-}
+};

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -8,7 +8,7 @@ import {
 import { map } from "rxjs/operators";
 import { merge } from "../utils/object";
 
-const EN = require("./en.json");
+import EN from "./en";
 
 /**
  * Takes the `Observable` returned from `i18n.get` and an object of variables to replace.
@@ -153,7 +153,7 @@ export class I18n {
 	 *
 	 * @param path optional, looks like `"NOTIFICATION.CLOSE_BUTTON"`
 	 */
-	public get(path?: string) {
+	public get(path?: string): any {
 		if (!path) {
 			return this.translationStrings;
 		}
@@ -221,7 +221,7 @@ export class I18n {
 				throw new Error(`no key ${segment} at ${path}`);
 			}
 		}
-		return value;
+		return value as any;
 	}
 
 	/**

--- a/src/i18n/i18n.spec.ts
+++ b/src/i18n/i18n.spec.ts
@@ -1,7 +1,7 @@
 import { I18n } from "./i18n.service";
 import { isObservable, BehaviorSubject } from "rxjs";
 
-const EN = require("./en.json");
+import EN from "./en";
 
 let service;
 

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -17,7 +17,7 @@ import { PlaceholderModule } from "./../placeholder/placeholder.module";
 import { ExperimentalModule } from "./../experimental.module";
 
 // exports
-export { default as Modal } from "./modal.decorator";
+export { default as ModalDecorator } from "./modal.decorator";
 export { ModalService } from "./modal.service";
 export * from "./alert-modal.interface";
 export * from "./base-modal.class";

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -1,4 +1,4 @@
-import { PaginationModel } from "./pagination.module";
+import { PaginationModel } from "./pagination-model.class";
 import {
 	Component,
 	Input,

--- a/src/table/head/table-head.component.ts
+++ b/src/table/head/table-head.component.ts
@@ -5,7 +5,7 @@ import {
 	EventEmitter
 } from "@angular/core";
 
-import { TableModel } from "../table.module";
+import { TableModel } from "../table-model.class";
 import { I18n, Overridable } from "../../i18n/i18n.module";
 import { Observable } from "rxjs";
 

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -11,7 +11,7 @@ import {
 } from "@angular/core";
 import { Subscription, fromEvent, Observable } from "rxjs";
 
-import { TableModel } from "./table.module";
+import { TableModel } from "./table-model.class";
 import { TableHeaderItem } from "./table-header-item.class";
 import { TableItem } from "./table-item.class";
 

--- a/src/table/table.module.ts
+++ b/src/table/table.module.ts
@@ -12,7 +12,8 @@ import { Close16Module } from "@carbon/icons-angular/lib/close/16";
 import { NFormsModule } from "./../forms/forms.module";
 import { DialogModule } from "./../dialog/dialog.module";
 import { I18nModule } from "./../i18n/i18n.module";
-import { ButtonModule, SearchModule } from "../";
+import { ButtonModule } from "./../button/button.module";
+import { SearchModule } from "./../search/search.module";
 
 // table utilities/toolbar imports
 import { TableToolbar } from "./toolbar/table-toolbar.component";

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -25,10 +25,10 @@
 		]
 	},
 	"files": [
-		"src/test.ts",
+		"src/test.ts"
 	],
 	"include": [
-		"**/*.spec.ts",
+		"**/*.spec.ts"
 	],
 	"angularCompilerOptions": {
 		"annotateForClosureCompiler": true,

--- a/tslint.json
+++ b/tslint.json
@@ -123,8 +123,6 @@
 			"check-type",
 			"check-preblock"
 		],
-
-		// [ENABLED, "attribute" | "element", "selectorPrefix" | ["listOfPrefixes"], "camelCase" | "kebab-case"]
 		"directive-selector": [true, "attribute", ["ibm", "app", "test"], "camelCase"],
 		"component-selector": [true, "element", ["ibm", "app", "test"], "kebab-case"],
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#641

- `en.json` is now `en.ts` - the angular compiler doesn't package `.json` by default, and there's no reason it needs to be `.json` formatted for our purposes anyway
- fixed a bunch of circular imports
- fixed some `mkrdir` deploy errors
- renamed the `Modal` decorator to `ModalDecorator` ... we'll need to have a v4 to fully support ivy, so we can drop it then ... I don't believe there will be compat issues since the decorator _doesn't work anyway_. But definitely open to suggestions on this issue.