### PR TITLE
fix(date picker): Show DatePicker when calendar icon is clicked

### DIFF
--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -36,9 +36,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[id]= "id"
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
-						<ibm-icon-calendar16
-							class="bx--date-picker__icon"
-							(click)="onClick()">
+						<ibm-icon-calendar16 class="bx--date-picker__icon">
 						</ibm-icon-calendar16>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
@@ -78,8 +76,6 @@ export class DatePickerInput {
 
 	@Output() valueChange: EventEmitter<string> = new EventEmitter();
 
-	@Output() selected = new EventEmitter();
-
 	@Input() theme: "light" | "dark" = "dark";
 
 	@Input() disabled = false;
@@ -99,10 +95,6 @@ export class DatePickerInput {
 		this.valueChange.emit(this.value);
 		this.propagateChange(this.value);
 		this.onTouched();
-	}
-
-	onClick() {
-		this.selected.emit();
 	}
 
 	public writeValue(value: any) {

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -78,7 +78,7 @@ export class DatePickerInput {
 
 	@Output() valueChange: EventEmitter<string> = new EventEmitter();
 
-	@Output() toggleCalendar: EventEmitter<boolean> = new EventEmitter();
+	@Output() selected = new EventEmitter();
 
 	@Input() theme: "light" | "dark" = "dark";
 
@@ -92,8 +92,6 @@ export class DatePickerInput {
 
 	@Input() value = "";
 
-	protected calendarOpen = false;
-
 	constructor(protected elementRef: ElementRef) {}
 
 	onChange(event) {
@@ -104,8 +102,7 @@ export class DatePickerInput {
 	}
 
 	onClick() {
-		this.calendarOpen = !this.calendarOpen;
-		this.toggleCalendar.emit(this.calendarOpen);
+		this.selected.emit();
 	}
 
 	public writeValue(value: any) {

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -37,7 +37,8 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
 						<ibm-icon-calendar16
-							class="bx--date-picker__icon">
+							class="bx--date-picker__icon"
+							(click)="onClick()">
 						</ibm-icon-calendar16>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
@@ -77,6 +78,8 @@ export class DatePickerInput {
 
 	@Output() valueChange: EventEmitter<string> = new EventEmitter();
 
+	@Output() toggleCalendar: EventEmitter<boolean> = new EventEmitter();
+
 	@Input() theme: "light" | "dark" = "dark";
 
 	@Input() disabled = false;
@@ -89,6 +92,8 @@ export class DatePickerInput {
 
 	@Input() value = "";
 
+	protected calendarOpen = false;
+
 	constructor(protected elementRef: ElementRef) {}
 
 	onChange(event) {
@@ -96,6 +101,11 @@ export class DatePickerInput {
 		this.valueChange.emit(this.value);
 		this.propagateChange(this.value);
 		this.onTouched();
+	}
+
+	onClick() {
+		this.calendarOpen = !this.calendarOpen;
+		this.toggleCalendar.emit(this.calendarOpen);
 	}
 
 	public writeValue(value: any) {

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -47,7 +47,8 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalid]="invalid"
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
-						(valueChange)="onValueChange($event)">
+						(valueChange)="onValueChange($event)"
+						(toggleCalendar)="onToggleCalendar($event)">
 					</ibm-date-picker-input>
 				</div>
 
@@ -252,6 +253,14 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 				this.setDateValues([date]);
 			}
 			this.doSelect(this.flatpickrInstance.selectedDates);
+		}
+	}
+
+	onToggleCalendar(event: boolean) {
+		if (event) {
+			this.flatpickrInstance.open();
+		} else {
+			this.flatpickrInstance.close();
 		}
 	}
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -48,7 +48,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onValueChange($event)"
-						(toggleCalendar)="onToggleCalendar($event)">
+						(selected)="flatpickrInstance.open()">
 					</ibm-date-picker-input>
 				</div>
 
@@ -64,7 +64,8 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalid]="invalid"
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
-						(valueChange)="onRangeValueChange($event)">
+						(valueChange)="onRangeValueChange($event)"
+						(selected)="flatpickrInstance.open()">
 					</ibm-date-picker-input>
 				</div>
 			</div>
@@ -253,14 +254,6 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 				this.setDateValues([date]);
 			}
 			this.doSelect(this.flatpickrInstance.selectedDates);
-		}
-	}
-
-	onToggleCalendar(event: boolean) {
-		if (event) {
-			this.flatpickrInstance.open();
-		} else {
-			this.flatpickrInstance.close();
 		}
 	}
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -48,7 +48,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onValueChange($event)"
-						(selected)="flatpickrInstance.open()">
+						(click)="flatpickrInstance.open()">
 					</ibm-date-picker-input>
 				</div>
 
@@ -65,7 +65,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onRangeValueChange($event)"
-						(selected)="flatpickrInstance.open()">
+						(click)="flatpickrInstance.open()">
 					</ibm-date-picker-input>
 				</div>
 			</div>


### PR DESCRIPTION
Closes #837 

DatePicker could not be opened when the calendar icon is clicked. A toggle has been added to open and close the DatePicker when the calendar icon is clicked.

#### Changelog

**New**

* It is now possible to open and close the calendar when the calendar icon is clicked.
