### PR TITLE
fix(overflow-menu): prevent overflow menu pane from opening twice on enter or space

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -68,15 +68,4 @@ export class OverflowMenuDirective extends DialogDirective {
 	onDialogChanges() {
 		this.updateConfig();
 	}
-
-	@HostListener("keydown", ["$event"])
-	hostkeys(event: KeyboardEvent) {
-		switch (event.key) {
-			case "Enter":
-			case " ":
-				event.preventDefault();
-				this.toggle();
-				break;
-		}
-	}
 }

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -68,4 +68,14 @@ export class OverflowMenuDirective extends DialogDirective {
 	onDialogChanges() {
 		this.updateConfig();
 	}
+
+	@HostListener("keydown", ["$event"])
+	hostkeys(event: KeyboardEvent) {
+		switch (event.key) {
+			case "Enter":
+			case " ":
+				event.preventDefault();
+				break;
+		}
+	}
 }


### PR DESCRIPTION
Closes #1118 

Since dialog service already opens the menu pane on enter or space we can remove the host listener in the overflow directive