### PR TITLE
fix(Button): Initialize ibmButton to primary on init

### DIFF
--- a/src/button/button.directive.ts
+++ b/src/button/button.directive.ts
@@ -1,7 +1,8 @@
 import {
 	Directive,
 	HostBinding,
-	Input
+	Input,
+	OnInit
 } from "@angular/core";
 
 /**
@@ -23,7 +24,7 @@ import {
 @Directive({
 	selector: "[ibmButton]"
 })
-export class Button {
+export class Button implements OnInit {
 	/**
 	 * sets the button type
 	 */
@@ -60,4 +61,10 @@ export class Button {
 	}
 	@HostBinding("class.bx--toolbar-action") toolbarAction = false;
 	@HostBinding("class.bx--overflow-menu") overflowMenu = false;
+
+	ngOnInit() {
+		if (!this.ibmButton) {
+			this.ibmButton = "primary";
+		}
+	}
 }


### PR DESCRIPTION
Button did not initialize to primary when it is initialized without a button type. 

#### Changelog

**New**

* Initialize button type to primary when button type is not provided.
