### PR TITLE
basic combobox clear input on button `enter` keyup

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -112,6 +112,7 @@ import { Observable } from "rxjs";
 					tabindex="0"
 					[attr.aria-label]="clearSelectionAria"
 					[title]="clearSelectionTitle"
+					(keyup.enter)="clearInput($event)"
 					(click)="clearInput($event)">
 					<ibm-icon-close size="16"></ibm-icon-close>
 				</div>


### PR DESCRIPTION
Basic combobox `clear` button is now keyboard accessible.