### PR TITLE
fix(datepicker): ensure bx classes are added on date picker creation

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -202,7 +202,7 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked, After
 			}
 		},
 		onDayCreate: (_dObj, _dStr, _fp, dayElem) => {
-			dayElem.className += " bx--date-picker__day";
+			dayElem.classList.add("bx--date-picker__day");
 		},
 		value: this.value
 	};

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -201,6 +201,9 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked, After
 				}
 			}
 		},
+		onDayCreate: (_dObj, _dStr, _fp, dayElem) => {
+			dayElem.className += ' bx--date-picker__day';
+		},
 		value: this.value
 	};
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -202,7 +202,7 @@ export class DatePicker implements OnDestroy, OnChanges, AfterViewChecked, After
 			}
 		},
 		onDayCreate: (_dObj, _dStr, _fp, dayElem) => {
-			dayElem.className += ' bx--date-picker__day';
+			dayElem.className += " bx--date-picker__day";
 		},
 		value: this.value
 	};


### PR DESCRIPTION
Closes IBM/carbon-components-angular #1312 

Using the `onDayCreate` hook to add the class fixes dates not being disabled as they should be after the date picker is opened for a re-selection.

For future I think the existing code adding the class can be removed. I wasn't sure of the difference between `daysContainer` and `dayContainer` to be able to remove it myself. 

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
