### PR TITLE
fix: TabHeaderGroup no longer throws ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -223,7 +223,7 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
 		});
 		this.selectedSubscriptionTracker.add(selectedSubscriptions);
 
-		this.tabHeaderQuery.toArray()[this.currentSelectedIndex].selectTab();
+		setTimeout(() => this.tabHeaderQuery.toArray()[this.currentSelectedIndex].selectTab());
 	}
 
 	ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1126

Moved the tab selection outside the ChangeDetector flow in order to avoid angular throwing an ExpressionChangedAfterItHasBeenCheckedError

#### Changelog

**Changed**

* the tab selection performed in `ngAfterContentInit` is now encapsulated in a `setTimeout`
