### PR TITLE
feature(inline-loading): Added `state` property and error state style.

### DIFF
--- a/src/inline-loading/inline-loading.component.ts
+++ b/src/inline-loading/inline-loading.component.ts
@@ -6,6 +6,19 @@ import {
 	HostBinding
 } from "@angular/core";
 
+export enum InlineLoadingState {
+	/** It hides the whole component. */
+	Hidden = "hidden",
+	/** It shows the `loadingText` but no loading animation. */
+	Inactive = "inactive",
+	/** It shows the `loadingText` with loading animation. */
+	Active = "active",
+	/** It shows the `successText` with a success state. */
+	Finished = "finished",
+	/** It shows the `errorText` with an error state. */
+	Error = "error"
+}
+
 /**
  * [See demo](../../?path=/story/inline-loading--basic)
  *
@@ -14,12 +27,13 @@ import {
 @Component({
 	selector: "ibm-inline-loading",
 	template: `
-		<div class="bx--inline-loading__animation">
+		<div *ngIf="state !== InlineLoadingState.Hidden"
+			class="bx--inline-loading__animation">
 			<div
-				*ngIf="success === false"
+				*ngIf="state === InlineLoadingState.Inactive || state === InlineLoadingState.Active"
 				class="bx--loading bx--loading--small"
 				[ngClass]="{
-					'bx--loading--stop': !isActive
+					'bx--loading--stop': state === InlineLoadingState.Inactive
 				}">
 				<svg class="bx--loading__svg" viewBox="-75 -75 150 150">
 					<circle class="bx--loading__background" cx="0" cy="0" r="30" />
@@ -27,47 +41,74 @@ import {
 				</svg>
 			</div>
 			<svg
-				*ngIf="success === true"
+				*ngIf="state === InlineLoadingState.Finished"
 				class="bx--inline-loading__checkmark-container bx--inline-loading__svg"
 				xmlns="http://www.w3.org/2000/svg"
 				viewBox="0 0 10 10">
 				<polyline class="bx--inline-loading__checkmark" points="0.74 3.4 3.67 6.34 9.24 0.74"></polyline>
 			</svg>
+			<svg
+				*ngIf="state === InlineLoadingState.Error"
+				class="bx--inline-loading--error"
+				xmlns="http://www.w3.org/2000/svg"
+				viewBox="0 0 16 16">
+				<path d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z"></path>
+				<path fill="none" d="M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z" data-icon-path="inner-path" opacity="0"></path>
+			</svg>
+
 		</div>
-		<p *ngIf="success === false" class="bx--inline-loading__text">{{loadingText}}</p>
-		<p *ngIf="success === true" class="bx--inline-loading__text">{{successText}}</p>
+		<p
+			*ngIf="state === InlineLoadingState.Inactive || state === InlineLoadingState.Active"
+			class="bx--inline-loading__text">{{loadingText}}</p>
+		<p *ngIf="state === InlineLoadingState.Finished" class="bx--inline-loading__text">{{successText}}</p>
+		<p *ngIf="state === InlineLoadingState.Error" class="bx--inline-loading__text">{{errorText}}</p>
 	`
 })
 export class InlineLoading {
+	InlineLoadingState = InlineLoadingState;
+
 	/**
 	 * Specify the text description for the loading state.
 	 */
-	@Input() loadingText;
+	@Input() state: InlineLoadingState = InlineLoadingState.Active;
+	/**
+	 * Specify the text description for the loading state.
+	 */
+	@Input() loadingText: string;
 	/**
 	 * Specify the text description for the success state.
 	 */
-	@Input() successText;
+	@Input() successText: string;
 	/**
 	 * Provide a delay for the `setTimeout` for success.
 	 */
 	@Input() successDelay = 1500;
 	/**
+	 * Specify the text description for the error state.
+	 */
+	@Input() errorText: string;
+	/**
 	 * set to `false` to stop the loading animation
 	 */
-	@Input() isActive = true;
+	@Input() get isActive() {
+		return this.state === InlineLoadingState.Active;
+	}
+	set isActive(active: boolean) {
+		this.state = active ? InlineLoadingState.Active : InlineLoadingState.Inactive;
+	}
 
 	/**
 	 * Returns value `true` if the component is in the success state.
 	 */
 	@Input() get success() {
-		return this._success;
+		return this.state === InlineLoadingState.Finished;
 	}
 	/**
 	 * Set the component's state to match the parameter and emits onSuccess if it exits.
 	 */
