### PR TITLE
fix(combobox): allow single and multi values to be reset through ngModel

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -444,8 +444,9 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 	writeValue(value: any) {
 		if (this.type === "single") {
 			this.view.propagateSelected([value]);
+			this.showClearButton = !!(value && this.view.getSelected().length);
 		} else {
-			this.view.propagateSelected(value);
+			this.view.propagateSelected(value ? value : [""]);
 		}
 		this.updateSelected();
 	}
@@ -578,9 +579,11 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 		const selected = this.view.getSelected();
 		if (this.type === "multi" ) {
 			this.updatePills();
-		} else if (selected && selected[0]) {
-			this.selectedValue = selected[0].content;
-			this.propagateChangeCallback(selected[0]);
+		} else if (selected) {
+			const value = selected[0] ? selected[0].content : "";
+			const changeCallbackValue = selected[0] ? selected[0] : "";
+			this.selectedValue = value;
+			this.propagateChangeCallback(changeCallbackValue);
 		}
 	}
 }


### PR DESCRIPTION
This makes sure that the correct value is being propagated to the abstract dropdown view when the value is passed through ngModel, and the clear button is displayed/removed at the appropriate times. A revisit of #1203.

#### Changelog

**Changed**

* Allow abstract dropdown view to propagate an array with an empty string in order to allow for clearing of selected items through ngModel by passing in an empty string.

* Show / remove clear button when values are set through ngModel.