### PR TITLE
feat(inline-loading): Added `state` property and error state style.

### DIFF
--- a/src/inline-loading/inline-loading.component.ts
+++ b/src/inline-loading/inline-loading.component.ts
@@ -70,7 +70,7 @@ export class InlineLoading {
 	/**
 	 * Specify the text description for the loading state.
 	 */
-	@Input() state: InlineLoadingState = InlineLoadingState.Active;
+	@Input() state: InlineLoadingState | string = InlineLoadingState.Active;
 	/**
 	 * Specify the text description for the loading state.
 	 */

--- a/src/inline-loading/inline-loading.spec.ts
+++ b/src/inline-loading/inline-loading.spec.ts
@@ -1,6 +1,6 @@
 import { async, ComponentFixture, TestBed } from "@angular/core/testing";
 
-import { InlineLoading } from "./inline-loading.component";
+import { InlineLoading, InlineLoadingState } from "./inline-loading.component";
 import { I18nModule } from "../i18n/i18n.module";
 
 describe("Inline Loading", () => {
@@ -19,5 +19,19 @@ describe("Inline Loading", () => {
 
 	it("should work", () => {
 		expect(component instanceof InlineLoading).toBe(true);
+	});
+
+	it("should show `finished` state and handle `state` as enum", () => {
+		component.successText = "success text";
+		component.state = InlineLoadingState.Finished;
+		fixture.detectChanges();
+		expect(fixture.nativeElement.innerHTML).toContain(component.successText);
+	});
+
+	it("should show `error` state and handle `state` as a string", () => {
+		component.errorText = "error text";
+		component.state = "error";
+		fixture.detectChanges();
+		expect(fixture.nativeElement.innerHTML).toContain(component.errorText);
 	});
 });


### PR DESCRIPTION
Added handling for the `state` property as a string, following the comment in https://github.com/IBM/carbon-components-angular/pull/1286
Added unit tests.

Closes IBM/carbon-components-angular#1278