### PR TITLE
fix(datepicker): add missing icon in the datepicker

### DIFF
--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -38,7 +38,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[id]= "id"
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
-						<svg ibmiIconCalendar size="16" class="bx--date-picker__icon"></svg>
+						<svg ibmIconCalendar size="16" class="bx--date-picker__icon"></svg>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
 					<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1238

I did not do any local tests (I did the change online without a local dev env), but checked the netlify preview and it now shows the icon as expected.