### PR TITLE
fix(data-table): Fix table focus/tabindex handling

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -614,9 +614,11 @@ export class Table implements AfterViewInit, OnDestroy {
 
 			// if the model has just initialized don't focus or reset anything
 			if (previousRow === -1 || previousColumn === -1) { return; }
-
-			const previousElement = tableAdapter.getCell(previousRow, previousColumn);
-			Table.setTabIndex(previousElement, -1);
+			// Make the previous cell unfocusable (if it's not the current)
+			if (previousRow !== currentRow || previousColumn !== currentColumn) {
+				const previousElement = tableAdapter.getCell(previousRow, previousColumn);
+				Table.setTabIndex(previousElement, -1);
+			}
 			Table.focus(currentElement);
 		});
 		// call this after assigning `this.interactionModel` since it depends on it

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -156,27 +156,27 @@ storiesOf("Components|Table", module).addDecorator(
 				<h4 ibmTableHeaderTitle>{{title}}</h4>
 				<p ibmTableHeaderDescription>{{description}}</p>
 			</ibm-table-header>
-			<ibm-table-toolbar [model]="model" [batchText]="batchText">
+			<ibm-table-toolbar [model]="model" [batchText]="batchText" #toolbar>
 				<ibm-table-toolbar-actions>
-					<button ibmButton="primary">
+					<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 						Delete
 						<ibm-icon-delete size="16" class="bx--btn__icon"></ibm-icon-delete>
 					</button>
-					<button ibmButton="primary">
+					<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 						Save
 						<ibm-icon-save size="16" class="bx--btn__icon"></ibm-icon-save>
 					</button>
-					<button ibmButton="primary">
+					<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 						Download
 						<ibm-icon-download size="16" class="bx--btn__icon"></ibm-icon-download>
 					</button>
 				</ibm-table-toolbar-actions>
 				<ibm-table-toolbar-content>
 					<ibm-table-toolbar-search [expandable]="true"></ibm-table-toolbar-search>
-					<button ibmButton="ghost" class="toolbar-action">
+					<button ibmButton="ghost" class="toolbar-action" [tabindex]="toolbar.selected ? -1 : 0">
 						<ibm-icon-settings size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
 					</button>
-					<button ibmButton="primary" size="sm">
+					<button ibmButton="primary" size="sm" [tabindex]="toolbar.selected ? -1 : 0">
 						Primary Button
 						<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
 					</button>

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -59,8 +59,7 @@ import { I18n, Overridable } from "../../i18n/index";
 					ibmButton="primary"
 					class="bx--batch-summary__cancel"
 					[tabindex]="selected ? 0 : -1"
-					(click)="onCancel()"
-				>
+					(click)="onCancel()">
 					{{_cancelText.subject | async}}
 				</button>
 			</div>

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -55,7 +55,14 @@ import { I18n, Overridable } from "../../i18n/index";
 			[attr.aria-label]="actionBarLabel.subject | async">
 			<div class="bx--action-list">
 				<ng-content select="ibm-table-toolbar-actions"></ng-content>
-				<button ibmButton="primary" class="bx--batch-summary__cancel" (click)="onCancel()">{{_cancelText.subject | async}}</button>
+				<button
+					ibmButton="primary"
+					class="bx--batch-summary__cancel"
+					[tabindex]="selected ? 0 : -1"
+					(click)="onCancel()"
+				>
+					{{_cancelText.subject | async}}
+				</button>
 			</div>
 			<div class="bx--batch-summary">
 				<p class="bx--batch-summary__para" *ngIf="count as n">


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1242

Fix data table focus/tabindex handling.

- `Table` component incorrectly sets `tabindex` to `-1` when a checkbox cell is clicked, which makes the cell unfocusable. This PR fixes that.

- For `TableToolbar` component, the buttons inside `batch-actions` and the buttons inside `toolbar-content` need to have `tabindex` set to `0` or `-1` properly depending on selection (since only one group of buttons will be shown). Otherwise the buttons may disappear when tabbing into the toolbar (!). Refer below screen shot.

![image](https://user-images.githubusercontent.com/34791554/80669073-81181c80-8a71-11ea-8c74-77de9390ca5d.png)

Carbon React does the same thing: https://github.com/carbon-design-system/carbon/blob/db99425fc9164a8868a006e791fa7d1f116423a1/packages/react/src/components/DataTable/TableBatchActions.js#L53

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
