### PR TITLE
fix: subscribe observable when set in dropdown-list

### DIFF
--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -121,6 +121,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 					observer.complete();
 				});
 			});
+			this.onItemsReady(null);
 		} else {
 			this.updateList(value);
 		}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1182

Subscribe observable when set in dropdown-list component so that it doesn't rely on parent component or other events to update the values.

#### Changelog

**Changed**

* Subscribe items observable when it's set