### PR TITLE
fix: added correct wapper class for textAreas

### DIFF
--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -5,8 +5,11 @@ import {
 	ElementRef,
 	HostBinding,
 	TemplateRef,
-	ViewChild
+	ViewChild,
+	ContentChild
 } from "@angular/core";
+
+import { TextArea } from "./text-area.directive";
 
 /**
  * [See demo](../../?path=/story/input--label)
@@ -42,7 +45,7 @@ import {
 			<ng-content></ng-content>
 		</label>
 		<div *ngIf="!skeleton" class="bx--form__helper-text">{{helperText}}</div>
-		<div class="bx--text-input__field-wrapper" [attr.data-invalid]="(invalid ? true : null)" #wrapper>
+		<div [class]="wrapperClass" [attr.data-invalid]="(invalid ? true : null)" #wrapper>
 			<ibm-icon-warning-filled16
 				*ngIf="invalid"
 				class="bx--text-input__invalid-icon bx--text-area__invalid-icon">
@@ -65,6 +68,10 @@ export class Label implements AfterContentInit {
 	 * its input counterpart through the 'for' attribute.
 	 */
 	labelInputID = "ibm-label-" + Label.labelCounter;
+	/**
+	 * The class of the wrapper
+	 */
+	wrapperClass = "bx--text-input__field-wrapper";
 
 	/**
 	 * State of the `Label` will determine the styles applied.
@@ -89,6 +96,8 @@ export class Label implements AfterContentInit {
 
 	@ViewChild("wrapper") wrapper: ElementRef<HTMLDivElement>;
 
+	@ContentChild(TextArea) textArea: TextArea;
+
 	@HostBinding("class.bx--form-item") labelClass = true;
 
 	/**
@@ -102,6 +111,9 @@ export class Label implements AfterContentInit {
 	 * Sets the id on the input item associated with the `Label`.
 	 */
 	ngAfterContentInit() {
+		if (this.textArea) {
+			this.wrapperClass = "bx--text-area__wrapper";
+		}
 		this.wrapper.nativeElement.querySelector("input,textarea,div").setAttribute("id", this.labelInputID);
 	}
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1173

Added correct wapper class for `ibm-label` when an `ibmTextArea` is passed as child

#### Changelog

**Changed**

* `ibm-label` will now have `bx--text-input__field-wrapper` class or `bx--text-area__wrapper` one depending on its child component
