### PR TITLE
fix(table-toolbar): prevent error on search focusOut

### DIFF
--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -202,6 +202,7 @@ export class Search implements ControlValueAccessor {
 	focusOut(event) {
 		this.onTouched();
 		if (this.toolbar &&
+			this.inputRef &&
 			this.inputRef.nativeElement.value === "" &&
 			event.relatedTarget === null) {
 			this.active = false;


### PR DESCRIPTION
Closes #1233 

I was unable to reproduce the issue locally, this PR adds in a guard that should prevent such an error from coming up.
