### PR TITLE
feat(number-input): accessibility and i18n support. Closes #968

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -87,6 +87,11 @@ export default {
 	"MODAL": {
 		"CLOSE": "Close modal"
 	},
+	"NUMBER_INPUT": {
+		"ICON_DESCRIPTION": "Choose a number",
+		"INCREMENT_BUTTON": "Increment number",
+		"DECREMENT_BUTTON": "Decrement number"
+	},
 	"NOTIFICATION": {
 		"CLOSE_BUTTON": "Close alert notification"
 	},

--- a/src/number-input/number.component.spec.ts
+++ b/src/number-input/number.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
+import { I18nModule, I18n } from "./../i18n/i18n.module";
 import { Number } from "./number.component";
 import { FormsModule } from "@angular/forms";
 import { CaretUp16Module } from "@carbon/icons-angular/lib/caret--up/16";
@@ -16,6 +17,7 @@ describe("Number", () => {
 	let buttonDown: HTMLButtonElement;
 	let labelElement: HTMLDivElement;
 	let helperTextElement: HTMLDivElement;
+	let i18n: I18n;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
@@ -24,9 +26,12 @@ describe("Number", () => {
 				FormsModule,
 				CaretUp16Module,
 				CaretDown16Module,
+				I18nModule,
 				WarningFilled16Module
 			],
-			providers: []
+			providers: [
+				I18n
+			]
 		});
 	});
 
