### PR TITLE
fix: ibm-tabs now support type container

### DIFF
--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -21,7 +21,8 @@ import { Subscription } from "rxjs";
 	<nav
 		class="bx--tabs"
 		[ngClass]="{
-			'bx--skeleton': skeleton
+			'bx--skeleton': skeleton,
+			'bx--tabs--container': type === 'container'
 		}"
 		role="navigation"
 		[attr.aria-label]="ariaLabel"
@@ -94,6 +95,8 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
 	 * in the tab header group cached and not reloaded on tab switching.
 	 */
 	@Input() cacheActive = false;
+
+	@Input() type: "default" | "container" = "default";
 
 	/**
 	 * ContentChildren of all the tabHeaders.

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -26,7 +26,8 @@ import { Tab } from "./tab.component";
 		<nav
 			class="bx--tabs"
 			[ngClass]="{
-				'bx--skeleton': skeleton
+				'bx--skeleton': skeleton,
+				'bx--tabs--container': type === 'container'
 			}"
 			role="navigation"
 			[attr.aria-label]="ariaLabel"
@@ -133,6 +134,8 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 
 	@Input() contentBefore: TemplateRef<any>;
 	@Input() contentAfter: TemplateRef<any>;
+
+	@Input() type: "default" | "container" = "default";
 
 	/**
 	 * Gets the Unordered List element that holds the `Tab` headings from the view DOM.

--- a/src/tabs/tabs.component.ts
+++ b/src/tabs/tabs.component.ts
@@ -49,7 +49,8 @@ import { TabHeaders } from "./tab-headers.component";
 				[contentBefore]="before"
 				[contentAfter]="after"
 				[ariaLabel]="ariaLabel"
-				[ariaLabelledby]="ariaLabelledby">
+				[ariaLabelledby]="ariaLabelledby"
+				[type]="type">
 			</ibm-tab-headers>
 			<ng-content></ng-content>
 			<ng-template #before>
@@ -62,7 +63,8 @@ import { TabHeaders } from "./tab-headers.component";
 				*ngIf="hasTabHeaders() && position === 'bottom'"
 				[skeleton]="skeleton"
 				[tabs]="tabs"
-				[cacheActive]="cacheActive">
+				[cacheActive]="cacheActive"
+				[type]="type">
 			</ibm-tab-headers>
 	`
 })
@@ -96,6 +98,10 @@ export class Tabs implements AfterContentInit, OnChanges {
 	 * Sets the aria labelledby on the `TabHeader`s nav element.
 	 */
 	@Input() ariaLabelledby: string;
