### PR TITLE
fix: bx--btn--danger--primary undefined

### DIFF
--- a/src/button/button.directive.ts
+++ b/src/button/button.directive.ts
@@ -50,10 +50,7 @@ export class Button implements OnInit {
 		return this.ibmButton === "ghost";
 	}
 	@HostBinding("class.bx--btn--danger") get dangerButton() {
-		return this.ibmButton === "danger";
-	}
-	@HostBinding("class.bx--btn--danger--primary") get dangerPrimaryButton() {
-		return this.ibmButton === "danger--primary";
+		return this.ibmButton === "danger" || this.ibmButton === "danger--primary";
 	}
 	@HostBinding("class.bx--skeleton") @Input() skeleton = false;
 	@HostBinding("class.bx--btn--sm") get smallSize() {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Carbon only defines `bx--btn--danger`. `bx--btn--danger--primary` is not defined. https://github.com/carbon-design-system/carbon/blob/master/packages/components/src/components/button/_button.scss

So we need to use `bx--btn--danger` for `danger--primary` so the button can render correctly.

![image](https://user-images.githubusercontent.com/34791554/75123801-bf135180-5678-11ea-9f04-f8ebffa25a34.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
