### PR TITLE
fix(table): check length of tableModel.data before select/deselect all

### DIFF
--- a/src/table/table-model.class.ts
+++ b/src/table/table-model.class.ts
@@ -522,8 +522,10 @@ export class TableModel implements PaginationModel {
 	 * @param value state to set all rows to. Defaults to `true`
 	 */
 	selectAll(value = true) {
-		for (let i = 0; i < this.rowsSelected.length; i++) {
-			this.selectRow(i, value);
+		if (this.data.length > 1) {
+			for (let i = 0; i < this.rowsSelected.length; i++) {
+				this.selectRow(i, value);
+			}
 		}
 	}
 

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -628,17 +628,13 @@ export class Table implements AfterViewInit, OnDestroy {
 	}
 
 	onSelectAll() {
-		if (this.model.data.length > 1) {
-			this.model.selectAll(true);
-			this.selectAll.emit(this.model);
-		}
+		this.model.selectAll(true);
+		this.selectAll.emit(this.model);
 	}
 
 	onDeselectAll() {
-		if (this.model.data.length > 1) {
-			this.model.selectAll(false);
-			this.deselectAll.emit(this.model);
-		}
+		this.model.selectAll(false);
+		this.deselectAll.emit(this.model);
 	}
 
 	onSelectRow(event) {

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -628,13 +628,17 @@ export class Table implements AfterViewInit, OnDestroy {
 	}
 
 	onSelectAll() {
-		this.model.selectAll(true);
-		this.selectAll.emit(this.model);
+		if (this.model.data.length > 1) {
+			this.model.selectAll(true);
+			this.selectAll.emit(this.model);
+		}
 	}
 
 	onDeselectAll() {
-		this.model.selectAll(false);
-		this.deselectAll.emit(this.model);
+		if (this.model.data.length > 1) {
+			this.model.selectAll(false);
+			this.deselectAll.emit(this.model);
+		}
 	}
 
 	onSelectRow(event) {


### PR DESCRIPTION
When the table model contains no data and onSelectAll is called, it gives the following console error:

```
ERROR TypeError: Cannot read property 'length' of undefined
    at TableModel.push../src/table/table-model.class.ts.TableModel.selectAll (VM37 main.5f83aacd3a20d62a5fc8.bundle.js:21725)
    at Table.push../src/table/table.component.ts.Table.onSelectAll (VM37 main.5f83aacd3a20d62a5fc8.bundle.js:22320)
    at Object.eval [as handleEvent] (VM104 Table.ngfactory.js:107)
    at handleEvent (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:47008)
    at callWithDebugContext (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:48101)
    at Object.debugHandleEvent [as handleEvent] (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:47804)
    at dispatchEvent (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:44467)
    at VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:45947
    at SafeSubscriber.schedulerFn [as _next] (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:40317)
    at SafeSubscriber.push../node_modules/rxjs/_esm5/internal/Subscriber.js.SafeSubscriber.__tryOrUnsub (VM36 vendors~main.5f83aacd3a20d62a5fc8.bundle.js:137132)

```

it now behaves as expected.
