### PR TITLE
feat(ellipsis tooltip): refactor ellipsis tooltip and add disabled property for dialog

### DIFF
--- a/src/dialog/dialog-config.interface.ts
+++ b/src/dialog/dialog-config.interface.ts
@@ -57,4 +57,8 @@ export interface DialogConfig {
 	 * This specifies any vertical and horizontal offset for the position of the dialog
 	 */
 	offset?: { x: number, y: number };
+	/**
+	 * This prevents the dialog from being toggled
+	 */
+	disabled?: boolean;
 }

--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -81,6 +81,10 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 
 	@Input() @HostBinding("attr.aria-expanded") isOpen = false;
 	/**
+	 * This prevents the dialog from being toggled
+	 */
+	@Input() disabled = false;
+	/**
 	 * Config object passed to the rendered component
 	 */
 	dialogConfig: DialogConfig;
@@ -144,7 +148,8 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 			shouldClose: () => true,
 			appendInline: this.appendInline,
 			wrapperClass: this.wrapperClass,
-			data: this.data
+			data: this.data,
+			disabled: this.disabled
 		};
 
 		if (changes.isOpen) {
@@ -221,7 +226,7 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	 */
 	open() {
 		// don't allow dialogs to be opened if they're already open
-		if (this.dialogRef) { return; }
+		if (this.dialogRef || this.disabled) { return; }
 
 		// actually open the dialog, emit events, and set the open state
 		this.dialogRef = this.dialogService.open(this.viewContainerRef, this.dialogConfig);

--- a/src/dialog/tooltip/ellipsis-tooltip.directive.ts
+++ b/src/dialog/tooltip/ellipsis-tooltip.directive.ts
@@ -31,6 +31,11 @@ import { Tooltip } from "./tooltip.component";
 	]
 })
 export class EllipsisTooltip extends TooltipDirective {
+	/**
+	 * If text is truncated, this appends the text to the dialog as content.
+	 * @returns null
+	 * @memberof EllipsisTooltip
+	 */
 	updateTooltipContent() {
 		if (this.elementRef.nativeElement.scrollWidth <= this.elementRef.nativeElement.offsetWidth) {
 			this.disabled = true;

--- a/src/dialog/tooltip/ellipsis-tooltip.directive.ts
+++ b/src/dialog/tooltip/ellipsis-tooltip.directive.ts
@@ -5,7 +5,8 @@ import {
 	ElementRef,
 	Injector,
 	ComponentFactoryResolver,
-	ViewContainerRef
+	ViewContainerRef,
+	HostListener
 } from "@angular/core";
 import { TooltipDirective } from "./tooltip.directive";
 import { DialogService } from "./../dialog.service";
@@ -30,17 +31,32 @@ import { Tooltip } from "./tooltip.component";
 	]
 })
 export class EllipsisTooltip extends TooltipDirective {
-	/**
-	 * Toggles tooltip in view if text is truncated.
-	 * @returns null
-	 * @memberof EllipsisTooltip
-	 */
-	toggle() {
+	updateTooltipContent() {
 		if (this.elementRef.nativeElement.scrollWidth <= this.elementRef.nativeElement.offsetWidth) {
+			this.disabled = true;
 			return;
 		}
 
+		this.disabled = false;
 		this.dialogConfig.content = this.elementRef.nativeElement.innerText;
-		super.toggle();
+	}
+
+	@HostListener("click")
+	onClick() {
+		if (this.trigger === "click") {
+			this.updateTooltipContent();
+		}
+	}
+
+	@HostListener("mouseenter")
+	onHover() {
+		if (this.trigger === "hover" || this.trigger === "mouseenter") {
+			this.updateTooltipContent();
+		}
+	}
+
+	@HostListener("focus")
+	onFocus() {
+		this.updateTooltipContent();
 	}
 }

--- a/src/dialog/tooltip/tooltip.stories.ts
+++ b/src/dialog/tooltip/tooltip.stories.ts
@@ -169,6 +169,38 @@ storiesOf("Components|Tooltip", module)
 			isOpen: boolean("isOpen", false)
 		}
 	}))
+	.add("Ellipsis tooltip", () => ({
+		styles: [`
+			.fullText {
+				white-space: nowrap;
+				display: inline-block;
+			}
+			.overflowText {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				width: 100px;
+				display: inline-block;
+			}
+		`],
+		template: `
+			<span
+				class="ellipsis"
+				[ngClass]="{
+					'fullText': showFullText,
+					'overflowText': !showFullText
+				}"
+				trigger="hover"
+				[placement]="'bottom'"
+				ibmEllipsisTooltip>
+					Tooltip for ellipsis because I can and I am really really long
+			</span>
+			<ibm-placeholder></ibm-placeholder>
+		`,
+		props: {
+			showFullText: boolean("Show full text", false)
+		}
+	}))
 	.add("Documentation", () => ({
 		template: `
 			<ibm-documentation src="documentation/directives/TooltipDirective.html"></ibm-documentation>


### PR DESCRIPTION
This allows the ellipsis tooltip to generate the dialog content on hover, previously it only worked when trigger is click. Also prevents an empty tooltip from being generated when there is no overflow.