### PR TITLE
feat(dialog): add ability to specify vertical and horizontal offset in position

### DIFF
--- a/src/dialog/dialog-config.interface.ts
+++ b/src/dialog/dialog-config.interface.ts
@@ -49,4 +49,16 @@ export interface DialogConfig {
 	 * Additional arbitrary properties (mostly for internal/extended component use)
 	 */
 	[propName: string]: any;
+	/**
+	 * Classes to add to the dialog container
+	 */
+	wrapperClass?: string;
+	/**
+	 * Vertical offset for the position of the dialog
+	 */
+	verticalOffset?: number;
+	/**
+	 * Horizontal offset for the position of the dialog
+	 */
+	horizontalOffset?: number;
 }

--- a/src/dialog/dialog-config.interface.ts
+++ b/src/dialog/dialog-config.interface.ts
@@ -54,11 +54,7 @@ export interface DialogConfig {
 	 */
 	wrapperClass?: string;
 	/**
-	 * Vertical offset for the position of the dialog
+	 * This specifies any vertical and horizontal offset for the position of the dialog
 	 */
-	verticalOffset?: number;
-	/**
-	 * Horizontal offset for the position of the dialog
-	 */
-	horizontalOffset?: number;
+	offset?: { x: number, y: number };
 }

--- a/src/dialog/dialog.component.ts
+++ b/src/dialog/dialog.component.ts
@@ -204,9 +204,11 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 				pos = this.addGap[placement](positionService.findAbsolute(reference, target, placement));
 			}
 
-			// Apply vertical and horizontal offsets given through the dialogConfig
-			pos.top = pos.top + this.dialogConfig.verticalOffset;
-			pos.left = pos.left + this.dialogConfig.horizontalOffset;
+			if (this.dialogConfig.offset) {
+				// Apply vertical and horizontal offsets given through the dialogConfig
+				pos.top = pos.top + this.dialogConfig.offset.y;
+				pos.left = pos.left + this.dialogConfig.offset.x;
+			}
 
 			return pos;
 		};

--- a/src/dialog/dialog.component.ts
+++ b/src/dialog/dialog.component.ts
@@ -203,6 +203,11 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 			} else {
 				pos = this.addGap[placement](positionService.findAbsolute(reference, target, placement));
 			}
+
+			// Apply vertical and horizontal offsets given through the dialogConfig
+			pos.top = pos.top + this.dialogConfig.verticalOffset;
+			pos.left = pos.left + this.dialogConfig.horizontalOffset;
+
 			return pos;
 		};
 

--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -63,7 +63,7 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	 */
 	@Input() placement = "left";
 	/**
-	 * Class to add to the dialog container
+	 * Classes to add to the dialog container
 	 */
 	@Input() wrapperClass: string;
 	/**

--- a/src/dialog/overflow-menu/overflow-menu.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu.component.ts
@@ -31,8 +31,7 @@ import { OverflowMenuDirective } from "./overflow-menu.directive";
 			[ngClass]="{'bx--overflow-menu--open': open}"
 			[attr.aria-label]="buttonLabel"
 			[flip]="flip"
-			[verticalOffset]="verticalOffset"
-			[horizontalOffset]="horizontalOffset"
+			[offset]="offset"
 			[wrapperClass]="wrapperClass"
 			(onOpen)="open = true"
 			(onClose)="open = false"
@@ -79,9 +78,10 @@ export class OverflowMenu {
 
 	@Input() placement: "bottom" | "top" = "bottom";
 
-	@Input() verticalOffset = 0;
-
-	@Input() horizontalOffset = 0;
+	/**
+	 * This specifies any vertical and horizontal offset for the position of the dialog
+	 */
+	@Input() offset: { x: number, y: number };
 
 	@Input() wrapperClass = '';
 

--- a/src/dialog/overflow-menu/overflow-menu.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu.component.ts
@@ -31,6 +31,9 @@ import { OverflowMenuDirective } from "./overflow-menu.directive";
 			[ngClass]="{'bx--overflow-menu--open': open}"
 			[attr.aria-label]="buttonLabel"
 			[flip]="flip"
+			[verticalOffset]="verticalOffset"
+			[horizontalOffset]="horizontalOffset"
+			[wrapperClass]="wrapperClass"
 			(onOpen)="open = true"
 			(onClose)="open = false"
 			role="button"
