### PR TITLE
fix(pagination): Align pagination select arrows

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -80,7 +80,6 @@ export interface PaginationTranslations {
 						</option>
 					</select>
 					<svg
-						[ngClass]="{'If this is here its the new chevron': true}"
 						ibmIconChevronDown16
 						style="display: inherit"
 						class="bx--select__arrow"
@@ -133,7 +132,6 @@ export interface PaginationTranslations {
 						<option *ngFor="let page of pageOptions; let i = index;" class="bx--select-option" [value]="i + 1">{{i + 1}}</option>
 					</select>
 					<svg
-						[ngClass]="{'If this is here its the new chevron': true}"
 						*ngIf="pageOptions.length <= 1000"
 						ibmIconChevronDown16
 						style="display: inherit;"

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -80,15 +80,12 @@ export interface PaginationTranslations {
 						</option>
 					</select>
 					<svg
-						focusable="false"
-						preserveAspectRatio="xMidYMid meet"
-						style="will-change: transform;"
-						xmlns="http://www.w3.org/2000/svg"
+						[ngClass]="{'If this is here its the new chevron': true}"
+						ibmIconChevronDown16
+						style="display: inherit"
 						class="bx--select__arrow"
-						width="16" height="16"
-						viewBox="0 0 16 16"
-						aria-hidden="true">
-						<path d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"></path>
+						aria-hidden="true"
+						[ariaLabel]="optionsListText.subject | async">
 					</svg>
 				</div>
 			</div>
@@ -136,17 +133,12 @@ export interface PaginationTranslations {
 						<option *ngFor="let page of pageOptions; let i = index;" class="bx--select-option" [value]="i + 1">{{i + 1}}</option>
 					</select>
 					<svg
+						[ngClass]="{'If this is here its the new chevron': true}"
 						*ngIf="pageOptions.length <= 1000"
-						focusable="false"
-						preserveAspectRatio="xMidYMid meet"
-						style="will-change: transform;"
-						xmlns="http://www.w3.org/2000/svg"
+						ibmIconChevronDown16
+						style="display: inherit;"
 						class="bx--select__arrow"
-						width="16"
-						height="16"
-						viewBox="0 0 16 16"
-						aria-hidden="true">
-						<path d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"></path>
+						[ariaLabel]="optionsListText.subject | async">
 					</svg>
 				</div>
 			</div>

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -79,11 +79,17 @@ export interface PaginationTranslations {
 								{{ option }}
 						</option>
 					</select>
-					<ibm-icon-chevron-down16
-						style="display: inherit;"
-						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText.subject | async">
-					</ibm-icon-chevron-down16>
+					<svg
+						focusable="false"
+						preserveAspectRatio="xMidYMid meet"
+						style="will-change: transform;"
+						xmlns="http://www.w3.org/2000/svg"
+						class="bx--select__arrow"
+						width="16" height="16"
+						viewBox="0 0 16 16"
+						aria-hidden="true">
+						<path d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"></path>
+					</svg>
 				</div>
 			</div>
 
@@ -129,12 +135,19 @@ export interface PaginationTranslations {
 						[(ngModel)]="currentPage">
 						<option *ngFor="let page of pageOptions; let i = index;" class="bx--select-option" [value]="i + 1">{{i + 1}}</option>
 					</select>
-					<ibm-icon-chevron-down16
+					<svg
 						*ngIf="pageOptions.length <= 1000"
-						style="display: inherit;"
-						innerClass="bx--select__arrow"
-						[ariaLabel]="optionsListText.subject | async">
-					</ibm-icon-chevron-down16>
+						focusable="false"
+						preserveAspectRatio="xMidYMid meet"
+						style="will-change: transform;"
+						xmlns="http://www.w3.org/2000/svg"
+						class="bx--select__arrow"
+						width="16"
+						height="16"
+						viewBox="0 0 16 16"
+						aria-hidden="true">
+						<path d="M8 11L3 6l.7-.7L8 9.6l4.3-4.3.7.7z"></path>
+					</svg>
 				</div>
 			</div>
 

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -5,6 +5,7 @@ import { ChevronDown16Module } from "@carbon/icons-angular/lib/chevron--down/16"
 import { CaretLeft16Module } from "@carbon/icons-angular/lib/caret--left/16";
 import { CaretRight16Module } from "@carbon/icons-angular/lib/caret--right/16";
 
+
 import { Pagination } from "./pagination.component";
 import { I18nModule } from "./../i18n/i18n.module";
 import { ExperimentalModule } from "./../experimental.module";

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -5,7 +5,6 @@ import { ChevronDown16Module } from "@carbon/icons-angular/lib/chevron--down/16"
 import { CaretLeft16Module } from "@carbon/icons-angular/lib/caret--left/16";
 import { CaretRight16Module } from "@carbon/icons-angular/lib/caret--right/16";
 
-
 import { Pagination } from "./pagination.component";
 import { I18nModule } from "./../i18n/i18n.module";
 import { ExperimentalModule } from "./../experimental.module";


### PR DESCRIPTION
Closes #764 

The arrows are aligned in the storybook but when the pagination component is used outside of the storybook they are no longer aligned as shown below:

![Screen Shot 2019-10-15 at 4 54 18 PM](https://user-images.githubusercontent.com/45505172/66869455-7b436980-ef6d-11e9-8e87-a4261e51f3b9.png)

The arrows are now aligned when the component is used both in and out of the storybook.

#### Changelog

**Changed**

* Changed the chevron-down-16 icon component to svg path in order to properly align the arrows.
