### PR TITLE
feat(table): add initial model parameter for skeletonModel function

### DIFF
--- a/src/table/cell/table-data.component.ts
+++ b/src/table/cell/table-data.component.ts
@@ -10,8 +10,8 @@ import { TableItem } from "./../table-item.class";
 	template: `
 		<ng-container *ngIf="!item.template">
 			{{item.data}}
-			<span *ngIf="skeleton && !item.data"></span>
 		</ng-container>
+		<span *ngIf="skeleton && !item.data"></span>
 		<ng-template
 			[ngTemplateOutlet]="item.template" [ngTemplateOutletContext]="{data: item.data}">
 		</ng-template>

--- a/src/table/cell/table-data.component.ts
+++ b/src/table/cell/table-data.component.ts
@@ -8,11 +8,12 @@ import { TableItem } from "./../table-item.class";
 	// tslint:disable-next-line: component-selector
 	selector: "[ibmTableData]",
 	template: `
-		<ng-container *ngIf="!skeleton && !item.template">{{item.data}}</ng-container>
+		<ng-container *ngIf="!item.template">
+			{{item.data}}
+			<span *ngIf="skeleton && !item.data"></span>
+		</ng-container>
 		<ng-template
-			*ngIf="!skeleton"
-			[ngTemplateOutlet]="item.template"
-			[ngTemplateOutletContext]="{data: item.data}">
+			[ngTemplateOutlet]="item.template" [ngTemplateOutletContext]="{data: item.data}">
 		</ng-template>
 	`
 })

--- a/src/table/head/table-head-cell.component.ts
+++ b/src/table/head/table-head-cell.component.ts
@@ -17,7 +17,7 @@ import { TableHeaderItem } from "./../table-header-item.class";
 	template: `
 		<button
 			class="bx--table-sort"
-			*ngIf="sortable && !skeleton && this.sort.observers.length > 0 && column.sortable"
+			*ngIf="sortable && this.sort.observers.length > 0 && column.sortable"
 			[attr.aria-label]="(column.sorted && column.ascending ? getSortDescendingLabel() : getSortAscendingLabel()) | async"
 			aria-live="polite"
 			[ngClass]="{
@@ -26,13 +26,17 @@ import { TableHeaderItem } from "./../table-header-item.class";
 			}"
 			(click)="onClick()">
 			<span
-				*ngIf="!column.template"
+				*ngIf="!column.template && !skeleton"
 				[title]="column.data"
 				tabindex="-1">
-				<div *ngIf="!skeleton">
+				<div>
 					{{column.data}}
 				</div>
 			</span>
+			<div *ngIf="skeleton && column.data">
+				{{column.data}}
+			</div>
+			<span *ngIf="skeleton && !column.data"></span>
 			<ng-template
 				*ngIf="!skeleton"
 				[ngTemplateOutlet]="column.template"

--- a/src/table/head/table-head-cell.component.ts
+++ b/src/table/head/table-head-cell.component.ts
@@ -25,18 +25,13 @@ import { TableHeaderItem } from "./../table-header-item.class";
 				'bx--table-sort--ascending': column.ascending
 			}"
 			(click)="onClick()">
-			<span
-				*ngIf="!column.template && !skeleton"
+			<div
+				*ngIf="!column.template && column.data"
 				[title]="column.data"
 				tabindex="-1">
-				<div>
-					{{column.data}}
-				</div>
-			</span>
-			<div *ngIf="skeleton && column.data">
 				{{column.data}}
 			</div>
-			<span *ngIf="skeleton && !column.data"></span>
+			<span *ngIf="!column.template && skeleton && !column.data"></span>
 			<ng-template
 				*ngIf="!skeleton"
 				[ngTemplateOutlet]="column.template"

