### PR TITLE
fix(ui-shell): #1165 - syntax errors for NavigationItem interface

### DIFF
--- a/src/ui-shell/header/header-navigation-items.interface.ts
+++ b/src/ui-shell/header/header-navigation-items.interface.ts
@@ -3,19 +3,19 @@
  * items and menus through a model.
  */
 export interface NavigationItem {
-    type: "menu | item",
-    title?: string,
-    href?: string,
-    trigger?: "click" | "mouseover",
-    route?: any[],
-    routeExtras?: any[],
-    content?: string
-    menuItems?: HeaderItemInterface[]
+	type: "menu" | "item";
+	title?: string;
+	href?: string;
+	trigger?: "click" | "mouseover";
+	route?: any[];
+	routeExtras?: any[];
+	content?: string;
+	menuItems?: HeaderItemInterface[];
 }
 
 export interface HeaderItemInterface {
-    href?: string,
-    route?: any[],
-    routeExtras?: any[],
-    content?: string
+	href?: string;
+	route?: any[];
+	routeExtras?: any[];
+	content?: string;
 }


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1165

#### Changelog

**New**
N/A

**Changed**
fixed:
- commas in interface should be semi-colons
- supported values for `type` in `NavigationItem` should be separate values
- spaces changed to tabs as per tslint config for project

**Removed**
N/A