+	/**
+	 * Sets the type of the `TabHeader`s
+	 */
+	@Input() type: "default" | "container" = "default";
 
 	/**
 	 * Maintains a `QueryList` of the `Tab` elements and updates if `Tab`s are added or removed.

--- a/src/tabs/tabs.stories.ts
+++ b/src/tabs/tabs.stories.ts
@@ -1,5 +1,5 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
-import { withKnobs, boolean } from "@storybook/addon-knobs/angular";
+import { withKnobs, boolean, select } from "@storybook/addon-knobs/angular";
 
 import { TabsModule, DocumentationModule } from "../";
 import { Component, Input } from "@angular/core";
@@ -7,7 +7,7 @@ import { Component, Input } from "@angular/core";
 @Component({
 	selector: "ibm-header-group",
 	template: `
-		<ibm-tab-header-group [followFocus]="followFocus" [cacheActive]="cacheActive">
+		<ibm-tab-header-group [type]="type" [followFocus]="followFocus" [cacheActive]="cacheActive">
 			<ibm-tab-header [paneReference]="content1">
 				Content 1
 			</ibm-tab-header>
@@ -39,6 +39,7 @@ import { Component, Input } from "@angular/core";
 class TabStory {
 	@Input() followFocus = true;
 	@Input() cacheActive = false;
+	@Input() type = "default";
 }
 
 storiesOf("Components|Tabs", module)
@@ -67,6 +68,21 @@ storiesOf("Components|Tabs", module)
 			cacheActive: boolean("Cache active", true)
 		}
 	}))
+	.add("Container", () => ({
+		template: `
+			<ibm-tabs type="container" [followFocus]="followFocus" [isNavigation]="isNavigation" [cacheActive]="cacheActive">
+				<ibm-tab heading="one">Tab Content 1</ibm-tab>
+				<ibm-tab heading="two">Tab Content 2</ibm-tab>
+				<ibm-tab heading="three">Tab Content 3</ibm-tab>
+				<ibm-tab heading="four" disabled="true">Tab Content 4</ibm-tab>
+			</ibm-tabs>
+		`,
+		props: {
+			followFocus: boolean("followFocus", true),
+			isNavigation: boolean("isNavigation", false),
+			cacheActive: boolean("Cache active", true)
+		}
+	}))
 	.add("With template", () => ({
 		template: `
 			<ng-template #customTabs let-item>
@@ -83,7 +99,7 @@ storiesOf("Components|Tabs", module)
 					</svg>
 				</div>
 			</ng-template>
-			<ibm-tabs [followFocus]="followFocus" [isNavigation]="isNavigation">
+			<ibm-tabs [type]="type" [followFocus]="followFocus" [isNavigation]="isNavigation">
 				<ibm-tab *ngFor="let item of data; let i = index;" [heading]="customTabs" [context]="item">Tab Content {{i + 1}}</ibm-tab>
 				<ibm-tab [heading]="iconTab">Tab Content Custom</ibm-tab>
 			</ibm-tabs>
@@ -95,25 +111,26 @@ storiesOf("Components|Tabs", module)
 				{ name: "one" },
 				{ name: "two" },
 				{ name: "three" }
-			]
+			],
+			type: select("type", ["default", "container"], "default")
 		}
 	}))
 	.add("Width before and after content", () => ({
 		template: `
 			<div style="font-weight: 600; padding-bottom: 10px; padding-top: 20px;">before</div>
-			<ibm-tabs [followFocus]="followFocus" [isNavigation]="isNavigation">
+			<ibm-tabs [type]="type" [followFocus]="followFocus" [isNavigation]="isNavigation">
 				<ibm-tab heading="one">foo</ibm-tab>
 				<ibm-tab heading="two">bar</ibm-tab>
 				<span before>content before</span>
 			</ibm-tabs>
 			<div style="font-weight: 600; padding-bottom: 10px; padding-top: 20px;">after</div>
-			<ibm-tabs [followFocus]="followFocus" [isNavigation]="isNavigation">
+			<ibm-tabs [type]="type" [followFocus]="followFocus" [isNavigation]="isNavigation">
 				<ibm-tab heading="one">foo</ibm-tab>
 				<ibm-tab heading="two">bar</ibm-tab>
 				<span after>content after</span>
 			</ibm-tabs>
 			<div style="font-weight: 600; padding-bottom: 10px; padding-top: 20px;">both</div>
-			<ibm-tabs [followFocus]="followFocus" [isNavigation]="isNavigation">
+			<ibm-tabs [type]="type" [followFocus]="followFocus" [isNavigation]="isNavigation">
 				<ibm-tab heading="one">foo</ibm-tab>
 				<ibm-tab heading="two">bar</ibm-tab>
 				<span before>content before</span>
@@ -122,16 +139,18 @@ storiesOf("Components|Tabs", module)
 		`,
 		props: {
 			followFocus: boolean("followFocus", true),
-			isNavigation: boolean("isNavigation", false)
+			isNavigation: boolean("isNavigation", false),
+			type: select("type", ["default", "container"], "default")
 		}
 	}))
 	.add("With TabHeaderGroup", () => ({
 		template: `
-			<ibm-header-group [followFocus]="followFocus" [cacheActive]="cacheActive"></ibm-header-group>
+			<ibm-header-group [type]="type" [followFocus]="followFocus" [cacheActive]="cacheActive"></ibm-header-group>
 		`,
 		props: {
 			followFocus: boolean("followFocus", true),
-			cacheActive: boolean("Cache active", true)
+			cacheActive: boolean("Cache active", true),
+			type: select("type", ["default", "container"], "default")
 		}
 	}))
 	.add("Skeleton", () => ({


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1175

Tabs component will now accept a type property that can assume "default" or "container" value. If "container" is passed, the tabs will render accordingly with carbon styles.

#### Changelog

**Changed**

* `ibm-tabs` and `ibm-tab-header-group` will now support `type` property
