### PR TITLE
fix(combobox): add validation to avoid error when empty selected array

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -414,7 +414,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 			const matches = this.view.getListItems().some(item => item.content.toLowerCase().includes(searchString.toLowerCase()));
 			if (!matches) {
 				const selected = this.view.getSelected();
-				if (selected) {
+				if (selected && selected[0]) {
 					selected[0].selected = false;
 					// notify that the selection has changed
 					this.view.select.emit({ item: selected[0] });


### PR DESCRIPTION
Added missing validation to avoid error when empty selected array in onSearch.

#### Changelog

**New**

* Another validation to avoid error