### PR TITLE
fix(dropdown service): check parentRef before assigning width

### DIFF
--- a/src/dropdown/dropdown.service.ts
+++ b/src/dropdown/dropdown.service.ts
@@ -42,7 +42,9 @@ export class DropdownService {
 		menuRef.style.display = "block";
 		const dropdownWrapper = document.createElement("div");
 		dropdownWrapper.className = `dropdown ${classList}`;
-		dropdownWrapper.style.width = parentRef.offsetWidth + "px";
+		if (parentRef) {
+			dropdownWrapper.style.width = parentRef.offsetWidth + "px";
+		}
 		dropdownWrapper.style.position = "absolute";
 		dropdownWrapper.appendChild(menuRef);
 


### PR DESCRIPTION
Running some tests I would sometimes come across the error shown below:

```
	TypeError: Cannot read property 'offsetWidth' of null
	    at <Jasmine>
	    at Object.bottom (./node_modules/@carbon/utils-position/index.js?:22:56)
	    at Position.calculatePosition (./node_modules/@carbon/utils-position/index.js?:153:45)
	    at Position.findAbsolute (./node_modules/@carbon/utils-position/index.js?:85:21)
	    at DropdownService.positionDropdown (./src/dropdown/dropdown.service.ts?:88:83)
	    at DropdownService.updatePosition (./src/dropdown/dropdown.service.ts?:85:14)
	    at SafeSubscriber.eval [as _next] (./src/dropdown/dropdown.component.ts?:525:38)
	    at SafeSubscriber.__tryOrUnsub (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:194:16)
	    at SafeSubscriber.next (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:133:22)
	    at Subscriber._next (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:81:26)
	    at Subscriber.next (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:58:18)
HeadlessChrome 0.0.0 (Mac OS X 10.14.6): Executed 88 of 228 (1 FAILED) (skipped 10) (0 secs / 1.97 secs)
HeadlessChrome 0.0.0 (Mac OS X 10.14.6) Dropdown should work FAILED
	TypeError: Cannot read property 'offsetWidth' of null
	    at <Jasmine>
	    at Object.bottom (./node_modules/@carbon/utils-position/index.js?:22:56)
	    at Position.calculatePosition (./node_modules/@carbon/utils-position/index.js?:153:45)
	    at Position.findAbsolute (./node_modules/@carbon/utils-position/index.js?:85:21)
	    at DropdownService.positionDropdown (./src/dropdown/dropdown.service.ts?:88:83)
	    at DropdownService.updatePosition (./src/dropdown/dropdown.service.ts?:85:14)
	    at SafeSubscriber.eval [as _next] (./src/dropdown/dropdown.component.ts?:525:38)
	    at SafeSubscriber.__tryOrUnsub (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:194:16)
	    at SafeSubscriber.next (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:133:22)
	    at Subscriber._next (./node_modules/rxjs/_esm2015/internal/Subscriber.js?:81:26)

```

checking if parentRef is not null or undefined seems to have fixed it.