### PR TITLE
fix(modal): Modal close icon should be 20x20

### DIFF
--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -28,7 +28,7 @@ import { ExperimentalService } from "./../experimental.service";
 				class="bx--modal-close"
 				[attr.aria-label]="closeLabel"
 				(click)="onClose()">
-				<ibm-icon-close size="16" class="bx--modal-close__icon"></ibm-icon-close>
+				<svg ibmIconClose size="20" class="bx--modal-close__icon"></svg>
 			</button>
 		</header>
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Modal close icon should be 20x20 according to Carbon design.

https://github.com/carbon-design-system/carbon/blob/6db63e027eeccc30d8531bf76d1983ae035767c3/packages/components/src/components/modal/_modal.scss#L342

#### Changelog

**New**

* {{new thing}}

**Changed**

* Change icon size to 20 and use svg directive instead of component.

**Removed**

* {{removed thing}}