@@ -70,12 +73,17 @@ import { OverflowMenuDirective } from "./overflow-menu.directive";
 	encapsulation: ViewEncapsulation.None
 })
 export class OverflowMenu {
-
 	@Input() buttonLabel = this.i18n.get().OVERFLOW_MENU.OVERFLOW;
 
 	@Input() flip = false;
 
 	@Input() placement: "bottom" | "top" = "bottom";
+
+	@Input() verticalOffset = 0;
+
+	@Input() horizontalOffset = 0;
+
+	@Input() wrapperClass = '';
 
 	@ContentChild(OverflowMenuDirective) overflowMenuDirective: OverflowMenuDirective;
 

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -74,6 +74,7 @@ export class OverflowMenuDirective extends DialogDirective {
 		this.dialogConfig.flip = this.flip;
 		this.dialogConfig.verticalOffset = this.verticalOffset;
 		this.dialogConfig.horizontalOffset = this.horizontalOffset;
+		this.dialogConfig.wrapperClass = this.wrapperClass;
 	}
 
 	onDialogInit() {

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -43,6 +43,19 @@ export class OverflowMenuDirective extends DialogDirective {
 	 * Controls wether the overflow menu is flipped
 	 */
 	@Input() flip = false;
+	/**
+	 * Vertical offset for the position of the dialog
+	 */
+	@Input() verticalOffset = 0;
+	/**
+	 * Horizontal offset for the position of the dialog
+	 */
+	@Input() horizontalOffset = 0;
+
+	/**
+	 * Classes to add to the dialog container
+	 */
+	@Input() wrapperClass = '';
 
 	/**
 	 * Creates an instance of `OverflowMenuDirective`.
@@ -59,6 +72,8 @@ export class OverflowMenuDirective extends DialogDirective {
 	updateConfig() {
 		this.dialogConfig.content = this.ibmOverflowMenu;
 		this.dialogConfig.flip = this.flip;
+		this.dialogConfig.verticalOffset = this.verticalOffset;
+		this.dialogConfig.horizontalOffset = this.horizontalOffset;
 	}
 
 	onDialogInit() {

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -44,14 +44,9 @@ export class OverflowMenuDirective extends DialogDirective {
 	 */
 	@Input() flip = false;
 	/**
-	 * Vertical offset for the position of the dialog
+	 * This specifies any vertical and horizontal offset for the position of the dialog
 	 */
-	@Input() verticalOffset = 0;
-	/**
-	 * Horizontal offset for the position of the dialog
-	 */
-	@Input() horizontalOffset = 0;
-
+	@Input() offset: { x: number, y: number };
 	/**
 	 * Classes to add to the dialog container
 	 */
@@ -72,8 +67,7 @@ export class OverflowMenuDirective extends DialogDirective {
 	updateConfig() {
 		this.dialogConfig.content = this.ibmOverflowMenu;
 		this.dialogConfig.flip = this.flip;
-		this.dialogConfig.verticalOffset = this.verticalOffset;
-		this.dialogConfig.horizontalOffset = this.horizontalOffset;
+		this.dialogConfig.offset = this.offset;
 		this.dialogConfig.wrapperClass = this.wrapperClass;
 	}
 

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -1,5 +1,10 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { withKnobs, number, boolean } from "@storybook/addon-knobs";
+import {
+	withKnobs,
+	number,
+	boolean,
+	object
+} from "@storybook/addon-knobs";
 
 import { DialogModule, DocumentationModule } from "../../";
 import { PlaceholderModule } from "../../placeholder/placeholder.module";
@@ -31,8 +36,7 @@ storiesOf("Components|Overflow Menu", module)
 				<h1 style="margin-bottom: 1rem">Bottom placement</h1>
 				<ibm-overflow-menu
 					[flip]="flip"
-					[verticalOffset]="verticalOffset"
-					[horizontalOffset]="horizontalOffset">
+					[offset]="offset">
 					<ibm-overflow-menu-option (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -51,8 +55,7 @@ storiesOf("Components|Overflow Menu", module)
 				<ibm-overflow-menu
 					[flip]="flip"
 					placement="top"
-					[verticalOffset]="verticalOffset"
-					[horizontalOffset]="horizontalOffset">
+					[offset]="offset">
 					<ibm-overflow-menu-option (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -71,8 +74,7 @@ storiesOf("Components|Overflow Menu", module)
 			click: () => console.log("click"),
 			selected: () => console.log("selected"),
 			flip: boolean("Flipped", false),
-			verticalOffset: number("Vertical offset", 0),
-			horizontalOffset: number("Horizontal offset", 0)
+			offset: object("Horizontal and vertical offset", { x: 0, y: 0 })
 		}
 	}))
 	.add("With links", () => ({
@@ -81,8 +83,7 @@ storiesOf("Components|Overflow Menu", module)
 				<h1 style="margin-bottom: 1rem">Bottom placement</h1>
 				<ibm-overflow-menu
 					[flip]="flip"
-					[verticalOffset]="verticalOffset"
-					[horizontalOffset]="horizontalOffset">
+					[offset]="offset">
 					<ibm-overflow-menu-option href="https://www.ibm.com" (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -101,8 +102,7 @@ storiesOf("Components|Overflow Menu", module)
 				<ibm-overflow-menu
 					[flip]="flip"
 					placement="top"
-					[verticalOffset]="verticalOffset"
-					[horizontalOffset]="horizontalOffset">
+					[offset]="offset">
 					<ibm-overflow-menu-option href="https://www.ibm.com" (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -121,8 +121,7 @@ storiesOf("Components|Overflow Menu", module)
 			click: () => console.log("click"),
 			selected: () => console.log("selected"),
 			flip: boolean("Flipped", false),
-			verticalOffset: number("Vertical offset", 0),
-			horizontalOffset: number("Horizontal offset", 0)
+			offset: object("Horizontal and vertical offset", { x: 0, y: 0 })
 		}
 	}))
 	.add("Dynamic", () => ({
@@ -132,7 +131,7 @@ storiesOf("Components|Overflow Menu", module)
 				using the <code style="font-family: monospace;">optionCount</code> knob <br/>
 				to change the number of menu options
 			</span>
-			<ibm-overflow-menu [verticalOffset]="verticalOffset" [horizontalOffset]="horizontalOffset">
+			<ibm-overflow-menu [offset]="offset">
 				<ibm-overflow-menu-option *ngFor="let option of options(optionCount)">
 					{{option}}
 				</ibm-overflow-menu-option>
@@ -141,8 +140,7 @@ storiesOf("Components|Overflow Menu", module)
 		props: {
 			optionCount: number("optionCount", 10),
 			options: createOptions,
-			verticalOffset: number("Vertical offset", 0),
-			horizontalOffset: number("Horizontal offset", 0)
+			offset: object("Horizontal and vertical offset", { x: 0, y: 0 })
 		}
 	}))
 	.add("Documentation", () => ({

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -29,7 +29,10 @@ storiesOf("Components|Overflow Menu", module)
 		template: `
 			<div>
 				<h1 style="margin-bottom: 1rem">Bottom placement</h1>
-				<ibm-overflow-menu [flip]="flip">
+				<ibm-overflow-menu
+					[flip]="flip"
+					[verticalOffset]="verticalOffset"
+					[horizontalOffset]="horizontalOffset">
 					<ibm-overflow-menu-option (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -45,7 +48,11 @@ storiesOf("Components|Overflow Menu", module)
 			</div>
 			<div style="margin-top: 8rem">
 				<h1 style="margin-bottom: 1rem">Top placement</h1>
-				<ibm-overflow-menu [flip]="flip" placement="top">
+				<ibm-overflow-menu
+					[flip]="flip"
+					placement="top"
+					[verticalOffset]="verticalOffset"
+					[horizontalOffset]="horizontalOffset">
 					<ibm-overflow-menu-option (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -63,14 +70,19 @@ storiesOf("Components|Overflow Menu", module)
 		props: {
 			click: () => console.log("click"),
 			selected: () => console.log("selected"),
-			flip: boolean("Flipped", false)
+			flip: boolean("Flipped", false),
+			verticalOffset: number("Vertical offset", 0),
+			horizontalOffset: number("Horizontal offset", 0)
 		}
 	}))
 	.add("With links", () => ({
 		template: `
 			<div>
 				<h1 style="margin-bottom: 1rem">Bottom placement</h1>
-				<ibm-overflow-menu [flip]="flip" >
+				<ibm-overflow-menu
+					[flip]="flip"
+					[verticalOffset]="verticalOffset"
+					[horizontalOffset]="horizontalOffset">
 					<ibm-overflow-menu-option href="https://www.ibm.com" (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -86,7 +98,11 @@ storiesOf("Components|Overflow Menu", module)
 			</div>
 			<div style="margin-top: 8rem">
 				<h1 style="margin-bottom: 1rem">Top placement</h1>
-				<ibm-overflow-menu [flip]="flip" placement="top">
+				<ibm-overflow-menu
+					[flip]="flip"
+					placement="top"
+					[verticalOffset]="verticalOffset"
+					[horizontalOffset]="horizontalOffset">
 					<ibm-overflow-menu-option href="https://www.ibm.com" (selected)="selected($event)" (click)="click($event)">
 						An example option that is really long to show what should be done to handle long text
 					</ibm-overflow-menu-option>
@@ -104,7 +120,9 @@ storiesOf("Components|Overflow Menu", module)
 		props: {
 			click: () => console.log("click"),
 			selected: () => console.log("selected"),
-			flip: boolean("Flipped", false)
+			flip: boolean("Flipped", false),
+			verticalOffset: number("Vertical offset", 0),
+			horizontalOffset: number("Horizontal offset", 0)
 		}
 	}))
 	.add("Dynamic", () => ({
@@ -114,7 +132,7 @@ storiesOf("Components|Overflow Menu", module)
 				using the <code style="font-family: monospace;">optionCount</code> knob <br/>
 				to change the number of menu options
 			</span>
-			<ibm-overflow-menu>
+			<ibm-overflow-menu [verticalOffset]="verticalOffset" [horizontalOffset]="horizontalOffset">
 				<ibm-overflow-menu-option *ngFor="let option of options(optionCount)">
 					{{option}}
 				</ibm-overflow-menu-option>
@@ -122,7 +140,9 @@ storiesOf("Components|Overflow Menu", module)
 		`,
 		props: {
 			optionCount: number("optionCount", 10),
-			options: createOptions
+			options: createOptions,
+			verticalOffset: number("Vertical offset", 0),
+			horizontalOffset: number("Horizontal offset", 0)
 		}
 	}))
 	.add("Documentation", () => ({


### PR DESCRIPTION
Closes #1153 

- Allows for vertical and horizontal offsets to be specified through the `verticalOffset` and `horitontalOffset` inputs for the overflow menu.
- Allows for custom classes to be applied to dialog wrappers.