### PR TITLE
`search.component`: Remove `role="search"` from `input` element

### DIFF
--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -18,7 +18,6 @@
 			*ngIf="!toolbar || active || value !== ''"
 			class="bx--search-input"
 			[type]="tableSearch || !toolbar ? 'text' : 'search'"
-			role="search"
 			[id]="id"
 			[value]="value"
 			[autocomplete]="autocomplete"


### PR DESCRIPTION
The search role is added to the **container element** that encompasses the items and objects that, as a whole, combine to create search functionality.
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/search.html

#### Changelog

**Removed**

* `role="search"` from `input` element
