### PR TITLE
Make rendering of helper text for the label component consistent with…

### DIFF
--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -44,7 +44,7 @@ import { TextArea } from "./text-area.directive";
 			}">
 			<ng-content></ng-content>
 		</label>
-		<div *ngIf="!skeleton" class="bx--form__helper-text">{{helperText}}</div>
+		<div *ngIf="!skeleton && helperText" class="bx--form__helper-text">{{helperText}}</div>
 		<div [class]="wrapperClass" [attr.data-invalid]="(invalid ? true : null)" #wrapper>
 			<ibm-icon-warning-filled16
 				*ngIf="invalid"


### PR DESCRIPTION
… other components

Closes IBM/carbon-components-angular#1192

The label component seems to be the outlier here - all other components only render a div for the helper text if the value of helperText is truthy - updated to make consistent with other components.

