### PR TITLE
fix(datepicker): Change to svg ibmIconCalendar16

### DIFF
--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -38,8 +38,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[id]= "id"
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
-						<ibm-icon-calendar16 class="bx--date-picker__icon">
-						</ibm-icon-calendar16>
+					<svg ibmIconCalendar16 class="bx--date-picker__icon"></svg>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
 					<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Replace `ibm-icon-calendar16` component with `ibmIconCalendar16` directive to fix icon alignment issue.

Before:

![image](https://user-images.githubusercontent.com/34791554/77218206-44b2e180-6aff-11ea-9cfb-264547554748.png)

After:

![image](https://user-images.githubusercontent.com/34791554/77218211-4da3b300-6aff-11ea-935b-0e3c6355604d.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
