### PR TITLE
fix(date picker): display correct date on calendar when focused or updated

### DIFF
--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -4,7 +4,8 @@ import {
 	Output,
 	EventEmitter,
 	ElementRef,
-	TemplateRef
+	TemplateRef,
+	ViewChild
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -26,6 +27,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				</label>
 				<div class="bx--date-picker-input__wrapper">
 					<input
+						#input
 						*ngIf="!skeleton"
 						autocomplete="off"
 						type="text"
@@ -45,7 +47,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				</div>
 			</div>
 		</div>
-	</div>
+</div>
 	`,
 	providers: [
 		{
@@ -57,7 +59,6 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 })
 export class DatePickerInput {
 	private static datePickerCount = 0;
-
 	/**
 	 * Select a calendar type for the `model`.
 	 * Internal purposes only.
@@ -87,6 +88,8 @@ export class DatePickerInput {
 	@Input() skeleton = false;
 
 	@Input() value = "";
+
+	@ViewChild("input") input: ElementRef;
 
 	constructor(protected elementRef: ElementRef) {}
 

--- a/src/datepicker/carbon-flatpickr-month-select.ts
+++ b/src/datepicker/carbon-flatpickr-month-select.ts
@@ -93,6 +93,7 @@ export const carbonFlatpickrMonthSelectPlugin = fp => {
 
 	return {
 		onMonthChange: updateCurrentMonth,
+		onValueUpdate: updateCurrentMonth,
 		onOpen: updateCurrentMonth,
 		onReady: [setupElements, updateCurrentMonth, register]
 	};

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -227,7 +227,6 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 			if (this.rangeInput.input.nativeElement === document.activeElement && this.flatpickrInstance.selectedDates[1]) {
 				const currentMonth = this.flatpickrInstance.selectedDates[1].getMonth();
 				this.flatpickrInstance.changeMonth(currentMonth, false);
-
 			} else if (this.input.input.nativeElement === document.activeElement && this.flatpickrInstance.selectedDates[0]) {
 				const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
 				this.flatpickrInstance.changeMonth(currentMonth, false);

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -218,20 +218,15 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 
 	@HostListener("focusin")
 	onFocus() {
-		// Updates the months and years manually when calendar mode is range because months
-		// and years are not updated properly without manually updating them on focus.
+		// Updates the month manually when calendar mode is range because month
+		// will not update properly without manually updating them on focus.
 		if (this.range) {
 			if (this.rangeInput.input.nativeElement === document.activeElement && this.flatpickrInstance.selectedDates[1]) {
 				const currentMonth = this.flatpickrInstance.selectedDates[1].getMonth();
-
-				this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[1].getFullYear();
-
 				this.flatpickrInstance.changeMonth(currentMonth, false);
+
 			} else if (this.input.input.nativeElement === document.activeElement && this.flatpickrInstance.selectedDates[0]) {
 				const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
-
-				this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
-
 				this.flatpickrInstance.changeMonth(currentMonth, false);
 			}
 		}

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -303,7 +303,6 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 		// the month and year needs to be manually changed to the current selected month and
 		// year otherwise the calendar view will not be updated upon opening.
 		if (datepickerInput === this.input && this.range && this.flatpickrInstance.selectedDates[0]) {
-
 			const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
 
 			this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();


### PR DESCRIPTION
When date picker is in range mode:

* Opening the calendar using the calendar icon will display the date which was last opened. For example, if the first input was clicked first, then clicking the second input will display the first input's date on the calendar.

* Switching focus between the inputs with tab will always display the second input's month. If at any point the second input has received focus.

* Manually changing the input and then clicking enter did not display the correct month on the calendar.

It all behaves as expected now.

#### Changelog

**New**

* Manually update the month when input receives focus.

* Call updateCurrentMonth in the onMonthChange event hook in the month select plugin.

**Changed**

* When opening the calendar using the calendar icon, manually change the current month and year to make sure the calendar displays the correct date.
