### PR TITLE
fix(combobox): prevent search results from being cleared when new items are added

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -64,7 +64,7 @@ import { Observable } from "rxjs";
 					(keydown.enter)="clearSelected()"
 					role="button"
 					class="bx--tag--filter bx--list-box__selection--multi"
-          tabindex="0"
+					tabindex="0"
 					[title]="clearSelectionsTitle"
 					[attr.aria-label]="clearSelectionAria">
 					{{ pills.length }}
@@ -347,6 +347,9 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 	ngOnChanges(changes) {
 		if (changes.items) {
 			this.view.items = changes.items.currentValue;
+			// If new items are added into the combobox while there is search input, this
+			// prevents the search results from being cleared once the new items are added.
+			this.onSearch(this.input.nativeElement.value);
 			this.updateSelected();
 		}
 	}

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -352,8 +352,8 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 	ngOnChanges(changes) {
 		if (changes.items) {
 			this.view.items = changes.items.currentValue;
-			// If new items are added into the combobox while there is search input, this
-			// prevents the search results from being cleared once the new items are added.
+			// If new items are added into the combobox while there is search input,
+			// repeat the search.
 			this.onSearch(this.input.nativeElement.value);
 			this.updateSelected();
 		}

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -4,6 +4,7 @@ import { withKnobs, text, boolean } from "@storybook/addon-knobs/angular";
 
 import { ComboBoxModule } from "./combobox.module";
 import { DocumentationModule } from "./../documentation-component/documentation.module";
+import { Component, AfterViewInit } from "@angular/core";
 
 const getOptions = (override = {}) => {
 	const options = {
@@ -33,9 +34,56 @@ const getOptions = (override = {}) => {
 	return Object.assign({}, options, override);
 };
 
+@Component({
+	selector: "app-dynamic-list-combobox",
+	template: `
+		<ibm-combo-box
+			[(items)]="items"
+			type="multi"
+			(selected)="updateSelected($event)">
+			<ibm-dropdown-list></ibm-dropdown-list>
+		</ibm-combo-box>
+	`
+})
+class DynamicListComboBox implements AfterViewInit {
+	items = [
+		{
+			content: "one"
+		},
+		{
+			content: "two"
+		},
+		{
+			content: "three"
+		},
+		{
+			content: "four"
+		}
+	];
+
+	updateSelected(event) {
+		this.items.forEach((item: any) => {
+			if (event.some(selectedItem => selectedItem.content === item.content)) {
+				item.selected = true;
+			} else {
+				item.selected = false;
+			}
+		});
+	}
+
+	ngAfterViewInit() {
+		setInterval(() => {
+			const newItems = JSON.parse(JSON.stringify(this.items));
+			newItems.push({ content: `New ${newItems.length}` });
+			this.items = newItems;
+		}, 4000);
+	}
+}
+
 storiesOf("Components|Combobox", module)
 	.addDecorator(
 		moduleMetadata({
+			declarations: [DynamicListComboBox],
 			imports: [
 				ComboBoxModule,
 				DocumentationModule
@@ -58,6 +106,11 @@ storiesOf("Components|Combobox", module)
 			</ibm-combo-box>
 		`,
 		props: getOptions()
+	}))
+	.add("Dynamically added list items", () => ({
+		template: `
+			<app-dynamic-list-combobox></app-dynamic-list-combobox>
+		`
 	}))
 	.add("With dynamic search", () => ({
 		template: `


### PR DESCRIPTION
This will prevent the search results from being cleared when new items are added into the combobox after it has been initialized. Also added a storybook example for updating the selected items. @Pablodotnet 
