### PR TITLE
Tag Filter close icon requires a class selector for latest Carbon

### DIFF
--- a/src/tag/tag-filter.component.ts
+++ b/src/tag/tag-filter.component.ts
@@ -14,6 +14,7 @@ import { Tag } from "./tag.component";
 			(click)="close.emit()"
 			focusable="false"
 			preserveAspectRatio="xMidYMid meet"
+			class="bx--tag__close-icon"
 			style="will-change: transform;"
 			xmlns="http://www.w3.org/2000/svg"
 			aria-label="Clear filter"


### PR DESCRIPTION
Added `bx--tag__close-icon` class to `svg` element to align w/latest from Carbon: https://github.com/carbon-design-system/carbon/blob/09348e65d26e32a92dca4e60a09caff87843575d/packages/components/src/components/tag/_tag.scss#L156

The selector `bx--tag--filter>svg` is no longer present in the latest from Carbon. They opted for using a class selector on the `svg` element.

#### Note
The latest docs from Carbon don't seem to reflect this change... I'm not sure if that is because the docs haven't yet been updated, but they should. For example, the tag filter section here no longer appears to be correct (unless I'm missing something): https://the-carbon-components.netlify.app/?nav=tag

I'm using:
    "carbon-components": "^10.10.3",
    "carbon-components-angular": "^4.1.6",