### PR TITLE
Update header.component.ts

### DIFF
--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -27,7 +27,7 @@ import { I18n } from "../../i18n/i18n.module";
 			role="banner"
 			[attr.aria-label]="brand + ' ' + name">
 			<a
-				*ngIf="!skipTo"
+				*ngIf="skipTo"
 				class="bx--skip-to-content"
 				[href]="skipTo"
 				tabindex="0">


### PR DESCRIPTION
Updating `ngIf` directive to use the correct condition for the `skipTo` anchor

Closes IBM/carbon-components-angular#980

The `ngIf` directive's condition should be the opposite.

Currently it is:
```
*ngIf="!skipTo"
```

It should be:
```
*ngIf="skipTo"
```

The way it is currently coded, I get the anchor by not including the `skipTo` attribute/prop (or by defining it with a falsey value). As soon as I pass a value to the `skipTo` input, the anchor isn't rendered because it no longer meets the condition.
