### PR TITLE
feat(input): Typeahead support for Search Component

### DIFF
--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -36,7 +36,7 @@
 		>
 			<li
 				(click)="updateSearchResult(option)"
-				*ngFor="let option of typeAheadResults"
+				*ngFor="let option of _typeAheadResults"
 				class="bx--list-box__menu-item"
 			>
 				<div
@@ -44,7 +44,9 @@
 					tabindex="-1"
 					class="bx--list-box__menu-item__option"
 				>
-					<ng-container *ngIf="!listTpl">{{ option }}</ng-container>
+					<ng-container *ngIf="!listTpl">
+						<span [innerHtml]="option.html"></span>
+					</ng-container>
 					<ng-template 
 						*ngIf="listTpl" 
 						[ngTemplateOutletContext]="{item: option}"

--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -1,6 +1,7 @@
 <div
 	class="bx--search"
 	[ngClass]="{
+		'search-wrapper': typeahead,
 		'bx--search--sm': size === 'sm',
 		'bx--search--xl': size === 'xl',
 		'bx--search--light': theme === 'light',
@@ -26,6 +27,33 @@
 			[disabled]="disabled"
 			[required]="required"
 			(input)="onSearch($event.target.value)"/>
+
+		<ul
+			*ngIf="typeahead"
+			#list
+			role="listbox"
+			class="bx--list-box__menu typeahead-list"
+		>
+			<li
+				(click)="updateSearchResult(option)"
+				*ngFor="let option of typeAheadResults"
+				class="bx--list-box__menu-item"
+			>
+				<div
+					#listItem
+					tabindex="-1"
+					class="bx--list-box__menu-item__option"
+				>
+					<ng-container *ngIf="!listTpl">{{ option }}</ng-container>
+					<ng-template 
+						*ngIf="listTpl" 
+						[ngTemplateOutletContext]="{item: option}"
+						[ngTemplateOutlet]="listTpl"
+					>
+					</ng-template>
+				</div>
+			</li>
+		</ul>
 		<button *ngIf="!tableSearch && toolbar" class="bx--toolbar-search__btn" (click)="openSearch()">
 			<ibm-icon-search16 class="bx--search-magnifier"></ibm-icon-search16>
 		</button>

