### PR TITLE
refactor(content-switcher): removes focus host listener

### DIFF
--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -35,7 +35,7 @@ export class ContentSwitcherOption {
 	/**
 	 * Emits when the option is selected.
 	 */
-	@Output() selected = new EventEmitter();
+	@Output() selected = new EventEmitter<boolean>();
 
 	@HostBinding("class") switcherClass = "bx--content-switcher-btn";
 	@HostBinding("class.bx--content-switcher--selected") selectedClass = false;
@@ -47,12 +47,6 @@ export class ContentSwitcherOption {
 
 	@HostListener("click")
 	hostClick() {
-		this.active = true;
-		this.selected.emit(true);
-	}
-
-	@HostListener("focus")
-	onFocus() {
 		this.active = true;
 		this.selected.emit(true);
 	}

--- a/src/content-switcher/content-switcher.component.ts
+++ b/src/content-switcher/content-switcher.component.ts
@@ -45,7 +45,7 @@ export class ContentSwitcher implements AfterViewInit {
 	/**
 	 * Emits the activated `ContentSwitcherOption`
 	 */
-	@Output() selected = new EventEmitter();
+	@Output() selected = new EventEmitter<ContentSwitcherOption>();
 
 	@ContentChildren(ContentSwitcherOption) options: QueryList<ContentSwitcherOption>;
 
@@ -59,7 +59,7 @@ export class ContentSwitcher implements AfterViewInit {
 		}
 		// subscribe to each item, emit when one is selected, and reset the active states
 		this.options.forEach(option => {
-			option.selected.subscribe(_ => {
+			option.selected.subscribe((_: void) => {
 				const active = option;
 				this.options.forEach(option => {
 					if (option !== active) {

--- a/src/content-switcher/content-switcher.stories.ts
+++ b/src/content-switcher/content-switcher.stories.ts
@@ -24,7 +24,7 @@ storiesOf("Components|Content Switcher", module)
 			</ibm-content-switcher>
 		`,
 		props: {
-			selected: action("selection changed")
+			selected: action("selection changed"),
 		}
 	}))
 	.add("Documentation", () => ({

--- a/src/content-switcher/content-switcher.stories.ts
+++ b/src/content-switcher/content-switcher.stories.ts
@@ -24,7 +24,7 @@ storiesOf("Components|Content Switcher", module)
 			</ibm-content-switcher>
 		`,
 		props: {
-			selected: action("selection changed"),
+			selected: action("selection changed")
 		}
 	}))
 	.add("Documentation", () => ({


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1244

Removes focus HostListener from ContentSwitcherOption and adds missing typing to variables.

#### Changelog

**Removed**

* `@HostListener("focus")`
