### PR TITLE
fix(dropdown): add in expanded class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9223,9 +9223,9 @@
       "dev": true
     },
     "carbon-components": {
-      "version": "10.10.3",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.10.3.tgz",
-      "integrity": "sha512-uOHcMvQNtqazCqBxXlIaAU6Jmsb1/wE6fhJ3r6wt69MfW42xjCOVAegXDXylCAk1k6F+DR6cx4WsbYMUjOXR3A==",
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.11.2.tgz",
+      "integrity": "sha512-bclmy7lXH3/GXXh5Udwcup51i+MUDbDle1kUEilRF9e6phkVhn7I+qN7y/xuRfE4PuXsBC7CtMVNEjtnie6Qow==",
       "dev": true,
       "requires": {
         "flatpickr": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"@types/node": "11.13.0",
 		"angular2-template-loader": "0.6.2",
 		"babel-loader": "8.0.5",
-		"carbon-components": "10.10.3",
+		"carbon-components": "10.11.2",
 		"codelyzer": "5.0.0",
 		"commitizen": "4.0.3",
 		"core-js": "2.6.11",

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -43,7 +43,8 @@ import { Observable } from "rxjs";
 		<div
 			[ngClass]="{
 				'bx--multi-select': type === 'multi',
-				'bx--combo-box': type === 'single' || !pills.length
+				'bx--combo-box': type === 'single' || !pills.length,
+				'bx--list-box--expanded': open
 			}"
 			class="bx--combo-box bx--list-box"
 			role="listbox"

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -69,7 +69,8 @@ import { hasScrollableParents } from "../utils";
 			'bx--skeleton': skeleton,
 			'bx--dropdown--disabled bx--list-box--disabled': disabled,
 			'bx--dropdown--invalid': invalid,
-			'bx--list-box--up': dropUp
+			'bx--list-box--up': dropUp,
+			'bx--list-box--expanded': !menuIsClosed
 		}">
 		<div
 			type="button"


### PR DESCRIPTION
`bx--list-box--expanded` class is needed to open the dropdown menu in carbon-components v10.11.2, this PR adds in that class