### PR TITLE
fix(timepicker-select): add input wrapper to prevent icon from displaying incorrectly in IE11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8480,12 +8480,11 @@
       "dev": true
     },
     "carbon-components": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.9.2.tgz",
-      "integrity": "sha512-2XXIQqCDqrJUsIKq4d3nJcwzbTBRB9LMKHMV5GCgSOTw06jfzo0hrHhgvGsG+oxqsdAAJAwcXMpSibbXtQJMJw==",
+      "version": "10.10.3",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.10.3.tgz",
+      "integrity": "sha512-uOHcMvQNtqazCqBxXlIaAU6Jmsb1/wE6fhJ3r6wt69MfW42xjCOVAegXDXylCAk1k6F+DR6cx4WsbYMUjOXR3A==",
       "dev": true,
       "requires": {
-        "carbon-icons": "^7.0.7",
         "flatpickr": "4.6.1",
         "lodash.debounce": "^4.0.8",
         "warning": "^3.0.0"
@@ -8501,12 +8500,6 @@
           }
         }
       }
-    },
-    "carbon-icons": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/carbon-icons/-/carbon-icons-7.0.7.tgz",
-      "integrity": "sha512-3vgkdXJRgCViCrH3fLUdyAXo0I8wmohO6QETv7vWFx6yc7s+SirWFBSFL38zUx4MHtR8iTxIlLEzkeU6FlFtXg==",
-      "dev": true
     },
     "cardinal": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "channel": "carbon-v9",
         "range": "2.X"
       }
-	],
-	"tagFormat": "v${version}@latest"
+    ],
+    "tagFormat": "v${version}@latest"
   },
   "config": {
     "commitizen": {
@@ -97,7 +97,7 @@
     "@types/node": "11.13.0",
     "angular2-template-loader": "0.6.2",
     "babel-loader": "8.0.5",
-    "carbon-components": "10.9.2",
+    "carbon-components": "10.10.3",
     "codelyzer": "5.0.0",
     "commitizen": "3.0.7",
     "core-js": "3.1.3",

--- a/src/timepicker-select/timepicker-select.component.ts
+++ b/src/timepicker-select/timepicker-select.component.ts
@@ -17,7 +17,8 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 @Component({
 	selector: "ibm-timepicker-select",
 	template: `
-			<label *ngIf="!skeleton && label" [attr.for]="id" class="bx--label bx--visually-hidden">{{label}}</label>
+		<label *ngIf="!skeleton && label" [attr.for]="id" class="bx--label bx--visually-hidden">{{label}}</label>
+		<div class="bx--select-input__wrapper">
 			<select
 				#select
 				[attr.id]="id"
@@ -27,6 +28,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				<ng-content></ng-content>
 			</select>
 			<ibm-icon-chevron-down16 *ngIf="!skeleton" class="bx--select__arrow"></ibm-icon-chevron-down16>
+		</div>
 	`,
 	providers: [
 		{

--- a/src/timepicker-select/timepicker-select.component.ts
+++ b/src/timepicker-select/timepicker-select.component.ts
@@ -27,7 +27,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				class="bx--select-input">
 				<ng-content></ng-content>
 			</select>
-			<ibm-icon-chevron-down16 *ngIf="!skeleton" class="bx--select__arrow"></ibm-icon-chevron-down16>
+			<svg ibmIconChevronDown16 *ngIf="!skeleton" class="bx--select__arrow"></svg>
 		</div>
 	`,
 	providers: [


### PR DESCRIPTION
Closes #1143 

Still not perfect, but it looks a lot better with the wrapper. It seems like a styling issue since the problem exists in the react implementation as well.

before:
<img width="261" alt="Screen Shot 2020-03-23 at 4 32 56 PM" src="https://user-images.githubusercontent.com/45505172/77362718-cc7b3480-6d27-11ea-887b-ea4fa9862d58.png">

after:
<img width="119" alt="Screen Shot 2020-03-23 at 4 54 18 PM" src="https://user-images.githubusercontent.com/45505172/77362673-b79ea100-6d27-11ea-8bff-1623a9dc3dc7.png">

