### PR TITLE
fix(selection tile): trigger selected event on tile-group on keyboard selection

### DIFF
--- a/src/tiles/selection-tile.component.ts
+++ b/src/tiles/selection-tile.component.ts
@@ -88,6 +88,7 @@ export class SelectionTile {
 	keyboardInput(event) {
 		if (event.key === "Enter" || event.key === "Spacebar" || event.key === " ") {
 			this.selected = !this.selected;
+			this.input.nativeElement.dispatchEvent(new Event("change"));
 		}
 	}
 

--- a/src/tiles/selection-tile.component.ts
+++ b/src/tiles/selection-tile.component.ts
@@ -88,7 +88,7 @@ export class SelectionTile {
 	keyboardInput(event) {
 		if (event.key === "Enter" || event.key === "Spacebar" || event.key === " ") {
 			this.selected = !this.selected;
-			this.input.nativeElement.dispatchEvent(new Event("change"));
+			this.change.emit();
 		}
 	}
 

--- a/src/tiles/selection-tile.component.ts
+++ b/src/tiles/selection-tile.component.ts
@@ -88,7 +88,7 @@ export class SelectionTile {
 	keyboardInput(event) {
 		if (event.key === "Enter" || event.key === "Spacebar" || event.key === " ") {
 			this.selected = !this.selected;
-			this.change.emit();
+			this.change.emit(event);
 		}
 	}
 


### PR DESCRIPTION
issue #880 

When a selection is made using the keyboard, the selected event on the tile-group was not being triggered. Now the selected event gets triggered as expected.

