### PR TITLE
fix: make compare function more robust

### DIFF
--- a/src/table/table-header-item.class.ts
+++ b/src/table/table-header-item.class.ts
@@ -241,11 +241,11 @@ export class TableHeaderItem {
 		if (!one || !two) {
 			return 0;
 		}
-		
+
 		if (typeof one.data === "string") {
 			return one.data.localeCompare(two.data);
 		}
-		
+
 		if (one.data < two.data) {
 			return -1;
 		} else if (one.data > two.data) {

--- a/src/table/table-header-item.class.ts
+++ b/src/table/table-header-item.class.ts
@@ -234,7 +234,7 @@ export class TableHeaderItem {
 	 * Override to enable different sorting.
 	 *
 	 * < 0 if `one` should go before `two`
-	 * > 0 if `one` shoulg go after `two`
+	 * > 0 if `one` should go after `two`
 	 * 0 if it doesn't matter (they are the same)
 	 */
 	compare(one: TableItem, two: TableItem): number {

--- a/src/table/table-header-item.class.ts
+++ b/src/table/table-header-item.class.ts
@@ -238,6 +238,14 @@ export class TableHeaderItem {
 	 * 0 if it doesn't matter (they are the same)
 	 */
 	compare(one: TableItem, two: TableItem): number {
+		if (!one || !two) {
+			return 0;
+		}
+		
+		if (typeof one.data === "string") {
+			return one.data.localeCompare(two.data);
+		}
+		
 		if (one.data < two.data) {
 			return -1;
 		} else if (one.data > two.data) {


### PR DESCRIPTION
in a striped table in dark theme there is an empty row added at the start of the table. That row shows as `undefined` in compare when a column is sorted. This ensures the empty row stays at the top. Also using localeCompare to compare a string
