### PR TITLE
fix(select): Change @ViewChild static to true

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -145,7 +145,7 @@ export class Select implements ControlValueAccessor {
 	@Output() valueChange = new EventEmitter();
 
 	// @ts-ignore
-	@ViewChild("select", { static: false }) select: ElementRef;
+	@ViewChild("select", { static: true }) select: ElementRef;
 
 	get value() {
 		return this.select.nativeElement.value;


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Change `@ViewChild` `static` to `true`, since the `select` component has `@Input` setters which will be called in `ngOnChanges`.

```
ERROR TypeError: Cannot read property 'nativeElement' of undefined
    at Select.set value [as value] (carbon-components-angular.js:13207)
    at Select.writeValue (carbon-components-angular.js:13215)
    at setUpControl (forms.js:3186)
    at FormGroupDirective.addControl (forms.js:7345)
    at FormControlName._setUpControl (forms.js:8070)
    at FormControlName.ngOnChanges (forms.js:7993)
    at checkAndUpdateDirectiveInline (core.js:31906)
    at checkAndUpdateNodeInline (core.js:44367)
    at checkAndUpdateNode (core.js:44306)
    at debugCheckAndUpdateNode (core.js:45328)
```

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
