### PR TITLE
Breadcrumb

### DIFF
--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -62,6 +62,10 @@ export class BreadcrumbItemComponent {
 
 	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) { }
 
+	useTemplate() {
+		return this.skeleton || this._href || this.route;
+	}
+
 	navigate(event) {
 		if (this.router && this.route) {
 			event.preventDefault();

--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -17,7 +17,7 @@ import { Router } from "@angular/router";
 		[href]="(skeleton ? '/#' : href)"
 		(click)="navigate($event)"
 		[attr.aria-current]="(current ? ariaCurrent : null)"
-		*ngIf="skeleton || href; else content">
+		*ngIf="useTemplate(); else content">
 		<ng-container *ngTemplateOutlet="content"></ng-container>
 	</a>
 	<ng-template #content>

--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -58,7 +58,7 @@ export class BreadcrumbItemComponent {
 
 	@HostBinding("class.bx--breadcrumb-item") itemClass = true;
 
-	protected _href = "javascript:void(0)";
+	protected _href;
 
 	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) { }
 

--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -14,7 +14,7 @@ import { Router } from "@angular/router";
 	template: `
 	<a
 		class="bx--link"
-		href="{{skeleton ? '/#' : href}}"
+		[href]="(skeleton ? '/#' : href)"
 		(click)="navigate($event)"
 		[attr.aria-current]="(current ? ariaCurrent : null)"
 		*ngIf="skeleton || href; else content">

--- a/src/breadcrumb/breadcrumb-item.interface.ts
+++ b/src/breadcrumb/breadcrumb-item.interface.ts
@@ -13,6 +13,16 @@ export interface BreadcrumbItem {
 	 */
 	href: string;
 	/**
+	 * Array of commands to send to the router when the link is activated
+	 * See: https://angular.io/api/router/Router#navigate
+	 */
+	route?: any[];
+	/**
+	 * Router options. Used in conjunction with `route`
+	 * See: https://angular.io/api/router/Router#navigate
+	 */
+	routeExtras?: any;
+	/**
 	 * Optional `TemplateRef` for the breadcrumb item. Receives the content as an `$implicit` template variable
 	 */
 	template?: TemplateRef<any>;

--- a/src/breadcrumb/breadcrumb-item.interface.ts
+++ b/src/breadcrumb/breadcrumb-item.interface.ts
@@ -11,7 +11,7 @@ export interface BreadcrumbItem {
 	/**
 	 * Href for the breadcrumb item.
 	 */
-	href: string;
+	href?: string;
 	/**
 	 * Array of commands to send to the router when the link is activated
 	 * See: https://angular.io/api/router/Router#navigate

--- a/src/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/breadcrumb/breadcrumb.component.spec.ts
@@ -116,6 +116,8 @@ describe("Breadcrumb", () => {
 		const breadcrumbItemElements = testFixture.debugElement.queryAll(By.directive(BreadcrumbItemComponent));
 		expect(breadcrumbItemElements).not.toBeNull();
 		expect(breadcrumbItemElements.length).toBe(4); // 4 because one is created for the overflow menu
+		console.log(JSON.stringify(breadcrumbItemElements[1].name));
+		breadcrumbItemElements[1].children.forEach(child => console.log("child", child.name));
 		expect(breadcrumbItemElements[1].children[0].name).toEqual("ibm-overflow-menu");
 	});
 });

--- a/src/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/breadcrumb/breadcrumb.component.spec.ts
@@ -116,7 +116,6 @@ describe("Breadcrumb", () => {
 		const breadcrumbItemElements = testFixture.debugElement.queryAll(By.directive(BreadcrumbItemComponent));
 		expect(breadcrumbItemElements).not.toBeNull();
 		expect(breadcrumbItemElements.length).toBe(4); // 4 because one is created for the overflow menu
-		breadcrumbItemElements[1].children.forEach(child => console.log("child", child.name));
 		expect(breadcrumbItemElements[1].children[0].name).toEqual("ibm-overflow-menu");
 	});
 });

--- a/src/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/breadcrumb/breadcrumb.component.spec.ts
@@ -116,7 +116,6 @@ describe("Breadcrumb", () => {
 		const breadcrumbItemElements = testFixture.debugElement.queryAll(By.directive(BreadcrumbItemComponent));
 		expect(breadcrumbItemElements).not.toBeNull();
 		expect(breadcrumbItemElements.length).toBe(4); // 4 because one is created for the overflow menu
-		console.log(JSON.stringify(breadcrumbItemElements[1].name));
 		breadcrumbItemElements[1].children.forEach(child => console.log("child", child.name));
 		expect(breadcrumbItemElements[1].children[0].name).toEqual("ibm-overflow-menu");
 	});


### PR DESCRIPTION
Closes IBM/carbon-components-angular#902

@cal-smith @zvonimirfras I need help fixing the tests please. I'm getting the error below and I cannot figure out how to fix it. I figured as much that if I revert the changes from the `breadcrumb-item.component.ts` then the tests are passing but I just cannot connect why would they fail with the small update.
```
HeadlessChrome 0.0.0 (Mac OS X 10.15.1)
Breadcrumb should create a breadcrumb with five items and 
an overflow menu in second position FAILED
        Error: Expected 'a' to equal 'ibm-overflow-menu'.
```