### PR TITLE
fix(Modal): Fix incorrect filtering logic on close

### DIFF
--- a/src/modal/modal.service.ts
+++ b/src/modal/modal.service.ts
@@ -53,7 +53,7 @@ export class ModalService {
 		component.instance.close.subscribe(_ => {
 			this.placeholderService.destroyComponent(component);
 			// filter out our component
-			ModalService.modalList = ModalService.modalList.filter(c => c === component);
+			ModalService.modalList = ModalService.modalList.filter(c => c !== component);
 		});
 
 		component.onDestroy(() => {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

When a modal is closed, the filtering logic should remove that component from `modalList` using `!==`.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