--- a/src/search/search.component.scss
+++ b/src/search/search.component.scss
@@ -1,19 +1,21 @@
-.search-wrapper{
-    position: relative;
-    display: inline-block;
-    .typeahead-list{
-        position: absolute;
-        top: 100%;
-        left: 0;
-        right: 0;
-        b{
-            font-weight: bold;
-        }
-    }
+.search-wrapper {
+	position: relative;
+	display: inline-block;
 
-    .bx--search-close{
-        position: absolute;
-        top: 0;
-        right: 0;
-    }
+	.typeahead-list {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+
+		b {
+			font-weight: 400;
+		}
+	}
+
+	.bx--search-close {
+		position: absolute;
+		top: 0;
+		right: 0;
+	}
 }

--- a/src/search/search.component.scss
+++ b/src/search/search.component.scss
@@ -6,6 +6,9 @@
         top: 100%;
         left: 0;
         right: 0;
+        b{
+            font-weight: bold;
+        }
     }
 
     .bx--search-close{

--- a/src/search/search.component.scss
+++ b/src/search/search.component.scss
@@ -1,0 +1,16 @@
+.search-wrapper{
+    position: relative;
+    display: inline-block;
+    .typeahead-list{
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+    }
+
+    .bx--search-close{
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
+}

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -6,7 +6,8 @@ import {
 	HostBinding,
 	ElementRef,
 	HostListener,
-	ViewChild
+	ViewChild,
+	TemplateRef
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 import { I18n } from "../i18n/i18n.module";
@@ -34,6 +35,7 @@ export class SearchChange {
 @Component({
 	selector: "ibm-search",
 	templateUrl: "search.component.html",
+	styleUrls: ["search.component.scss"],
 	providers: [
 		{
 			provide: NG_VALUE_ACCESSOR,
@@ -68,6 +70,11 @@ export class Search implements ControlValueAccessor {
 	get size(): "sm" | "lg" | "xl" {
 		return this._size;
 	}
+
+	/**
+	 * Template to bind to items in the `DropdownList` (optional).
+	 */
+	@Input() listTpl: string | TemplateRef<any> = null;
 	/**
 	 * Set to `true` for a disabled search input.
 	 */
@@ -109,6 +116,15 @@ export class Search implements ControlValueAccessor {
 	 * For refernece: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values
 	 */
 	@Input() autocomplete = "on";
+	/**
+	 * boolean to determine if typeahead functionality should be available
+	 */
+	@Input() typeahead: boolean;
+	/**
+	 * Array of items to be passed in from parent component to populate the typehead results list
+	 */
+	@Input() typeAheadResults: Array<any> = [];
+
 	/**
 	 * Sets the text inside the `label` tag.
 	 */
@@ -195,8 +211,20 @@ export class Search implements ControlValueAccessor {
 	 */
 	clearSearch(): void {
 		this.value = "";
+		this.clearTypeaheadResults();
 		this.clear.emit();
 		this.propagateChange(this.value);
+	}
+
+	clearTypeaheadResults() {
+		if (this.typeahead) {
+			this.typeAheadResults = [];
+		}
+	}
+
+	updateSearchResult(option: string) {
+		this.value = option;
+		this.clearTypeaheadResults();
 	}
 
 	doValueChange() {

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -10,6 +10,31 @@ import {
 
 import { SearchModule, DocumentationModule } from "../";
 
+function genTypeAheadList(searchterm: string) {
+	let list = [];
+	if (searchterm) {
+		const lsterm = searchterm.toLowerCase();
+		for (let i = 0; i < ( Math.round(Math.random() * 5) || 3 ); i++) {
+			list.push(`Api result ${(i + 1)} for ${lsterm}`);
+		}
+	}
+	return list;
+}
+
+const tProps = {
+	size: select("size", ["lg", "sm"], "lg"),
+	theme: select("theme", ["dark", "light"], "dark"),
+	typeahead: boolean("typeahead", true),
+	typeAheadResults : array("typeAheadResults", []),
+	valueChange: function(event) {
+		// simulate api result for a backend
+		setTimeout(() => {
+			this.typeAheadResults = genTypeAheadList(event);
+			action("array value change fired!")(event);
+		}, 500);
+	}
+};
+
 storiesOf("Components|Search", module).addDecorator(
 	moduleMetadata({
 		imports: [SearchModule, DocumentationModule]
@@ -39,63 +64,46 @@ storiesOf("Components|Search", module).addDecorator(
 		}
 	}))
 	.add("Typeahead search", () => {
-		const genTypeAheadList = (searchterm: string) => {
-				let list = [];
-				if (searchterm) {
-					for (let i = 0; i < ( Math.round(Math.random() * 5) || 3 ); i++) {
-						list.push(searchterm + " api result " + (i + 1));
-					}
-				}
-				return list;
-			};
-
-
-		let tProps = {
-			size: select("size", ["lg", "sm"], "lg"),
-			theme: select("theme", ["dark", "light"], "dark"),
-			typeahead: boolean("typeahead", true),
-			typeAheadResults : array("typeAheadResults", []),
-			valueChange: function(event) {
-				// simulate api result for a backend
-				setTimeout(() => {
-					this.typeAheadResults = genTypeAheadList(event);
-					action("array value change fired!")(event);
-				}, 500);
-			}
-		};
-
 		return ({
-		template: `
-			<div>
-				<p>Default template</p>
-				<ibm-search
-					[typeahead]="true"
-					[size]="size"
-					[typeAheadResults]="typeAheadResults"
-					[theme]="theme"
-					placeholder="search"
-					(valueChange)="valueChange($event)"
-				>
-				</ibm-search>
-
-				<div style="margin-top: 150px;"><p>With custom template</p></div>
-				<ibm-search
-					[typeahead]="true"
-					[size]="size"
-					[typeAheadResults]="typeAheadResults"
-					[listTpl]="myTemplate"
-					[theme]="theme"
-					placeholder="search"
-					(valueChange)="valueChange($event)"
-				>
-				</ibm-search>
-				<ng-template #myTemplate>
-					Custom template
-				</ng-template>
-			</div>
-		`,
-		props: tProps
-	})})
+			template: `
+				<div>
+					<p>Default template</p>
+					<ibm-search
+						[typeahead]="true"
+						[size]="size"
+						[typeAheadResults]="typeAheadResults"
+						[theme]="theme"
+						placeholder="search"
+						(valueChange)="valueChange($event)"
+					>
+					</ibm-search>
+				</div>
+			`,
+			props: tProps
+		});
+	})
+	.add("Typeahead with template", () => {
+		return ({
+			template: `
+				<div>
+					<ibm-search
+						[typeahead]="true"
+						[size]="size"
+						[typeAheadResults]="typeAheadResults"
+						[listTpl]="myTemplate"
+						[theme]="theme"
+						placeholder="search"
+						(valueChange)="valueChange($event)"
+					>
+					</ibm-search>
+					<ng-template #myTemplate let-item>
+						Custom template {{ item }}
+					</ng-template>
+				</div>
+			`,
+			props: tProps
+		});
+	})
 	.add("Toolbar search", () => ({
 		template: `
 		<div class="bx--toolbar">

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -2,6 +2,7 @@ import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { action } from "@storybook/addon-actions";
 import {
 	withKnobs,
+	array,
 	boolean,
 	select,
 	text
@@ -37,7 +38,32 @@ storiesOf("Components|Search", module).addDecorator(
 			clear: action("clear fired!")
 		}
 	}))
-	.add("Typeahead search", () => ({
+	.add("Typeahead search", () => {
+		const genTypeAheadList = (searchterm: string) => {
+				let list = [];
+				if (searchterm) {
+					for (let i = 0; i < ( Math.round(Math.random() * 5) || 3 ); i++) {
+						list.push(searchterm + " api result " + (i + 1));
+					}
+				}
+				return list;
+			};
+
+
+		let tProps = {
+			size: select("size", ["lg", "sm"], "lg"),
+			theme: select("theme", ["dark", "light"], "dark"),
+			typeahead: boolean("typeahead", true),
+			typeAheadResults : array("typeAheadResults", []),
+			valueChange: function(event) {
+				setTimeout(() => {
+					this.typeAheadResults = genTypeAheadList(event);
+					action("array value change fired!")(event);
+				}, 1000);
+			}
+		};
+
+		return ({
 		template: `
 			<div>
 				<p>Default template</p>
@@ -67,14 +93,8 @@ storiesOf("Components|Search", module).addDecorator(
 				</ng-template>
 			</div>
 		`,
-		props: {
-			size: select("size", ["lg", "sm"], "lg"),
-			theme: select("theme", ["dark", "light"], "dark"),
-			typeahead: boolean("typeahead", true),
-			typeAheadResults : ['item1', 'item2'],
-			valueChange: action("value change fired!")
-		}
-	}))
+		props: tProps
+	})})
 	.add("Toolbar search", () => ({
 		template: `
 		<div class="bx--toolbar">

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -56,10 +56,11 @@ storiesOf("Components|Search", module).addDecorator(
 			typeahead: boolean("typeahead", true),
 			typeAheadResults : array("typeAheadResults", []),
 			valueChange: function(event) {
+				// simulate api result for a backend
 				setTimeout(() => {
 					this.typeAheadResults = genTypeAheadList(event);
 					action("array value change fired!")(event);
-				}, 1000);
+				}, 500);
 			}
 		};
 

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -37,6 +37,44 @@ storiesOf("Components|Search", module).addDecorator(
 			clear: action("clear fired!")
 		}
 	}))
+	.add("Typeahead search", () => ({
+		template: `
+			<div>
+				<p>Default template</p>
+				<ibm-search
+					[typeahead]="true"
+					[size]="size"
+					[typeAheadResults]="typeAheadResults"
+					[theme]="theme"
+					placeholder="search"
+					(valueChange)="valueChange($event)"
+				>
+				</ibm-search>
+
+				<div style="margin-top: 150px;"><p>With custom template</p></div>
+				<ibm-search
+					[typeahead]="true"
+					[size]="size"
+					[typeAheadResults]="typeAheadResults"
+					[listTpl]="myTemplate"
+					[theme]="theme"
+					placeholder="search"
+					(valueChange)="valueChange($event)"
+				>
+				</ibm-search>
+				<ng-template #myTemplate>
+					Custom template
+				</ng-template>
+			</div>
+		`,
+		props: {
+			size: select("size", ["lg", "sm"], "lg"),
+			theme: select("theme", ["dark", "light"], "dark"),
+			typeahead: boolean("typeahead", true),
+			typeAheadResults : ['item1', 'item2'],
+			valueChange: action("value change fired!")
+		}
+	}))
 	.add("Toolbar search", () => ({
 		template: `
 		<div class="bx--toolbar">


### PR DESCRIPTION
Partially addresses: https://github.com/IBM/carbon-components-angular/issues/997

Added a typeahead support for the `<ibm-search>` component.

#### Changelog

**New**

* Boolean Input for `typeahead`
* `TypeAheadResults` array passed in from parent component
* `debounceTime` for specifying a non standard debounce interval for the `valueChange` output event

**Changed**

* Changed the way the `valueChange` event is fired using Observables for unique values only after a default debounce time of 500ms.

**Screenshots**

![pr_1034](https://user-images.githubusercontent.com/38618245/73716856-3753ba80-473e-11ea-98e3-6c914967dd0d.png)
