### PR TITLE
fix(dropdown): moved expanded class as HostBind; added guard for boxMenu in dropdown service

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -69,8 +69,7 @@ import { hasScrollableParents } from "../utils";
 			'bx--skeleton': skeleton,
 			'bx--dropdown--disabled bx--list-box--disabled': disabled,
 			'bx--dropdown--invalid': invalid,
-			'bx--list-box--up': dropUp,
-			'bx--list-box--expanded': !menuIsClosed
+			'bx--list-box--up': dropUp
 		}">
 		<div
 			type="button"

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -69,7 +69,8 @@ import { hasScrollableParents } from "../utils";
 			'bx--skeleton': skeleton,
 			'bx--dropdown--disabled bx--list-box--disabled': disabled,
 			'bx--dropdown--invalid': invalid,
-			'bx--list-box--up': dropUp
+			'bx--list-box--up': dropUp,
+			'bx--list-box--expanded': !menuIsClosed
 		}">
 		<div
 			type="button"
@@ -619,7 +620,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		this.dropdownService.appendToBody(
 			this.dropdownButton.nativeElement,
 			this.dropdownMenu.nativeElement,
-			this.elementRef.nativeElement.className);
+			`${this.elementRef.nativeElement.className}${!this.menuIsClosed ? " bx--list-box--expanded" : ""}`);
 		this.dropdownMenu.nativeElement.addEventListener("keydown", this.keyboardNav, true);
 	}
 

--- a/src/dropdown/dropdown.service.ts
+++ b/src/dropdown/dropdown.service.ts
@@ -111,22 +111,24 @@ export class DropdownService implements OnDestroy {
 
 		const boxMenu = menuRef.querySelector(".bx--list-box__menu");
 
-		// If the parentRef and boxMenu are in a different left position relative to the
-		// window, the the boxMenu position has already been flipped and a check needs to be done
-		// to see if it needs to stay flipped.
-		if (parentRef.getBoundingClientRect().left !== boxMenu.getBoundingClientRect().left) {
-			// The getBoundingClientRect().right of the boxMenu if it were hypothetically flipped
-			// back into the original position before the flip.
-			const testBoxMenuRightEdgePos =
-				parentRef.getBoundingClientRect().left - boxMenu.getBoundingClientRect().left + boxMenu.getBoundingClientRect().right;
+		if (boxMenu) {
+			// If the parentRef and boxMenu are in a different left position relative to the
+			// window, the the boxMenu position has already been flipped and a check needs to be done
+			// to see if it needs to stay flipped.
+			if (parentRef.getBoundingClientRect().left !== boxMenu.getBoundingClientRect().left) {
+				// The getBoundingClientRect().right of the boxMenu if it were hypothetically flipped
+				// back into the original position before the flip.
+				const testBoxMenuRightEdgePos =
+					parentRef.getBoundingClientRect().left - boxMenu.getBoundingClientRect().left + boxMenu.getBoundingClientRect().right;
 
-			if (testBoxMenuRightEdgePos > (window.innerWidth || document.documentElement.clientWidth)) {
+				if (testBoxMenuRightEdgePos > (window.innerWidth || document.documentElement.clientWidth)) {
+					leftOffset = parentRef.offsetWidth - boxMenu.offsetWidth;
+				}
+			// If it has not already been flipped, check if it is necessary to flip, ie. if the
+			// boxMenu is outside of the right viewPort.
+			} else if (boxMenu.getBoundingClientRect().right > (window.innerWidth || document.documentElement.clientWidth)) {
 				leftOffset = parentRef.offsetWidth - boxMenu.offsetWidth;
 			}
-		// If it has not already been flipped, check if it is necessary to flip, ie. if the
-		// boxMenu is outside of the right viewPort.
-		} else if (boxMenu.getBoundingClientRect().right > (window.innerWidth || document.documentElement.clientWidth)) {
-			leftOffset = parentRef.offsetWidth - boxMenu.offsetWidth;
 		}
 
 		let pos = position.findAbsolute(parentRef, menuRef, "bottom");

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -9,7 +9,8 @@ import {
 	ViewChild,
 	ElementRef,
 	ViewChildren,
-	QueryList
+	QueryList,
+	HostBinding
 } from "@angular/core";
 import { Observable, isObservable, Subscription, of } from "rxjs";
 import { first } from "rxjs/operators";
@@ -163,6 +164,8 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	 * item selection.
 	 */
 	@Input() type: "single" | "multi" = "single";
+
+	@HostBinding("class.bx--list-box--expanded") hostClass = true;
 	/**
 	 * Defines the rendering size of the `DropdownList` input component.
 	 *

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -9,8 +9,7 @@ import {
 	ViewChild,
 	ElementRef,
 	ViewChildren,
-	QueryList,
-	HostBinding
+	QueryList
 } from "@angular/core";
 import { Observable, isObservable, Subscription, of } from "rxjs";
 import { first } from "rxjs/operators";
@@ -164,8 +163,6 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	 * item selection.
 	 */
 	@Input() type: "single" | "multi" = "single";
-
-	@HostBinding("class.bx--list-box--expanded") hostClass = true;
 	/**
 	 * Defines the rendering size of the `DropdownList` input component.
 	 *


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1276

Moved the `bx--list-box--expanded` class as HostBind of the DropdownList so that it will cover in one place both append inline and append to body cases. Also added `null` guard for boxMenu in the DropdownService to avoid console errors.

#### Changelog

**Changed**

* `bx--list-box--expanded` is now added as HostBind of the DropdownList component
* added guard for boxMenu in DropdownService
