### PR TITLE
feat: disable APF

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,8 @@ set -e # exit with nonzero exit code if anything fails
 rm -rf dist
 
 # run the angular/ng-packagr build
-ng build
+# TODO enable with v4
+# ng build
 
 # run the classic buld - TODO remove with v4/Carbon v11
 gulp build


### PR DESCRIPTION
APF was causing issues with many existing consumers. Since v4 is right around the corner, we can roll back this change and swap everything over at once to avoid further intermediate breakages.