### PR TITLE
fix(overflow-menu): prevent tabIndex from being set on focus element if it doesn't exist

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -130,8 +130,10 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 				button.tabIndex = -1;
 			}
 		});
-		focusElementList[0].tabIndex = 0;
-		focusElementList[0].focus();
+		if (focusElementList[0]) {
+			focusElementList[0].tabIndex = 0;
+			focusElementList[0].focus();
+		}
 	}
 
 	protected listItems() {


### PR DESCRIPTION
Closes #1152 