@@ -35,6 +40,7 @@ describe("Number", () => {
 		component = fixture.componentInstance;
 		inputElement = fixture.debugElement.query(By.css("input")).nativeElement;
 		containerElement = fixture.debugElement.query(By.css(".bx--number")).nativeElement;
+		i18n = TestBed.get(I18n);
 	});
 
 	it("should work", () => {
@@ -149,4 +155,63 @@ describe("Number", () => {
 		fixture.detectChanges();
 		expect(containerElement.className.includes("bx--number--light")).toEqual(true);
 	});
+
+	it("should bind increment label to button title", () => {
+		const expectedTitle = "Increment that number";
+		fixture.detectChanges();
+		buttonUp = fixture.debugElement.query(By.css(".up-icon")).nativeElement;
+		expect(buttonUp.title).toEqual(i18n.get("NUMBER_INPUT.INCREMENT_BUTTON").value);
+		component.incrementLabel = expectedTitle;
+		fixture.detectChanges();
+		expect(buttonUp.title).toEqual(expectedTitle);
+	});
+
+	it("should bind increment label to aria-label", () => {
+		const expectedTitle = "Increment that number";
+		fixture.detectChanges();
+		buttonUp = fixture.debugElement.query(By.css(".up-icon")).nativeElement;
+		expect(buttonUp.getAttribute("aria-label")).toEqual(i18n.get("NUMBER_INPUT.INCREMENT_BUTTON").value);
+		component.incrementLabel = expectedTitle;
+		fixture.detectChanges();
+		expect(buttonUp.getAttribute("aria-label")).toEqual(expectedTitle);
+	});
+
+	it("should default increment label aria-label to iconDescription", () => {
+		const expectedAriaLabel = i18n.get("NUMBER_INPUT.ICON_DESCRIPTION").value;
+		fixture.componentInstance.incrementLabel = null;
+		fixture.detectChanges();
+		buttonUp = fixture.debugElement.query(By.css(".up-icon")).nativeElement;
+		expect(buttonUp.getAttribute("aria-label")).not.toEqual(i18n.get("NUMBER_INPUT.INCREMENT_BUTTON").value);
+		expect(buttonUp.getAttribute("aria-label")).not.toEqual(expectedAriaLabel);
+	});
+
+	it("should bind decrement label to title", () => {
+		const expectedTitle = "Decrement that number";
+		fixture.detectChanges();
+		buttonDown = fixture.debugElement.query(By.css(".down-icon")).nativeElement;
+		expect(buttonDown.title).toEqual(i18n.get("NUMBER_INPUT.DECREMENT_BUTTON").value);
+		component.decrementLabel = expectedTitle;
+		fixture.detectChanges();
+		expect(buttonDown.title).toEqual(expectedTitle);
+	});
+
+	it("should bind decrement label to aria-label", () => {
+		const expectedAriaLabel = "Decrement that number";
+		fixture.detectChanges();
+		buttonDown = fixture.debugElement.query(By.css(".down-icon")).nativeElement;
+		expect(buttonDown.getAttribute("aria-label")).toEqual(i18n.get("NUMBER_INPUT.DECREMENT_BUTTON").value);
+		component.decrementLabel = expectedAriaLabel;
+		fixture.detectChanges();
+		expect(buttonDown.getAttribute("aria-label")).toEqual(expectedAriaLabel);
+	});
+
+	it("should default decrement label aria-label to iconDescription", () => {
+		const expectedAriaLabel = i18n.get("NUMBER_INPUT.ICON_DESCRIPTION");
+		fixture.componentInstance.decrementLabel = null;
+		fixture.detectChanges();
+		buttonDown = fixture.debugElement.query(By.css(".down-icon")).nativeElement;
+		expect(buttonDown.getAttribute("aria-label")).not.toEqual(i18n.get("NUMBER_INPUT.DECREMENT_BUTTON").value);
+		expect(buttonDown.getAttribute("aria-label")).not.toEqual(expectedAriaLabel);
+	});
+
 });

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -8,6 +8,9 @@ import {
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 
+import { I18n } from "../i18n/i18n.module";
+import { Observable } from "rxjs";
+
 /**
  * Used to emit changes performed on number input components.
  */
@@ -68,6 +71,8 @@ export class NumberChange {
 					<button
 						class="bx--number__control-btn up-icon"
 						type="button"
+						[title]="getIncrementLabel() | async"
+						[attr.aria-label]="(getIncrementLabel() || getIconDescription()) | async"
 						aria-live="polite"
 						aria-atomic="true"
 						(click)="onIncrement()">
@@ -76,6 +81,8 @@ export class NumberChange {
 					<button
 						class="bx--number__control-btn down-icon"
 						type="button"
+						[title]="getDecrementLabel() | async"
+						[attr.aria-label]="(getDecrementLabel() || getIconDescription()) | async"
 						aria-live="polite"
 						aria-atomic="true"
 						(click)="onDecrement()">
@@ -110,6 +117,16 @@ export class NumberComponent implements ControlValueAccessor {
 	 */
 	@Input() theme: "light" | "dark" = "dark";
 	/**
+	 * Set Number input decrement arrow icon label
+	 */
+	@Input()
+	set decrementLabel(value: string | Observable<string>) {
+		this._decrementLabel.override(value);
+	}
+	get decrementLabel() {
+		return this._decrementLabel.value;
+	}
+	/**
 	 * Set to `true` for a disabled number input.
 	 */
 	@Input() disabled = false;
@@ -117,6 +134,26 @@ export class NumberComponent implements ControlValueAccessor {
 	 * Set to `true` for a loading number component.
 	 */
 	@Input() skeleton = false;
+	/**
+	 * Provide a description for up/down icons that can be read by screen readers
+	 */
+	@Input()
+	set iconDescription(value: string | Observable<string>) {
+		this._iconDescription.override(value);
+	}
+	get iconDescription() {
+		return this._iconDescription.value;
+	}
+	/**
+	 * Set Number input increment arrow icon label
+	 */
+	@Input()
+	set incrementLabel(value: string | Observable<string>) {
+		this._incrementLabel.override(value);
+	}
+	get incrementLabel() {
+		return this._incrementLabel.value;
+	}
 	/**
 	 * Set to `true` for an invalid number component.
 	 */
@@ -164,12 +201,18 @@ export class NumberComponent implements ControlValueAccessor {
 	 */
 	@Output() change = new EventEmitter<NumberChange>();
 
+	protected _decrementLabel = this.i18n.getOverridable("NUMBER_INPUT.DECREMENT_BUTTON");
+
+	protected _iconDescription = this.i18n.getOverridable("NUMBER_INPUT.ICON_DESCRIPTION");
+
+	protected _incrementLabel = this.i18n.getOverridable("NUMBER_INPUT.INCREMENT_BUTTON");
+
 	protected _value = 0;
 
 	/**
 	 * Creates an instance of `Number`.
 	 */
-	constructor() {
+	constructor(protected i18n: I18n) {
 		NumberComponent.numberCount++;
 	}
 
@@ -194,6 +237,18 @@ export class NumberComponent implements ControlValueAccessor {
 	 */
 	public registerOnTouched(fn: any) {
 		this.onTouched = fn;
+	}
+
+	getDecrementLabel(): Observable<string> {
+		return this._decrementLabel.subject;
+	}
+
+	getIconDescription(): Observable<string> {
+		return this._iconDescription.subject;
+	}
+
+	getIncrementLabel(): Observable<string> {
+		return this._incrementLabel.subject;
 	}
 
 	/**

--- a/src/number-input/number.stories.ts
+++ b/src/number-input/number.stories.ts
@@ -2,10 +2,11 @@ import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { withKnobs, boolean, number, select, text } from "@storybook/addon-knobs/angular";
 
 import { NumberModule, DocumentationModule } from "../";
+import { I18nModule } from "../i18n/i18n.module";
 
 storiesOf("Components|Number", module).addDecorator(
 	moduleMetadata({
-		imports: [NumberModule, DocumentationModule]
+		imports: [NumberModule, DocumentationModule, I18nModule]
 	})
 )
 	.addDecorator(withKnobs)
@@ -14,6 +15,9 @@ storiesOf("Components|Number", module).addDecorator(
 			<ibm-number
 				[label]="label"
 				[helperText]="[helperText]"
+				[iconDescription]="iconDescription"
+				[incrementLabel]="incrementLabel"
+				[decrementLabel]="decrementLabel"
 				[theme]="theme"
 				[min]="min"
 				[max]="max"
@@ -25,6 +29,9 @@ storiesOf("Components|Number", module).addDecorator(
 		props: {
 			label: text("label", "Number Input Label"),
 			helperText: text("helper text", "Optional helper text."),
+			iconDescription: text("icon description", "Choose a number"),
+			decrementLabel: text("decrement label", "Decrement number"),
+			incrementLabel: text("increment label", "Increment number"),
 			invalidText: text("Form validation content", "Invalid number"),
 			theme: select("theme", ["dark", "light"], "dark"),
 			min: number("min", 0),
@@ -38,6 +45,9 @@ storiesOf("Components|Number", module).addDecorator(
 			<ibm-number
 				[label]="label"
 				[helperText]="[helperText]"
+				[iconDescription]="iconDescription"
+				[incrementLabel]="incrementLabel"
+				[decrementLabel]="decrementLabel"
 				[theme]="theme"
 				[min]="min"
 				[max]="max"
@@ -52,6 +62,9 @@ storiesOf("Components|Number", module).addDecorator(
 			value: 0,
 			label: text("label", "Number Input Label"),
 			helperText: text("helper text", "Optional helper text."),
+			iconDescription: text("icon description", "Choose a number"),
+			decrementLabel: text("decrement label", "Decrement number"),
+			incrementLabel: text("increment label", "Increment number"),
 			invalidText: text("Form validation content", "Invalid number"),
 			theme: select("theme", ["dark", "light"], "dark"),
 			min: number("min", 0),


### PR DESCRIPTION
Changes are based on the implementation found in the React Carbon
version:
https://git.io/JeNuN
http://react.carbondesignsystem.com/?path=/story/numberinput--default
- title for up/down button
- arial-label for up/down button
- default localized values for up/down title and aria-label
- tests updated
- Storybook changed

Thanks!

Closes IBM/carbon-components-angular#968

{{short description}}

#### Changelog

**New**

* `title` property binding for up/down icons
* 'aria-label` attribute bindings for up/down icons