### PR TITLE
fix(table container): Add wrapper to allow elements to be visible in 'scrollable parents'

### DIFF
--- a/src/table/table-container.component.ts
+++ b/src/table/table-container.component.ts
@@ -2,8 +2,10 @@ import { Component, HostBinding } from "@angular/core";
 
 @Component({
 	selector: "ibm-table-container",
-	template: `<ng-content></ng-content>`
+	template: `
+		<div [ngClass]="{'bx--data-table-container': containerClass}">
+			<ng-content></ng-content>
+		</div>
+	`
 })
-export class TableContainer {
-	@HostBinding("class.bx--data-table-container") containerClass = true;
-}
+export class TableContainer { }

--- a/src/table/table-container.component.ts
+++ b/src/table/table-container.component.ts
@@ -2,10 +2,8 @@ import { Component, HostBinding } from "@angular/core";
 
 @Component({
 	selector: "ibm-table-container",
-	template: `
-		<div [ngClass]="{'bx--data-table-container': containerClass}">
-			<ng-content></ng-content>
-		</div>
-	`
+	template: `<div><ng-content></ng-content></div>`
 })
-export class TableContainer { }
+export class TableContainer {
+	@HostBinding("class.bx--data-table-container") containerClass = true;
+}

--- a/src/table/table-container.component.ts
+++ b/src/table/table-container.component.ts
@@ -2,7 +2,13 @@ import { Component, HostBinding } from "@angular/core";
 
 @Component({
 	selector: "ibm-table-container",
-	template: `<div><ng-content></ng-content></div>`
+	template: `<ng-content></ng-content>`,
+	styles: [`
+		:host {
+			display: block;
+			position: relative;
+		}
+	`]
 })
 export class TableContainer {
 	@HostBinding("class.bx--data-table-container") containerClass = true;


### PR DESCRIPTION
closes #1064

`dialogRef` was considered by the `isVisibleInContainer` as not visible in scrollable parents when it is within the table container because of the `overflow-x: auto` style. By adding `display: block` and `position: relative` it allows the `dialogRef` to be considered visible.