### PR TITLE
feature(dropdown-list): add ability to set output to emit scroll event

### DIFF
--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -16,8 +16,8 @@ import { I18n } from "../../i18n/i18n.module";
 import { AbstractDropdownView } from "./../abstract-dropdown-view.class";
 import { ListItem } from "./../list-item.interface";
 import { watchFocusJump } from "./../dropdowntools";
-import { ScrollableList } from "./../scrollable-list.directive";
 import { Observable, isObservable, Subscription } from "rxjs";
+import { ScrollCustomEvent } from "./scroll-custom-event.interface";
 
 
 /**
@@ -52,6 +52,7 @@ import { Observable, isObservable, Subscription } from "rxjs";
 			#list
 			role="listbox"
 			class="bx--list-box__menu bx--multi-select"
+			(scroll)="emitScroll($event)"
 			[attr.aria-label]="ariaLabel">
 			<li
 				role="option"
@@ -129,6 +130,10 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	 * Event to emit selection of a list item within the `DropdownList`.
 	 */
 	@Output() select: EventEmitter<Object> = new EventEmitter<Object>();
+	/**
+	 * Event to emit scroll event of a list within the `DropdownList`.
+	 */
+	@Output() scroll: EventEmitter<ScrollCustomEvent> = new EventEmitter<ScrollCustomEvent>();
 	/**
 	 * Event to suggest a blur on the view.
 	 * Emits _after_ the first/last item has been focused.
@@ -475,5 +480,15 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 		const element = this.listElementList.toArray()[index].nativeElement;
 		element.classList.remove("bx--list-box__menu-item--highlighted");
 		element.tabIndex = -1;
+	}
+
+	/**
+	 * Emits the scroll event of the options list
+	 */
+	emitScroll(event) {
+		const atTop: boolean = event.srcElement.scrollTop === 0;
+		const atBottom: boolean = event.srcElement.scrollHeight - event.srcElement.scrollTop === event.srcElement.clientHeight;
+		const customScrollEvent = { atTop, atBottom, event };
+		this.scroll.emit(customScrollEvent);
 	}
 }

--- a/src/dropdown/list/scroll-custom-event.interface.ts
+++ b/src/dropdown/list/scroll-custom-event.interface.ts
@@ -1,5 +1,3 @@
-import { Scroll } from "@angular/router";
-
 /**
  * A custom structure that represents a custom event to emit when scroll.
  *
@@ -7,7 +5,7 @@ import { Scroll } from "@angular/router";
  * export interface ScrollCustomEvent {
  * 	atTop: boolean;
  * 	atBottom: boolean;
- * 	event: Scroll;
+ * 	event: Event;
  * }
  * ```
  */
@@ -23,5 +21,5 @@ export interface ScrollCustomEvent {
 	/**
 	 * Complete Scroll event available to get any more data required
 	 */
-	event: Scroll;
+	event: Event;
 }

--- a/src/dropdown/list/scroll-custom-event.interface.ts
+++ b/src/dropdown/list/scroll-custom-event.interface.ts
@@ -1,0 +1,27 @@
+import { Scroll } from "@angular/router";
+
+/**
+ * A custom structure that represents a custom event to emit when scroll.
+ *
+ * ```typescript
+ * export interface ScrollCustomEvent {
+ * 	atTop: boolean;
+ * 	atBottom: boolean;
+ * 	event: Scroll;
+ * }
+ * ```
+ */
+export interface ScrollCustomEvent {
+	/**
+	 * Flag to communicate if scroll is at the top of container
+	 */
+	atTop: boolean;
+	/**
+	 * Flag to communicate if scroll is at the bottom of container
+	 */
+	atBottom: boolean;
+	/**
+	 * Complete Scroll event available to get any more data required
+	 */
+	event: Scroll;
+}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#398

Adds the ability to set an output to get the scroll event of the ibm-dropdown-list so that user can have the opportunity to set a handler.

#### Changelog

**New**

* scroll output set to ibm-dropdown-list container

#### Usage

The event received has the next structure:
`{ atTop: boolean, atBottom: boolean, event: Scroll }`

````
<ibm-dropdown
    [label]="label"
    [helperText]="helperText"
    [invalid]="invalid"
    [invalidText]="invalidText"
    [theme]="theme"
    placeholder="Select"
    [disabled]="disabled"
    (selected)="selected($event)"
    (onClose)="onClose($event)">
        <ibm-dropdown-list [items]="items" (scroll)="handleScroll($event)"></ibm-dropdown-list>
</ibm-dropdown>
````