### PR TITLE
fix(modal-header): Close button was triggering submit on form

### DIFF
--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -24,6 +24,7 @@ import { ExperimentalService } from "./../experimental.service";
 		<header class="{{theme}} bx--modal-header">
 			<ng-content></ng-content>
 			<button
+				type="button"
 				class="bx--modal-close"
 				[attr.aria-label]="closeLabel"
 				(click)="onClose()">


### PR DESCRIPTION
In case that the modal contain a form the button on ibm-modal-header triggers the submit event due to missing `type="button"`on the button tag.

#### Changelog

**Changed**

* Added `type="button"` to close button on modal header
