### PR TITLE
fix: prevent ibm-modal to throw errors if hasScrollingContent has not been set

### DIFF
--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -216,7 +216,7 @@ export class Modal implements AfterViewInit, OnChanges {
 	 * Use the `hasScrollingContent` input to manually override the overflow indicator.
 	 */
 	get shouldShowScrollbar() {
-		const modalContent = this.modal.nativeElement.querySelector(".bx--modal-content");
+		const modalContent = this.modal ? this.modal.nativeElement.querySelector(".bx--modal-content") : null;
 		if (modalContent) {
 			const modalContentHeight = modalContent.getBoundingClientRect().height;
 			const modalContentScrollHeight = modalContent.scrollHeight;


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1220

Adding an in-line if to prevent accessing `nativeContent` of `undefined`
