### PR TITLE
fix: manually call onTouched on focus out

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -8,7 +8,8 @@ import {
 	Input,
 	Output,
 	ViewChild,
-	HostBinding
+	HostBinding,
+	HostListener
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 
@@ -307,6 +308,11 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 */
 	public registerOnTouched(fn: any) {
 		this.onTouched = fn;
+	}
+
+	@HostListener("focusout")
+	focusOut() {
+		this.onTouched();
 	}
 
 	/**

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -4,7 +4,8 @@ import {
 	HostBinding,
 	EventEmitter,
 	Output,
-	TemplateRef
+	TemplateRef,
+	HostListener
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 
@@ -226,6 +227,11 @@ export class NumberComponent implements ControlValueAccessor {
 	 */
 	public registerOnTouched(fn: any) {
 		this.onTouched = fn;
+	}
+
+	@HostListener("focusout")
+	focusOut() {
+		this.onTouched();
 	}
 
 	/**

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -200,6 +200,7 @@ export class Search implements ControlValueAccessor {
 
 	@HostListener("focusout", ["$event"])
 	focusOut(event) {
+		this.onTouched();
 		if (this.toolbar &&
 			this.inputRef.nativeElement.value === "" &&
 			event.relatedTarget === null) {

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -195,8 +195,8 @@ export class Select implements ControlValueAccessor {
 	/**
 	 * Listens for the host blurring, and notifies the model
 	 */
-	@HostListener("blur")
-	blur() {
+	@HostListener("focusout")
+	focusOut() {
 		this.onTouchedHandler();
 	}
 

--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -95,8 +95,8 @@ export class TimePicker implements ControlValueAccessor {
 		this.valueChange.emit(event.target.value);
 	}
 
-	@HostListener("blur")
-	blur() {
+	@HostListener("focusout")
+	focusOut() {
 		this.onTouchedHandler();
 	}
 


### PR DESCRIPTION
Closes #1201 

Also makes sure that any other component implementing `ControlValueAccessor` calls `onTouched` on focus out.
