### PR TITLE
fix(notification-toast): Run setTimeout for notifications with durati…

### DIFF
--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -6,7 +6,8 @@ import {
 	EventEmitter,
 	Injectable,
 	Injector,
-	OnDestroy
+	OnDestroy,
+	NgZone
 } from "@angular/core";
 
 import { NotificationContent, ToastContent } from "./notification-content.interface";
@@ -38,7 +39,8 @@ export class NotificationService implements OnDestroy {
 	constructor(
 		protected injector: Injector,
 		protected componentFactoryResolver: ComponentFactoryResolver,
-		protected applicationRef: ApplicationRef) {
+		protected applicationRef: ApplicationRef,
+		protected ngZone: NgZone) {
 	}
 
 	/**
@@ -104,16 +106,24 @@ export class NotificationService implements OnDestroy {
 		}
 
 		if (notificationObj.duration && notificationObj.duration > 0) {
-			setTimeout(() => {
-				this.close(notificationRef);
-			}, notificationObj.duration);
+			this.ngZone.runOutsideAngular(() => {
+				setTimeout(() => {
+					this.ngZone.run(() => {
+						this.close(notificationRef);
+					});
+				}, notificationObj.duration);
+			});
 		}
 
 		if (notificationObj.smart) {
-			// let it disappear after calculated timeout
-			setTimeout(() => {
-				this.close(notificationRef);
-			}, this.getSmartTimeout(notificationObj));
+			this.ngZone.runOutsideAngular(() => {
+				// let it disappear after calculated timeout
+				setTimeout(() => {
+					this.ngZone.run(() => {
+						this.close(notificationRef);
+					});
+				}, this.getSmartTimeout(notificationObj));
+			});
 		}
 
 		this.onClose.subscribe(() => {


### PR DESCRIPTION
…ons outside of the angular zone

Closes IBM/carbon-components-angular#1257

Run setTimeouts for closing notifications/toasts that have a duration, outside of the angular zone. This will unblock testing frameworks like Protractor that must wait until there are no pending asynchronous tasks (which means content of toasts/notifications are not testable as protractor is unblocked when the notification is closed). 

#### Changelog

**New**

When displaying notifications with a duration set, wrap the setTimeout with `this.ngZone.runOutsideAngular` and then wrap code that runs within the setTimeout callback with `this.ngZone.run` to run within the ngZone again.

Similar to this closed issue: https://github.com/IBM/carbon-components-angular/issues/1029
