### PR TITLE
fix(table-toolbar): Improve batch text handling

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -142,8 +142,9 @@ export default {
 		"ROW": "row"
 	},
 	"TABLE_TOOLBAR": {
-		"ACTION_BAR": "Table Action Bar",
-		"BATCH_TEXT": "items selected",
+		"ACTION_BAR": "Table action bar",
+		"BATCH_TEXT_SINGLE": "1 item selected",
+		"BATCH_TEXT_MULTIPLE": "{{count}} items selected",
 		"CANCEL": "Cancel"
 	},
 	"TABS": {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -143,6 +143,7 @@ export default {
 	},
 	"TABLE_TOOLBAR": {
 		"ACTION_BAR": "Table action bar",
+		"BATCH_TEXT": "",
 		"BATCH_TEXT_SINGLE": "1 item selected",
 		"BATCH_TEXT_MULTIPLE": "{{count}} items selected",
 		"CANCEL": "Cancel"

--- a/src/i18n/i18n.service.ts
+++ b/src/i18n/i18n.service.ts
@@ -229,7 +229,7 @@ export class I18n {
 	public getValueFromPath(path): string | { [key: string]: string } {
 		let value = this.translationStrings;
 		for (const segment of path.split(".")) {
-			if (value[segment]) {
+			if (value[segment] !== undefined && value[segment] !== null) {
 				value = value[segment];
 			} else {
 				throw new Error(`no key ${segment} at ${path}`);

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -5,6 +5,7 @@ import {
 	boolean,
 	select,
 	number,
+	object,
 	text
 } from "@storybook/addon-knobs/angular";
 
@@ -194,7 +195,10 @@ storiesOf("Components|Table", module).addDecorator(
 	`,
 		props: getProps({
 			description: text("Description", "With toolbar"),
-			batchText: text("Toolbar batch text", "items selected")
+			batchText: object("Toolbar batch text", {
+				SINGLE: "1 item selected",
+				MULTIPLE: "{{count}} items selected"
+			})
 		})
 	}))
 	.add("With toolbar without toolbar action", () => ({

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -59,8 +59,13 @@ import { I18n, Overridable } from "../../i18n/i18n.module";
 			</div>
 			<div class="bx--batch-summary">
 				<p class="bx--batch-summary__para" *ngIf="count as n">
-					<span *ngIf="n === 1">{{_batchTextSingle.subject | async}}</span>
-					<span *ngIf="n !== 1">{{_batchTextMultiple.subject | i18nReplace: {count: n} | async}}</span>
+					<ng-container *ngIf="_batchTextLegacy.subject | async as legacyText; else batchTextBlock">
+						<span>{{n}}</span> {{legacyText}}
+					</ng-container>
+					<ng-template #batchTextBlock>
+						<span *ngIf="n === 1">{{_batchTextSingle.subject | async}}</span>
+						<span *ngIf="n !== 1">{{_batchTextMultiple.subject | i18nReplace: {count: n} | async}}</span>
+					</ng-template>
 				</p>
 			</div>
 		</div>
@@ -77,8 +82,7 @@ export class TableToolbar {
 			this._batchTextMultiple.override(value.MULTIPLE);
 		} else {
 			// For compatibility with old code
-			this._batchTextSingle.override(`1 ${value}`);
-			this._batchTextMultiple.override(`{{count}} ${value}`);
+			this._batchTextLegacy.override(value);
 		}
 	}
 	@Input() set ariaLabel (value: { ACTION_BAR: string }) {
@@ -94,6 +98,7 @@ export class TableToolbar {
 
 	actionBarLabel: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.ACTION_BAR");
 	_cancelText: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.CANCEL");
+	_batchTextLegacy: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT");
 	_batchTextSingle: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT_SINGLE");
 	_batchTextMultiple: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT_MULTIPLE");
 

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -58,8 +58,9 @@ import { I18n, Overridable } from "../../i18n/i18n.module";
 				<button ibmButton="primary" class="bx--batch-summary__cancel" (click)="onCancel()">{{_cancelText.subject | async}}</button>
 			</div>
 			<div class="bx--batch-summary">
-				<p class="bx--batch-summary__para">
-					<span>{{count}}</span> {{_batchText.subject | async}}
+				<p class="bx--batch-summary__para" *ngIf="count as n">
+					<span *ngIf="n === 1">{{_batchTextSingle.subject | async}}</span>
+					<span *ngIf="n !== 1">{{_batchTextMultiple.subject | i18nReplace: {count: n} | async}}</span>
 				</p>
 			</div>
 		</div>
@@ -70,8 +71,15 @@ import { I18n, Overridable } from "../../i18n/i18n.module";
 export class TableToolbar {
 	@Input() model: TableModel;
 
-	@Input() set batchText (value: string) {
-		this._batchText.override(value);
+	@Input() set batchText (value: string | { SINGLE: string, MULTIPLE: string }) {
+		if (typeof value === "object") {
+			this._batchTextSingle.override(value.SINGLE);
+			this._batchTextMultiple.override(value.MULTIPLE);
+		} else {
+			// For compatibility with old code
+			this._batchTextSingle.override(`1 ${value}`);
+			this._batchTextMultiple.override(`{{count}} ${value}`);
+		}
 	}
 	@Input() set ariaLabel (value: { ACTION_BAR: string }) {
 		this.actionBarLabel.override(value.ACTION_BAR);
@@ -86,7 +94,8 @@ export class TableToolbar {
 
 	actionBarLabel: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.ACTION_BAR");
 	_cancelText: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.CANCEL");
-	_batchText: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT");
+	_batchTextSingle: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT_SINGLE");
+	_batchTextMultiple: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT_MULTIPLE");
 
 	constructor(protected i18n: I18n) {}
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1186

Improve batch text handling to properly handle single/multiple items and also translations.

Example:

![image](https://user-images.githubusercontent.com/34791554/79076747-90a21200-7cca-11ea-91f1-d5078e9bda67.png)
