### PR TITLE
fix(list): check that parentElement exists before trying to manipulate properties on it

### DIFF
--- a/src/list/list.directive.ts
+++ b/src/list/list.directive.ts
@@ -26,7 +26,7 @@ export class List {
 	}
 
 	@HostBinding("class.bx--list--nested") get nested() {
-		return this.elementRef.nativeElement.parentElement.tagName === "LI";
+		return (this.elementRef.nativeElement.parentElement && this.elementRef.nativeElement.parentElement.tagName === "LI");
 	}
 
 	constructor(protected elementRef: ElementRef) {}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1236

Fixes lists needing native HTML element wrappers when being used inside components like `ibm-accordion`

#### Changelog

**Changed**

* Check that the element has a parent before trying to check the tag name of the parent

