### PR TITLE
fix(table head checkbox): Bypass security for hostStyle

### DIFF
--- a/src/table/head/table-head-checkbox.component.ts
+++ b/src/table/head/table-head-checkbox.component.ts
@@ -5,10 +5,8 @@ import {
 	HostBinding,
 	EventEmitter
 } from "@angular/core";
-import { I18n, Overridable } from "./../../i18n/i18n.module";
+import { I18n } from "./../../i18n/i18n.module";
 import { Observable } from "rxjs";
-
-import { DomSanitizer } from '@angular/platform-browser';
 
 @Component({
 	// tslint:disable-next-line: component-selector
@@ -23,7 +21,11 @@ import { DomSanitizer } from '@angular/platform-browser';
 			(change)="change.emit()"
 			[aria-label]="getAriaLabel() | async">
 		</ibm-checkbox>
-	`
+	`,
+    styles: [`
+        :host { width: 10px; }
+    `
+	]
 })
 export class TableHeadCheckbox {
 	/**
@@ -50,11 +52,9 @@ export class TableHeadCheckbox {
 
 	@HostBinding("class.bx--table-column-checkbox") hostClass = true;
 
-	@HostBinding("attr.style") hostStyle = this.sanitizer.bypassSecurityTrustStyle(`width: 10px`);
-
 	protected _ariaLabel = this.i18n.getOverridable("TABLE.CHECKBOX_HEADER");
 
-	constructor(protected i18n: I18n, private sanitizer: DomSanitizer) { }
+	constructor(protected i18n: I18n) { }
 
 	getAriaLabel(): Observable<string> {
 		return this._ariaLabel.subject;

--- a/src/table/head/table-head-checkbox.component.ts
+++ b/src/table/head/table-head-checkbox.component.ts
@@ -8,6 +8,8 @@ import {
 import { I18n, Overridable } from "./../../i18n/i18n.module";
 import { Observable } from "rxjs";
 
+import { DomSanitizer } from '@angular/platform-browser';
+
 @Component({
 	// tslint:disable-next-line: component-selector
 	selector: "[ibmTableHeadCheckbox]",
@@ -48,11 +50,11 @@ export class TableHeadCheckbox {
 
 	@HostBinding("class.bx--table-column-checkbox") hostClass = true;
 
-	@HostBinding("attr.style") hostStyle = "width: 10px;";
+	@HostBinding("attr.style") hostStyle = this.sanitizer.bypassSecurityTrustStyle(`width: 10px`);
 
 	protected _ariaLabel = this.i18n.getOverridable("TABLE.CHECKBOX_HEADER");
 
-	constructor(protected i18n: I18n) { }
+	constructor(protected i18n: I18n, private sanitizer: DomSanitizer) { }
 
 	getAriaLabel(): Observable<string> {
 		return this._ariaLabel.subject;


### PR DESCRIPTION
- Prevents warning `'WARNING: sanitizing unsafe style value width: 10px; (see http://g.co/ng/security#xss).'` by bypassing security and trust the initial given style for hostStyle to be safe style value.