### PR TITLE
fix(date picker): Open picker popup when calendar icon is clicked

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -307,17 +307,22 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 	 * Handles opening the calendar "properly" when the calendar icon is clicked.
 	 */
 	openCalendar(datepickerInput: DatePickerInput) {
-		datepickerInput.input.nativeElement.click();
+		if (this.range) {
+			datepickerInput.input.nativeElement.click();
 
-		// If the first input's calendar icon is clicked when calendar is in range mode, then
-		// the month and year needs to be manually changed to the current selected month and
-		// year otherwise the calendar view will not be updated upon opening.
-		if (datepickerInput === this.input && this.range && this.flatpickrInstance.selectedDates[0]) {
-			const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
+			// If the first input's calendar icon is clicked when calendar is in range mode, then
+			// the month and year needs to be manually changed to the current selected month and
+			// year otherwise the calendar view will not be updated upon opening.
+			if (datepickerInput === this.input && this.flatpickrInstance.selectedDates[0]) {
+				const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
 
-			this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
-
-			this.flatpickrInstance.changeMonth(currentMonth, false);
+				this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
+				this.flatpickrInstance.changeMonth(currentMonth, false);
+			}
+		} else {
+			// Single-mode flatpickr handles mousedown but not click, so nativeElement.click() won't
+			// work when the calendar icon is clicked. In this case we simply use flatpickr.open().
+			this.flatpickrInstance.open();
 		}
 	}
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -307,16 +307,22 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 	 * Handles opening the calendar "properly" when the calendar icon is clicked.
 	 */
 	openCalendar(datepickerInput: DatePickerInput) {
-		this.flatpickrInstance.open();
+		if (this.range) {
+			datepickerInput.input.nativeElement.click();
 
-		// If the first input's calendar icon is clicked when calendar is in range mode, then
-		// the month and year needs to be manually changed to the current selected month and
-		// year otherwise the calendar view will not be updated upon opening.
-		if (datepickerInput === this.input && this.range && this.flatpickrInstance.selectedDates[0]) {
-			const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
+			// If the first input's calendar icon is clicked when calendar is in range mode, then
+			// the month and year needs to be manually changed to the current selected month and
+			// year otherwise the calendar view will not be updated upon opening.
+			if (datepickerInput === this.input && this.flatpickrInstance.selectedDates[0]) {
+				const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
 
-			this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
-			this.flatpickrInstance.changeMonth(currentMonth, false);
+				this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
+				this.flatpickrInstance.changeMonth(currentMonth, false);
+			}
+		} else {
+			// Single-mode flatpickr handles mousedown but not click, so nativeElement.click() won't
+			// work when the calendar icon is clicked. In this case we simply use flatpickr.open().
+			this.flatpickrInstance.open();
 		}
 	}
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -307,22 +307,16 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked {
 	 * Handles opening the calendar "properly" when the calendar icon is clicked.
 	 */
 	openCalendar(datepickerInput: DatePickerInput) {
-		if (this.range) {
-			datepickerInput.input.nativeElement.click();
+		this.flatpickrInstance.open();
 
-			// If the first input's calendar icon is clicked when calendar is in range mode, then
-			// the month and year needs to be manually changed to the current selected month and
-			// year otherwise the calendar view will not be updated upon opening.
-			if (datepickerInput === this.input && this.flatpickrInstance.selectedDates[0]) {
-				const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
+		// If the first input's calendar icon is clicked when calendar is in range mode, then
+		// the month and year needs to be manually changed to the current selected month and
+		// year otherwise the calendar view will not be updated upon opening.
+		if (datepickerInput === this.input && this.range && this.flatpickrInstance.selectedDates[0]) {
+			const currentMonth = this.flatpickrInstance.selectedDates[0].getMonth();
 
-				this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
-				this.flatpickrInstance.changeMonth(currentMonth, false);
-			}
-		} else {
-			// Single-mode flatpickr handles mousedown but not click, so nativeElement.click() won't
-			// work when the calendar icon is clicked. In this case we simply use flatpickr.open().
-			this.flatpickrInstance.open();
+			this.flatpickrInstance.currentYear = this.flatpickrInstance.selectedDates[0].getFullYear();
+			this.flatpickrInstance.changeMonth(currentMonth, false);
 		}
 	}
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Open picker popup when calendar icon is clicked in a single-mode date picker. This fixes a recent regression caused by previous PR https://github.com/IBM/carbon-components-angular/pull/939.

![image](https://user-images.githubusercontent.com/34791554/72656676-fe100200-396a-11ea-9f24-001c34b3796d.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
