### PR TITLE
feat(header): add option to use angular router attributes instead of events

### DIFF
--- a/src/ui-shell/header/header-item.component.ts
+++ b/src/ui-shell/header/header-item.component.ts
@@ -15,14 +15,24 @@ import { Router } from "@angular/router";
 	selector: "ibm-header-item",
 	template: `
 		<li style="height: 100%">
-			<a
-				class="bx--header__menu-item"
-				role="menuitem"
-				tabindex="0"
-				[href]="href"
-				(click)="navigate($event)">
-				<ng-content></ng-content>
-			</a>
+			<ng-container [ngSwitch]="useRouter">
+				<a *ngSwitchCase="false"
+				   class="bx--header__menu-item"
+				   role="menuitem"
+				   tabindex="0"
+				   [href]="href"
+				   (click)="navigate($event)">
+					<ng-content></ng-content>
+				</a>
+				<a *ngSwitchCase="true"
+				   class="bx--header__menu-item"
+				   role="menuitem"
+				   tabindex="0"
+				   [routerLink]="route"
+				   [routerLinkActive]="activeLinkClass">
+					<ng-content></ng-content>
+				</a>
+			</ng-container>
 		</li>
 	`
 })
@@ -38,6 +48,16 @@ export class HeaderItem {
 	get href() {
 		return this.domSanitizer.bypassSecurityTrustUrl(this._href) as string;
 	}
+
+	/**
+	 * Use the routerLink attribute on <a> tag for navigation instead of using event handlers
+	 */
+	@Input() useRouter: boolean = false;
+
+	/**
+	 * String or array of string class names to apply when active
+	 */
+	@Input() activeLinkClass: string | string[];
 
 	/**
 	 * Array of commands to send to the router when the link is activated

--- a/src/ui-shell/header/header-item.component.ts
+++ b/src/ui-shell/header/header-item.component.ts
@@ -16,13 +16,14 @@ import { Router } from "@angular/router";
 	template: `
 		<li style="height: 100%">
 			<ng-container [ngSwitch]="useRouter">
+				<ng-template #content><ng-content></ng-content></ng-template>
 				<a *ngSwitchCase="false"
 				   class="bx--header__menu-item"
 				   role="menuitem"
 				   tabindex="0"
 				   [href]="href"
 				   (click)="navigate($event)">
-					<ng-content></ng-content>
+					<ng-container *ngTemplateOutlet="content"></ng-container>
 				</a>
 				<a *ngSwitchCase="true"
 				   class="bx--header__menu-item"
@@ -30,7 +31,7 @@ import { Router } from "@angular/router";
 				   tabindex="0"
 				   [routerLink]="route"
 				   [routerLinkActive]="activeLinkClass">
-					<ng-content></ng-content>
+					<ng-container *ngTemplateOutlet="content"></ng-container>
 				</a>
 			</ng-container>
 		</li>

--- a/src/ui-shell/header/header.component.spec.ts
+++ b/src/ui-shell/header/header.component.spec.ts
@@ -5,6 +5,7 @@ import { By } from "@angular/platform-browser";
 import { I18nModule } from "../../i18n/index";
 import { Header } from "./header.component";
 import { Hamburger } from "../index";
+import {RouterModule} from "@angular/router";
 
 /**
  * Testing component for projecting an ibm-hamburger component
@@ -28,7 +29,7 @@ describe("UI Shell Header", () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			declarations: [Hamburger, HamburgerTest, Header],
-			imports: [I18nModule],
+			imports: [I18nModule, RouterModule],
 			providers: []
 		});
 

--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -38,14 +38,23 @@ import { I18n } from "../../i18n/index";
 				*ngIf="isTemplate(brand)"
 				[ngTemplateOutlet]="brand">
 			</ng-template>
-			<a
-				*ngIf="!isTemplate(brand)"
-				class="bx--header__name"
-				[href]="href"
-				(click)="navigate($event)">
-				<span class="bx--header__name--prefix">{{brand}}&nbsp;</span>
-				{{name}}
-			</a>
+			<ng-container *ngIf="!isTemplate(brand)" [ngSwitch]="useRouter">
+				<a
+					*ngSwitchCase="false"
+					class="bx--header__name"
+					[href]="href"
+					(click)="navigate($event)">
+					<span class="bx--header__name--prefix">{{brand}}&nbsp;</span>
+					{{name}}
+				</a>
+				<a
+					*ngSwitchCase="true"
+					class="bx--header__name"
+					[routerLink]="route">
+					<span class="bx--header__name--prefix">{{brand}}&nbsp;</span>
+					{{name}}
+				</a>
+			</ng-container>
 			<ng-content></ng-content>
 		</header>
 	`
@@ -85,6 +94,11 @@ export class Header {
 	 * See: https://angular.io/api/router/Router#navigate
 	 */
 	@Input() routeExtras: any;
+
+	/**
+	 * Use the routerLink attribute on <a> tag for navigation instead of using event handlers
+	 */
+	@Input() useRouter: boolean = false;
 
 	/**
 	 * Emits the navigation status promise when the link is activated

--- a/src/ui-shell/header/header.module.ts
+++ b/src/ui-shell/header/header.module.ts
@@ -13,6 +13,7 @@ import { HeaderGlobal } from "./header-global.component";
 import { HeaderAction } from "./header-action.component";
 
 import { Hamburger } from "./hamburger.component";
+import {RouterModule} from "@angular/router";
 
 export { HeaderItemInterface, NavigationItem } from "./header-navigation-items.interface";
 
@@ -36,12 +37,13 @@ export {
 		HeaderAction,
 		Hamburger
 	],
-	imports: [
-		CommonModule,
-		I18nModule,
-		CloseModule,
-		MenuModule
-	],
+    imports: [
+        CommonModule,
+        I18nModule,
+        CloseModule,
+        MenuModule,
+        RouterModule
+    ],
 	exports: [
 		Header,
 		HeaderItem,

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -442,6 +442,26 @@ storiesOf("Components|UI Shell", module)
 			]
 		}
 	}))
+	.add("Use angular router attributes for routing", () => (
+		{
+			template: `
+			<ibm-header name="[Platform]" [route]="['bar']" [useRouter]="true">
+				<ibm-header-navigation>
+					<ibm-header-item [route]="['foo']" [useRouter]="true" [activeLinkClass]="'item--active'">Catalog</ibm-header-item>
+					<ibm-header-item [route]="['bar']" [useRouter]="true" [activeLinkClass]="['item--active', 'another-class']">Docs</ibm-header-item>
+					<ibm-header-item [route]="['foo']" [useRouter]="true">Support</ibm-header-item>
+					<ibm-header-menu title="Manage">
+						<ibm-header-item [route]="['foo']" [useRouter]="true">Link 1</ibm-header-item>
+						<ibm-header-item [route]="['bar']" [useRouter]="true">Link 2</ibm-header-item>
+						<ibm-header-item [route]="['foo']" [useRouter]="true">Link 3</ibm-header-item>
+					</ibm-header-menu>
+				</ibm-header-navigation>
+			</ibm-header>
+			<div style="margin-top: 2rem">
+				<router-outlet></router-outlet>
+			</div>`
+		}
+	))
 	.add("Header Documentation", () => ({
 		template: `
 			<ibm-documentation src="documentation/components/Header.html"></ibm-documentation>


### PR DESCRIPTION
This PR is to address a conversation I had with @cal-smith over on slack #carbon-ng. Per that conversation I tried using the `href` and `route` attributes to allow a user to right click and open in new tab. The primary issue we ran into with that was the active status of the link was no longer being tracked. 

TLDR; this adds a flag on the `ibm-header` and `ibm-header-item` that uses the `@angular/router` `routerLink` and `routerLinkActive` attributes on a standard `<a>` tag.

I don't know if this falls under the direction you all have for the project or if it's the desired way to implement it.

#### Changelog

**New**

* add `useRouter` input to `ibm-header` and `ibm-header-item` that changes the template to use angular router's attributes
