### PR TITLE
fix(date picker): access flatpickrInstance only within DatePicker class

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -48,7 +48,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onValueChange($event)"
-						(click)="openFlatpickr()">
+						(click)="openFlatpickrInstance()">
 					</ibm-date-picker-input>
 				</div>
 
@@ -65,7 +65,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onRangeValueChange($event)"
-						(click)="openFlatpickr()">
+						(click)="openFlatpickrInstance()">
 					</ibm-date-picker-input>
 				</div>
 			</div>
@@ -270,9 +270,9 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		}
 	}
 
-	// Needs to be opened like this when calendar is clicked to avoid the error:
+	// FlatpickrInstance needs to be opened like this when calendar Icon is clicked to avoid the error:
 	// Property 'flatpickrInstance' is protected and only accessible within class 'DatePicker' and its subclasses.
-	openFlatpickr() {
+	openFlatpickrInstance() {
 		this.flatpickrInstance.open();
 	}
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -48,7 +48,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onValueChange($event)"
-						(click)="flatpickrInstance.open()">
+						(click)="openFlatpickr()">
 					</ibm-date-picker-input>
 				</div>
 
@@ -65,7 +65,7 @@ import { carbonFlatpickrMonthSelectPlugin } from "./carbon-flatpickr-month-selec
 						[invalidText]="invalidText"
 						[skeleton]="skeleton"
 						(valueChange)="onRangeValueChange($event)"
-						(click)="flatpickrInstance.open()">
+						(click)="openFlatpickr()">
 					</ibm-date-picker-input>
 				</div>
 			</div>
@@ -266,6 +266,12 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 			this.setDateValues([this.flatpickrInstance.selectedDates[0], date]);
 			this.doSelect(this.flatpickrInstance.selectedDates);
 		}
+	}
+
+	// Needs to be opened like this when calendar is clicked to avoid the error:
+	// Property 'flatpickrInstance' is protected and only accessible within class 'DatePicker' and its subclasses.
+	openFlatpickr() {
+		this.flatpickrInstance.open();
 	}
 
 	/**


### PR DESCRIPTION
The following error shows up when building: 
```
dist/src/datepicker/datepicker.component.ts.DatePicker.html(25,7): : Property 'flatpickrInstance' is protected and only accessible within class 'DatePicker' and its subclasses.
```
It now builds without the error.