--- a/src/table/stories/app-custom-table.component.ts
+++ b/src/table/stories/app-custom-table.component.ts
@@ -46,7 +46,6 @@ export class CustomHeaderItem extends TableHeaderItem {
 			[model]="model"
 			[size]="size"
 			[sortable]="sortable"
-			[skeleton]="skeleton"
 			[showSelectionColumn]="showSelectionColumn"
 			[stickyHeader]="stickyHeader"
 			[striped]="striped"
@@ -63,7 +62,6 @@ export class DynamicTableStory implements OnInit {
 	@Input() isDataGrid = false;
 	@Input() sortable = true;
 	@Input() stickyHeader = false;
-	@Input() skeleton = false;
 
 	@ViewChild("customHeaderTemplate")
 	protected customHeaderTemplate: TemplateRef<any>;

--- a/src/table/stories/app-expansion-table.component.ts
+++ b/src/table/stories/app-expansion-table.component.ts
@@ -42,7 +42,6 @@ class CustomHeaderItem extends TableHeaderItem {
 			[sortable]="sortable"
 			[showSelectionColumn]="showSelectionColumn"
 			[stickyHeader]="stickyHeader"
-			[skeleton]="skeleton"
 			[striped]="striped"
 			(sort)="customSort($event)"
 			[isDataGrid]="isDataGrid">
@@ -57,7 +56,6 @@ export class ExpansionTableStory implements OnInit {
 	@Input() isDataGrid = false;
 	@Input() sortable = true;
 	@Input() stickyHeader = false;
-	@Input() skeleton = false;
 
 	@ViewChild("customHeaderTemplate")
 	protected customHeaderTemplate: TemplateRef<any>;
@@ -83,7 +81,7 @@ export class ExpansionTableStory implements OnInit {
 			[new TableItem({ data: "Name 5" }), new TableItem({data: "twer"})],
 			[new TableItem({ data: "Name 6" }), new TableItem({data: "twer"})],
 			[new TableItem({ data: "Name 7" }), new TableItem({data: "twer"})]
-			
+
 		];
 		this.model.header = [
 			new TableHeaderItem({ data: "Very long title indeed" }),

--- a/src/table/stories/app-no-data.component.ts
+++ b/src/table/stories/app-no-data.component.ts
@@ -21,7 +21,6 @@ function sort(model, index: number) {
 	template: `
 		<ibm-table
 			style="display: block; width: 650px;"
-			[skeleton]="skeleton"
 			[model]="model"
 			[size]="size"
 			[showSelectionColumn]="showSelectionColumn"
@@ -39,7 +38,6 @@ export class TableNoDataStory implements OnInit, OnChanges {
 	@Input() striped = true;
 	@Input() sortable = true;
 	@Input() isDataGrid = false;
-	@Input() skeleton = false;
 
 	ngOnInit() {
 		this.model.header = [

--- a/src/table/stories/app-overflow-table.component.ts
+++ b/src/table/stories/app-overflow-table.component.ts
@@ -33,7 +33,6 @@ import { TableHeaderItem } from "../table-header-item.class";
 			[sortable]="sortable"
 			[showSelectionColumn]="showSelectionColumn"
 			[stickyHeader]="stickyHeader"
-			[skeleton]="skeleton"
 			[isDataGrid]="isDataGrid"
 			[striped]="striped">
 		</ibm-table>
@@ -47,7 +46,6 @@ export class OverflowTableStory implements OnInit {
 	@Input() isDataGrid = false;
 	@Input() sortable = true;
 	@Input() stickyHeader = false;
-	@Input() skeleton = false;
 
 	@ViewChild("overflowMenuItemTemplate")
 	protected overflowMenuItemTemplate: TemplateRef<any>;

--- a/src/table/stories/app-pagination-table.component.ts
+++ b/src/table/stories/app-pagination-table.component.ts
@@ -30,11 +30,9 @@ import { TableItem } from "../table-item.class";
 		<ibm-table
 			style="display: block; width: 650px;"
 			[sortable]="sortable"
-			[skeleton]="skeleton"
 			[model]="model"
 			(sort)="paginationSort($event)"
-			[stickyHeader]="stickyHeader"
-			[skeleton]="skeleton">
+			[stickyHeader]="stickyHeader">
 		</ibm-table>
 		<ibm-pagination [model]="model" (selectPage)="selectPage($event)"></ibm-pagination>
 	`
@@ -43,7 +41,6 @@ export class PaginationTableStory implements OnInit {
 	@Input() model = new TableModel();
 
 	@Input() sortable = true;
-	@Input() skeleton = false;
 
 	@Input() get totalDataLength() {
 		return this.model.totalDataLength;
@@ -53,7 +50,7 @@ export class PaginationTableStory implements OnInit {
 	}
 
 	@Input() stickyHeader = false;
-	
+
 	@ViewChild("filter")
 	filter: TemplateRef<any>;
 	@ViewChild("filterableHeaderTemplate")

--- a/src/table/stories/app-skeleton-table.component.ts
+++ b/src/table/stories/app-skeleton-table.component.ts
@@ -52,12 +52,10 @@ export class SkeletonTableStory implements OnInit, OnChanges {
 			[new TableItem({ data: "Name 6" }), new TableItem({data: "twer"})],
 			[new TableItem({ data: "Name 7" }), new TableItem({data: "twer"})]
 		];
-		console.log("in oninit: ",this.model);
 		this.skeletonModel = Table.skeletonModel(3, 5, this.withInitialModel ? this.model : null);
 	}
 
 	ngOnChanges() {
 		this.skeletonModel = Table.skeletonModel(3, 5, this.withInitialModel ? this.model : null);
-		console.log("in onchanges: ",this.model);
 	}
 }

--- a/src/table/stories/app-skeleton-table.component.ts
+++ b/src/table/stories/app-skeleton-table.component.ts
@@ -55,7 +55,6 @@ export class SkeletonTableStory implements OnInit, OnChanges {
 		];
 		// Creates an empty table with 5 rows and 5 columns
 		this.skeletonModel = Table.skeletonModel(5, 5, this.withInitialModel ? this.model : null);
-		console.log(this.skeletonModel);
 	}
 
 	ngOnChanges() {

--- a/src/table/stories/app-skeleton-table.component.ts
+++ b/src/table/stories/app-skeleton-table.component.ts
@@ -1,14 +1,14 @@
 import {
-	TemplateRef,
 	Component,
-	ViewChild,
 	OnInit,
 	Input,
-	OnChanges,
-	SimpleChanges
+	OnChanges
 } from "@angular/core";
 import { TableModel } from "../table-model.class";
-import { Table } from "../table.module";
+import {
+	Table,
+	TableHeaderItem,
+	TableItem } from "../table.module";
 
 @Component({
 	selector: "app-skeleton-table",
@@ -28,9 +28,37 @@ export class SkeletonTableStory implements OnInit, OnChanges {
 	@Input() striped = false;
 	@Input() skeleton = true;
 	@Input() skeletonModel = new TableModel();
+	@Input() model = new TableModel();
+	@Input() withInitialModel = false;
 
 	ngOnInit() {
+		this.model.header = [
+			new TableHeaderItem({
+				data: "Name"
+			}),
+			new TableHeaderItem({
+				data: "hwer",
+				className: "my-class"
+			})
+		];
+
+		this.model.rowsSelectedChange.subscribe(event => console.log(event));
+
+		this.model.data = [
+			[new TableItem({ data: "Name 1" }), new TableItem({ data: "qwer" })],
+			[new TableItem({ data: "Name 3" }), new TableItem({ data: "zwer" })],
+			[new TableItem({ data: "Name 2" }), new TableItem({ data: "swer" })],
+			[new TableItem({ data: "Name 4" }), new TableItem({data: "twer"})],
+			[new TableItem({ data: "Name 5" }), new TableItem({data: "twer"})],
+			[new TableItem({ data: "Name 6" }), new TableItem({data: "twer"})],
+			[new TableItem({ data: "Name 7" }), new TableItem({data: "twer"})]
+		];
 		// Creates an empty table with 5 rows and 5 columns
-		this.skeletonModel = Table.skeletonModel(5, 5);
+		this.skeletonModel = Table.skeletonModel(5, 5, this.withInitialModel ? this.model : null);
+		console.log(this.skeletonModel);
+	}
+
+	ngOnChanges() {
+		this.skeletonModel = Table.skeletonModel(5, 5, this.withInitialModel ? this.model : null);
 	}
 }

--- a/src/table/stories/app-skeleton-table.component.ts
+++ b/src/table/stories/app-skeleton-table.component.ts
@@ -8,7 +8,8 @@ import { TableModel } from "../table-model.class";
 import {
 	Table,
 	TableHeaderItem,
-	TableItem } from "../table.module";
+	TableItem
+} from "../table.module";
 
 @Component({
 	selector: "app-skeleton-table",

--- a/src/table/stories/app-skeleton-table.component.ts
+++ b/src/table/stories/app-skeleton-table.component.ts
@@ -43,8 +43,6 @@ export class SkeletonTableStory implements OnInit, OnChanges {
 			})
 		];
 
-		this.model.rowsSelectedChange.subscribe(event => console.log(event));
-
 		this.model.data = [
 			[new TableItem({ data: "Name 1" }), new TableItem({ data: "qwer" })],
 			[new TableItem({ data: "Name 3" }), new TableItem({ data: "zwer" })],
@@ -54,11 +52,12 @@ export class SkeletonTableStory implements OnInit, OnChanges {
 			[new TableItem({ data: "Name 6" }), new TableItem({data: "twer"})],
 			[new TableItem({ data: "Name 7" }), new TableItem({data: "twer"})]
 		];
-		// Creates an empty table with 5 rows and 5 columns
-		this.skeletonModel = Table.skeletonModel(5, 5, this.withInitialModel ? this.model : null);
+		console.log("in oninit: ",this.model);
+		this.skeletonModel = Table.skeletonModel(3, 5, this.withInitialModel ? this.model : null);
 	}
 
 	ngOnChanges() {
-		this.skeletonModel = Table.skeletonModel(5, 5, this.withInitialModel ? this.model : null);
+		this.skeletonModel = Table.skeletonModel(3, 5, this.withInitialModel ? this.model : null);
+		console.log("in onchanges: ",this.model);
 	}
 }

--- a/src/table/stories/app-table.component.ts
+++ b/src/table/stories/app-table.component.ts
@@ -24,7 +24,6 @@ function sort(model, index: number) {
 			style="display: block; width: 650px;"
 			[model]="model"
 			[size]="size"
-			[skeleton]="skeleton"
 			[showSelectionColumn]="true"
 			[enableSingleSelect]="false"
 			[sortable]="sortable"
@@ -45,7 +44,6 @@ export class TableStory implements OnInit, OnChanges {
 	@Input() isDataGrid = false;
 	@Input() noData = false;
 	@Input() stickyHeader = false;
-	@Input() skeleton = false;
 
 	ngOnInit() {
 		this.model.header = [
@@ -60,7 +58,7 @@ export class TableStory implements OnInit, OnChanges {
 
 		this.model.rowsSelectedChange.subscribe(event => console.log(event));
 
-		if (!this.noData && !this.skeleton) {
+		if (!this.noData) {
 			this.model.data = [
 				[new TableItem({ data: "Name 1" }), new TableItem({ data: "qwer" })],
 				[new TableItem({ data: "Name 3" }), new TableItem({ data: "zwer" })],

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -248,30 +248,55 @@ export interface TableTranslations {
 })
 export class Table implements AfterViewInit, OnDestroy {
 	/**
-	 * Creates a skeleton model with a row and column count specified by the user
+	 * Creates a skeleton model with a row and column count specified by the user.
 	 *
 	 * Example:
 	 *
 	 * ```typescript
 	 * this.model = Table.skeletonModel(5, 5);
 	 * ```
+	 *
+	 * An initial TableModel can be provided and a new skeleton model will be created based off the initial
+	 * model. Note that the new model will be created based on the number of rows/columns of the initial TableModel.
+	 * If headers are already provided in the intiial model, then the headers will be shown.
+	 *
+	 *	Example:
+	 *
+	 * ```typescript
+	 * this.model = Table.skeletonModel(5, 5, initialModel)
+	 * ```
+	 *
 	 */
-	static skeletonModel(rowCount: number, columnCount: number) {
-		const model = new TableModel();
-		let header = new Array<TableHeaderItem>();
-		let data = new Array<Array<TableItem>>();
-		let row = new Array<TableItem>();
+	static skeletonModel(rowCount: number, columnCount: number, initialModel?: TableModel) {
+		// If no initial model is supplied create a model with empty data.
+		if (!initialModel) {
+			const model = new TableModel();
+			let header = new Array<TableHeaderItem>();
+			let data = new Array<Array<TableItem>>();
+			let row = new Array<TableItem>();
 
-		for (let i = 0; i < columnCount; i++) {
-			header.push(new TableHeaderItem());
-			row.push(new TableItem());
+			for (let i = 0; i < columnCount; i++) {
+				header.push(new TableHeaderItem());
+				row.push(new TableItem({ data: " " }));
+			}
+
+			for (let i = 0; i < rowCount - 1; i++) {
+				data.push(row);
+			}
+
+			model.header = header;
+			model.data = data;
+			return model;
 		}
-		for (let i = 0; i < rowCount - 1; i++) {
-			data.push(row);
+		// If an initial model is provided, to create a skeleton state from the given model,
+		// create only first row with empty data to show loading animation only on the first row.
+		const model = Object.assign( Object.create( Object.getPrototypeOf(initialModel)), initialModel);
+		model.data[0] = model.data[0].map(col => new TableItem());
+
+		for (let i = 1; i < model.data.length; i++) {
+			model.data[i] = model.data[i].map(col => new TableItem({ data: " " }));
 		}
 
-		model.header = header;
-		model.data = data;
 		return model;
 	}
 
@@ -344,7 +369,9 @@ export class Table implements AfterViewInit, OnDestroy {
 	 */
 	@Input() size: "sm" | "sh" | "md" | "lg" = "md";
 	/**
-	 * Set to `true` for a loading table.
+	 * Set to `true` for a skeleton state table. Skeleton templates can be created using the `skeletonModel` function.
+	 * If data is already provided in the table, the data will not be hidden and the loading animation will not appear,
+	 * where there is already data.
 	 */
 	@Input() skeleton = false;
 	/**

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -393,9 +393,9 @@ const skeletonModel = Table.skeletonModel(0, 0, this.model);
 	 */
 	@Input() size: "sm" | "sh" | "md" | "lg" = "md";
 	/**
-	 * Set to `true` for a skeleton state table. Skeleton templates can be created using the `skeletonModel` function.
-	 * If data is already provided in the table, the data will not be hidden and the loading animation will not appear,
-	 * where there is already data.
+	 * Set to `true` for a skeleton state table. Generate a skeleton model using the `skeletonModel` static function, and set
+	 * the current table model to the skeleton model if you set this to `true`. Switch back to original model with fully loaded
+	 * data if you switch from `true` to `false`.
 	 */
 	@Input() skeleton = false;
 	/**

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -299,11 +299,14 @@ const skeletonModel = Table.skeletonModel(-1, 0, this.model);
 	 *
 	 */
 	static skeletonModel(rowCount: number, columnCount: number, initialModel?: TableModel) {
-		// If no initial model is supplied create a model with empty data.
 		const model = new TableModel();
+
+		// If no initial model is supplied create a model with empty data.
 		if (!initialModel) {
 			const header = new Array(columnCount).fill(0).map(() => new TableHeaderItem());
-			const data = new Array(rowCount).fill(0).map(() => new Array(columnCount).fill(0).map(() => new TableItem({ data: " " })));
+			const data = new Array(rowCount).fill(0).map(
+				() => new Array(columnCount).fill(0).map(() => new TableItem({ data: " " }))
+			);
 
 			model.header = header;
 			model.data = data;
@@ -312,33 +315,18 @@ const skeletonModel = Table.skeletonModel(-1, 0, this.model);
 		// If an initial model is provided, to create a skeleton state from the given model,
 		// create only first row with empty data to show loading animation only on the first row.
 		model.header = initialModel.header;
-		model.data = initialModel.data;
+		const headerLength = initialModel.header.length;
 
-		model.data[0] = model.data[0].map(column => {
-			column.data = "";
-			return column;
-		});
+		// Empty data is put into the first row of the `TableModel` to show a loading animation.
 
-		for (let i = 1; i < (rowCount === -1 ? model.data.length : rowCount); i++) {
-			// Create rows with default `TableItems` for extra rows when given `rowCount` is greater
-			// than the number of rows in the given initial model.
-			if (i >= model.data.length) {
-				model.data[i] = Array(model.data[0].length).fill(0).map(() => new TableItem({ data: " " }));
-			} else {
-				model.data[i] = model.data[i].map(column => {
-					column.data = " ";
-					return column;
-				});
-			}
+		let numberOfRows = rowCount;
+		if (numberOfRows === -1) {
+			numberOfRows = model.data.length;
 		}
-
-		// Delete extra rows if number given `rowCount` is less than the number of rows in a given initial model.
-		const modelLength = model.data.length;
-		if (rowCount < modelLength && rowCount !== -1) {
-			for (let i = rowCount; i < modelLength; i++) {
-				model.deleteRow(i);
-			}
-		}
+		const newData = [Array(headerLength).fill(0).map(() => new TableItem({ data: "" }))];
+		model.data = newData.concat(Array(numberOfRows - 1).fill(0).map(
+			() => Array(headerLength).fill(0).map(() => new TableItem({ data: " " }))
+		));
 
 		return model;
 	}
@@ -590,7 +578,7 @@ this.skeleton = false;
 	 * ```
 	 * <ibm-table [selectionLabelColumn]="0"></ibm-table>
 	 * <!-- results in aria-label="Select first column value"
-	 * (where "first column value" is the value of the first column in the row -->
+	 * where "first column value" is the value of the first column in the row -->
 	 * ```
 	 */
 	@Input() selectionLabelColumn: number;

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -252,19 +252,43 @@ export class Table implements AfterViewInit, OnDestroy {
 	 *
 	 * Example:
 	 *
-	 * ```typescript
-	 * this.model = Table.skeletonModel(5, 5);
-	 * ```
+```typescript
+this.model = Table.skeletonModel(5, 5);
+```
 	 *
-	 * An initial TableModel can be provided and a new skeleton model will be created based off the initial
-	 * model. Note that the new model will be created based on the number of rows/columns of the initial TableModel.
-	 * If headers are already provided in the intiial model, then the headers will be shown.
+	 * You can provide an initial table model as an optional parameter to create a skeleton model based on the initial table model.
+	 * Provide the initial model if you have data that is not completely loaded and set the table's model to the generated skeleton model.
+	 * When the data is fully loaded switch back to the original model which now contains the fully loaded data.
 	 *
 	 *	Example:
 	 *
-	 * ```typescript
-	 * this.model = Table.skeletonModel(5, 5, initialModel)
-	 * ```
+```typescript
+model = new TableModel();
+this.model.header = [
+	new TableHeaderItem({
+		data: "Name"
+	}),
+	new TableHeaderItem({
+		data: "hwer",
+		className: "my-class"
+	})
+];
+
+this.model.rowsSelectedChange.subscribe(event => console.log(event));
+
+this.model.data = [
+	[new TableItem({ data: "Name 1" }), new TableItem({ data: "qwer" })],
+	[new TableItem({ data: "Name 3" }), new TableItem({ data: "zwer" })],
+	[new TableItem({ data: "Name 2" }), new TableItem({ data: "swer" })],
+	[new TableItem({ data: "Name 4" }), new TableItem({data: "twer"})],
+	[new TableItem({ data: "Name 5" }), new TableItem({data: "twer"})],
+	[new TableItem({ data: "Name 6" }), new TableItem({data: "twer"})],
+	[new TableItem({ data: "Name 7" }), new TableItem({data: "twer"})]
+];
+// Note that if you provide the skeletonModel with an initial tableModel it makes the row and column count parameter not do anything.
+const skeletonModel = Table.skeletonModel(0, 0, this.model);
+// Set the table model to `skeletonModel` and switch back to `this.model` when data is finished loading.
+```
 	 *
 	 */
 	static skeletonModel(rowCount: number, columnCount: number, initialModel?: TableModel) {

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -300,9 +300,8 @@ const skeletonModel = Table.skeletonModel(-1, 0, this.model);
 	 */
 	static skeletonModel(rowCount: number, columnCount: number, initialModel?: TableModel) {
 		// If no initial model is supplied create a model with empty data.
+		const model = new TableModel();
 		if (!initialModel) {
-			const model = new TableModel();
-
 			const header = new Array(columnCount).fill(0).map(() => new TableHeaderItem());
 			const data = new Array(rowCount).fill(0).map(() => new Array(columnCount).fill(0).map(() => new TableItem({ data: " " })));
 
@@ -312,7 +311,6 @@ const skeletonModel = Table.skeletonModel(-1, 0, this.model);
 		}
 		// If an initial model is provided, to create a skeleton state from the given model,
 		// create only first row with empty data to show loading animation only on the first row.
-		const model = new TableModel();
 		model.header = initialModel.header;
 		model.data = initialModel.data;
 

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -63,8 +63,7 @@ const getProps = (more = {}) => {
 		striped: boolean("striped", false),
 		sortable: boolean("sortable", true),
 		isDataGrid: boolean("Data grid keyboard interactions", true),
-		stickyHeader: boolean("stickyHeader", false),
-		skeleton: boolean("skeleton", false)
+		stickyHeader: boolean("stickyHeader", false)
 	}, more);
 };
 
@@ -107,7 +106,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[model]="model"
 				[stickyHeader]="stickyHeader"
 				[size]="size"
-				[skeleton]="skeleton"
 				[showSelectionColumn]="showSelectionColumn"
 				[striped]="striped"
 				[sortable]="sortable"
@@ -127,7 +125,6 @@ storiesOf("Components|Table", module).addDecorator(
 			<app-no-data-table
 				[model]="model"
 				[size]="size"
-				[skeleton]="skeleton"
 				[showSelectionColumn]="showSelectionColumn"
 				[striped]="striped">
 				<tbody><tr><td class="no-data" colspan="3"><div>No data.</div></td></tr></tbody>
@@ -186,7 +183,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[showSelectionColumn]="showSelectionColumn"
 				[striped]="striped"
 				[sortable]="sortable"
-				[skeleton]="skeleton"
 				[stickyHeader]="stickyHeader"
 				[isDataGrid]="isDataGrid">
 			</app-table>
@@ -221,7 +217,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[size]="size"
 				[showSelectionColumn]="showSelectionColumn"
 				[stickyHeader]="stickyHeader"
-				[skeleton]="skeleton"
 				[striped]="striped"
 				[sortable]="sortable"
 				[isDataGrid]="isDataGrid">
@@ -256,7 +251,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[model]="model"
 				[size]="size"
 				[showSelectionColumn]="showSelectionColumn"
-				[skeleton]="skeleton"
 				[striped]="striped"
 				[sortable]="sortable"
 				[isDataGrid]="isDataGrid">
@@ -280,7 +274,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[showSelectionColumn]="showSelectionColumn"
 				[sortable]="sortable"
 				[stickyHeader]="stickyHeader"
-				[skeleton]="skeleton"
 				[striped]="striped"
 				[isDataGrid]="isDataGrid">
 			</app-expansion-table>
@@ -302,7 +295,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[showSelectionColumn]="showSelectionColumn"
 				[sortable]="sortable"
 				[stickyHeader]="stickyHeader"
-				[skeleton]="skeleton"
 				[striped]="striped"
 				[isDataGrid]="isDataGrid">
 			</app-custom-table>
@@ -324,7 +316,6 @@ storiesOf("Components|Table", module).addDecorator(
 				[showSelectionColumn]="showSelectionColumn"
 				[sortable]="sortable"
 				[stickyHeader]="stickyHeader"
-				[skeleton]="skeleton"
 				[striped]="striped"
 				[isDataGrid]="isDataGrid">
 			</app-overflow-table>
@@ -342,11 +333,9 @@ storiesOf("Components|Table", module).addDecorator(
 				<p ibmTableHeaderDescription>{{description}}</p>
 			</ibm-table-header>
 			<app-pagination-table
-				[skeleton]="skeleton"
 				[sortable]="sortable"
 				[totalDataLength]="totalDataLength"
 				[stickyHeader]="stickyHeader"
-				[skeleton]="skeleton"
 				[model]="model">
 			</app-pagination-table>
 		</ibm-table-container>
@@ -390,11 +379,14 @@ storiesOf("Components|Table", module).addDecorator(
 		template: `
 			<app-skeleton-table
 				[skeletonModel]="skeletonModel"
+				[withInitialModel]="withInitialModel"
 				[size]="size"
 				[striped]="striped">
 			</app-skeleton-table>
 	`,
-		props: getProps()
+		props: getProps({
+			withInitialModel: boolean("With initial model", false)
+		})
 	}))
 	.add("Documentation", () => ({
 		template: `


### PR DESCRIPTION
Closes #1036 

Add additional optional `initialModel` parameter to `skeletonModel` function to create a skeleton model based on a given model.

#### Changelog

**Changed**

* Enabling skeleton state when data is already present will no longer hide the data and put a loading animation. A loading animation will only be present if there is no data in a table cell and `skeleton` is set to `true`. This is to follow the guidelines  in https://www.carbondesignsystem.com/patterns/loading-pattern.
