### PR TITLE
fix(date picker): stop click propagation when calendar is clicked

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -172,7 +172,10 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		mode: "single",
 		dateFormat: "m/d/Y",
 		plugins: this.plugins,
-		onOpen: () => { this.updateClassNames(); },
+		onOpen: () => {
+			this.updateClassNames();
+			this.updateCalendarListeners();
+		},
 		value: this.value
 	};
 
@@ -276,6 +279,14 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		this.flatpickrInstance.open();
 	}
 
+	protected updateCalendarListeners() {
+		const calendarContainer = document.querySelectorAll(".flatpickr-calendar");
+		Array.from(calendarContainer).forEach(calendar => {
+			calendar.removeEventListener("click", this.preventCalendarClose);
+			calendar.addEventListener("click", this.preventCalendarClose);
+		});
+	}
+
 	/**
 	 * Carbon uses a number of specific classnames for parts of the flatpickr - this idempotent method applies them if needed.
 	 */
@@ -288,12 +299,6 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		const weekdayContainer = document.querySelectorAll(".flatpickr-weekday");
 		const daysContainer = document.querySelectorAll(".flatpickr-days");
 		const dayContainer = document.querySelectorAll(".flatpickr-day");
-
-		Array.from(calendarContainer)
-			.forEach(calendar => {
-				calendar.removeEventListener("click", this.preventCalendarClose);
-				calendar.addEventListener("click", this.preventCalendarClose);
-			});
 
 		// add classes to lists of elements
 		const addClassIfNotExists = (classname: string, elementList: NodeListOf<Element>) => {

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -278,10 +278,12 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		const weekdayContainer = document.querySelectorAll(".flatpickr-weekday");
 		const daysContainer = document.querySelectorAll(".flatpickr-days");
 		const dayContainer = document.querySelectorAll(".flatpickr-day");
-		const openCalendarContainer = document.querySelectorAll(".flatpickr-calendar.open");
 
-		Array.from(openCalendarContainer)
-			.forEach(calendar => calendar.addEventListener("click", event => event.stopPropagation()));
+		Array.from(calendarContainer)
+			.forEach(calendar => {
+				calendar.removeEventListener("click", event => event.stopPropagation());
+				calendar.addEventListener("click", event => event.stopPropagation());
+			});
 
 		// add classes to lists of elements
 		const addClassIfNotExists = (classname: string, elementList: NodeListOf<Element>) => {

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -271,7 +271,7 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 	 */
 	protected updateClassNames() {
 		if (!this.elementRef) { return; }
-
+		document.querySelector(".flatpickr-calendar").addEventListener("click", (event) => { event.stopPropagation(); });
 		// get all the possible flatpickrs in the document - we need to add classes to (potentially) all of them
 		const calendarContainer = document.querySelectorAll(".flatpickr-calendar");
 		const monthContainer = document.querySelectorAll(".flatpickr-month");

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -281,8 +281,8 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 
 		Array.from(calendarContainer)
 			.forEach(calendar => {
-				calendar.removeEventListener("click", event => event.stopPropagation());
-				calendar.addEventListener("click", event => event.stopPropagation());
+				calendar.removeEventListener("click", this.preventCalendarClose);
+				calendar.addEventListener("click", this.preventCalendarClose);
 			});
 
 		// add classes to lists of elements
@@ -362,6 +362,8 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 			}
 		}
 	}
+
+	protected preventCalendarClose = event => event.stopPropagation();
 
 	protected doSelect(selectedValue: (Date | string)[]) {
 		this.valueChange.emit(selectedValue);

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -271,7 +271,6 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 	 */
 	protected updateClassNames() {
 		if (!this.elementRef) { return; }
-		document.querySelector(".flatpickr-calendar").addEventListener("click", (event) => { event.stopPropagation(); });
 		// get all the possible flatpickrs in the document - we need to add classes to (potentially) all of them
 		const calendarContainer = document.querySelectorAll(".flatpickr-calendar");
 		const monthContainer = document.querySelectorAll(".flatpickr-month");
@@ -279,6 +278,10 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		const weekdayContainer = document.querySelectorAll(".flatpickr-weekday");
 		const daysContainer = document.querySelectorAll(".flatpickr-days");
 		const dayContainer = document.querySelectorAll(".flatpickr-day");
+		const openCalendarContainer = document.querySelectorAll(".flatpickr-calendar.open");
+
+		Array.from(openCalendarContainer)
+			.forEach(calendar => calendar.addEventListener("click", event => event.stopPropagation()));
 
 		// add classes to lists of elements
 		const addClassIfNotExists = (classname: string, elementList: NodeListOf<Element>) => {


### PR DESCRIPTION
Closes #876 

Clicking on the flatpickr calendar causes the click event to propagate. It now stops the click propagation. 
