### PR TITLE
fix(combobox): add check to avoid error when empty array

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -462,7 +462,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 		const selected = this.view.getSelected();
 		if (this.type === "multi" ) {
 			this.updatePills();
-		} else if (selected) {
+		} else if (selected && selected[0]) {
 			this.selectedValue = selected[0].content;
 			this.propagateChangeCallback(selected[0]);
 		}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#900

When selected is an empty array it causes an error of content of undefined, a check has been added to be sure it has the used element of the array

#### Changelog

**Changed**

* updated expression to be sure first place of array is defined
