### PR TITLE
fix(table): trigger selectAll now checks header checkbox as expected

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -663,6 +663,7 @@ export class Table implements AfterViewInit, OnDestroy {
 			this.selectAllCheckbox = false;
 			this.selectAllCheckboxSomeSelected = false;
 		} else if (selectedRowsCount < this.model.data.length) {
+			this.selectAllCheckbox = false;
 			this.selectAllCheckboxSomeSelected = true;
 		} else {
 			this.selectAllCheckbox = true;


### PR DESCRIPTION
Closes IBM/carbon-components-angular#812

The Selected All header checkbox now checks when manually select all items on the table.

#### Changelog

**Changed**

* Add a change to false that is needed to trigger change on selectedAllCheckbox variable.
