### PR TITLE
fix(dropdown): validate value of writtenValue before trigger write value

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -293,7 +293,9 @@ export class Dropdown implements OnInit, AfterContentInit, OnDestroy, ControlVal
 		if (!this.view) {
 			return;
 		}
-		this.writeValue(this.writtenValue);
+		if (this.writtenValue && this.writtenValue.length) {
+			this.writeValue(this.writtenValue);
+		}
 		this.view.type = this.type;
 		this.view.size = this.size;
 		this.view.select.subscribe(event => {

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -375,14 +375,14 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			console.error(`${this.constructor.name}.propagateSelected expects an Array<ListItem>, got ${JSON.stringify(value)}`);
 		}
 		// loop through the list items and update the `selected` state for matching items in `value`
-		for (let oldItem of value) {
+		for (let oldItem of this.getListItems()) {
 			// copy the item
 			let tempOldItem: string | ListItem = Object.assign({}, oldItem);
 			// deleted selected because it's what we _want_ to change
 			delete tempOldItem.selected;
 			// stringify for compare
 			tempOldItem = JSON.stringify(tempOldItem);
-			for (let newItem of this.getListItems()) {
+			for (let newItem of value) {
 				// copy the item
 				let tempNewItem: string | ListItem = Object.assign({}, newItem);
 				// deleted selected because it's what we _want_ to change


### PR DESCRIPTION
Closes IBM/carbon-components-angular#788
Closes IBM/carbon-components-angular#815

There was an issue when you have a previously selected value on the options list passed to items input in dropdown, it wasn't showing it as selected option, now it is selecting it as expected.

#### Changelog

**Changed**

* Added validation to just trigger write value if writtenValue actually has value.
