### PR TITLE
refactor(accordion-item): adds context input

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
         "channel": "carbon-v9",
         "range": "2.X"
       }
-	],
-	"tagFormat": "v${version}@latest"
+    ],
+    "tagFormat": "v${version}@latest"
   },
   "config": {
     "commitizen": {

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -23,7 +23,7 @@ import {
 				}">
 				{{!skeleton ? title : null}}
 			</p>
-			<ng-template *ngIf="isTemplate(title)" [ngTemplateOutlet]="title"></ng-template>
+			<ng-template *ngIf="isTemplate(title)" [ngTemplateOutlet]="title" [ngTemplateOutletContext]="context"></ng-template>
 		</button>
 		<div [id]="id" class="bx--accordion__content">
 			<ng-content *ngIf="!skeleton; else skeletonTemplate"></ng-content>
@@ -38,6 +38,7 @@ import {
 export class AccordionItem {
 	static accordionItemCount = 0;
 	@Input() title: string | TemplateRef<any>;
+	@Input() context?: Object;
 	@Input() id = `accordion-item-${AccordionItem.accordionItemCount}`;
 	@Input() skeleton = false;
 	@Output() selected = new EventEmitter();

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -23,7 +23,11 @@ import {
 				}">
 				{{!skeleton ? title : null}}
 			</p>
-			<ng-template *ngIf="isTemplate(title)" [ngTemplateOutlet]="title" [ngTemplateOutletContext]="context"></ng-template>
+			<ng-template
+				*ngIf="isTemplate(title)"
+				[ngTemplateOutlet]="title"
+				[ngTemplateOutletContext]="context">
+			</ng-template>
 		</button>
 		<div [id]="id" class="bx--accordion__content">
 			<ng-content *ngIf="!skeleton; else skeletonTemplate"></ng-content>
@@ -38,7 +42,7 @@ import {
 export class AccordionItem {
 	static accordionItemCount = 0;
 	@Input() title: string | TemplateRef<any>;
-	@Input() context?: Object;
+	@Input() context: Object | null = null;
 	@Input() id = `accordion-item-${AccordionItem.accordionItemCount}`;
 	@Input() skeleton = false;
 	@Output() selected = new EventEmitter();

--- a/src/accordion/accordion.stories.ts
+++ b/src/accordion/accordion.stories.ts
@@ -53,6 +53,33 @@ storiesOf("Components|Accordion", module)
 			selected: action("item expanded")
 		}
 	}))
+	.add("With title template", () => ({
+		template: `
+			<div style="width: 500px">
+				<ibm-accordion>
+					<ibm-accordion-item [title]="title" (selected)="selected($event)">Lorem ipsum dolor sit amet, \
+					consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore \
+					et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \
+					ullamco laboris nisi ut aliquip ex ea commodo consequat.</ibm-accordion-item>
+					<ibm-accordion-item [title]="titleWithContext" [context]="{ index: 2 }" (selected)="selected($event)">Lorem ipsum dolor sit amet, \
+					consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore \
+					et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \
+					ullamco laboris nisi ut aliquip ex ea commodo consequat.</ibm-accordion-item>
+				</ibm-accordion>
+			</div>
+
+			<ng-template #title>
+				<p class="bx--accordion__title">Section 1 title</p>
+			</ng-template>
+
+			<ng-template #titleWithContext let-index="index">
+				<p class="bx--accordion__title">Section {{ index }} title</p>
+			</ng-template>
+		`,
+		props: {
+			selected: action("item expanded")
+		}
+	}))
 	.add("Skeleton", () => ({
 		template: `
 			<div style="width: 500px">


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1180

#### Changelog


**Changed**

* Added a `context` input to `ibm-accordion-item`, which is a object that is passed to `[ngTemplateOutletContext]`