-	set success (success: boolean) {
-		this._success = success;
-		if (this._success) {
+	set success(success: boolean) {
+		this.state = success ? InlineLoadingState.Finished : InlineLoadingState.Error;
+		if (this.state === InlineLoadingState.Finished) {
 			setTimeout(() => {
 				this.onSuccess.emit();
 			}, this.successDelay);
@@ -80,9 +121,4 @@ export class InlineLoading {
 	@Output() onSuccess: EventEmitter<any> = new EventEmitter();
 
 	@HostBinding("class.bx--inline-loading") loadingClass = true;
-
-	/**
-	 * Set to `true` if the action is completed successfully.
-	 */
-	protected _success = false;
 }

--- a/src/inline-loading/inline-loading.stories.ts
+++ b/src/inline-loading/inline-loading.stories.ts
@@ -2,24 +2,64 @@ import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { action } from "@storybook/addon-actions";
 import { withKnobs, text, object } from "@storybook/addon-knobs/angular";
 
-import { InlineLoadingModule, ButtonModule, DocumentationModule } from "../";
+import { InlineLoadingModule, ButtonModule, PaginationModel } from "../";
+import { DocumentationModule } from "../documentation-component/documentation.module";
+import { InlineLoadingState } from "./inline-loading.component";
+import { Component, OnInit, Input } from "@angular/core";
+
+@Component({
+	selector: "app-inline-loading",
+	template: `
+		<ibm-inline-loading
+			[state]="state"
+			[loadingText]="loadingText"
+			[successText]="successText"
+			[errorText]="errorText"
+			(onSuccess)="onSuccess($event)">
+		</ibm-inline-loading>
+		<button ibmButton (click)="toggleState()">Toggle state</button>
+		<p>State: {{ state }}</p>
+	`
+})
+class InlineLoadingStory implements OnInit {
+	@Input() loadingText = "";
+	@Input() successText = "";
+	@Input() errorText = "";
+
+	state = InlineLoadingState.Active;
+
+	toggleState() {
+		switch (this.state) {
+			case InlineLoadingState.Inactive: this.state = InlineLoadingState.Active; break;
+			case InlineLoadingState.Active: this.state = InlineLoadingState.Finished; break;
+			case InlineLoadingState.Finished: this.state = InlineLoadingState.Error; break;
+			case InlineLoadingState.Error: this.state = InlineLoadingState.Inactive; break;
+		}
+	}
+}
 
 storiesOf("Components|Inline Loading", module)
 	.addDecorator(
 		moduleMetadata({
+			declarations: [InlineLoadingStory],
 			imports: [InlineLoadingModule, ButtonModule, DocumentationModule]
 		})
 	)
 	.addDecorator(withKnobs)
 	.add("Basic", () => ({
 		template: `
-			<ibm-inline-loading #loading (onSuccess)="onSuccess()" [loadingText]="loadingText" [successText]="successText"></ibm-inline-loading>
-			<button ibmButton (click)="loading.success = !loading.success">Toggle state</button>
+			<app-inline-loading
+				#loading
+				(onSuccess)="onSuccess()"
+				[loadingText]="loadingText"
+				[successText]="successText"
+				[errorText]="errorText"></app-inline-loading>
 		`,
 		props: {
 			onSuccess: action("onSuccess"),
 			loadingText: text("The loading text", "Loading data..."),
-			successText: text("The success text", "Data loaded.")
+			successText: text("The success text", "Data loaded."),
+			errorText: text("The error text", "Data not found.")
 		}
 	}))
 	.add("Documentation", () => ({


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1278

Streamlined component's state management to a single `state` property as opposed to the 2 flags `isActive` and `success`.

#### Changelog

**New**

* Added a `@Input() state: InlineLoadingState` property to better handle the different states of the inline loading component.
* Added `errorText: string` for the error text styling.

**Changed**

* Changed `isActive` and `success` to derive from `state` for backward compatibility.

**Removed**

* Removed `_success` in favor of `state`
