### PR TITLE
fix(ui-shell): remove close icon on active header action

### DIFF
--- a/src/ui-shell/header/header-action.component.ts
+++ b/src/ui-shell/header/header-action.component.ts
@@ -19,8 +19,7 @@ import {
 			[attr.aria-label]="title"
 			[title]="title"
 			(click)="onClick()">
-			<ng-content *ngIf="!active"></ng-content>
-			<svg *ngIf="active" ibmIconClose20></svg>
+			<ng-content></ng-content>
 		</button>
 	`
 })


### PR DESCRIPTION
Conflicts with #981 

To follow the examples in https://www.carbondesignsystem.com/components/UI-shell-header/code, header actions no longer switch to close icon when active by default. It is still possible to achieve this by providing the header action with two icons and event binding to the selected event.