### PR TITLE
fix(dropdown): list box should respect the light modifier

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -65,6 +65,7 @@ import { hasScrollableParents } from "../utils";
 		class="bx--dropdown bx--list-box"
 		[ngClass]="{
 			'bx--dropdown--light': theme === 'light',
+			'bx--list-box--light': theme === 'light',
 			'bx--list-box--inline': inline,
 			'bx--skeleton': skeleton,
 			'bx--dropdown--disabled bx--list-box--disabled': disabled,


### PR DESCRIPTION
This makes it so the component behaviour matches the demo here: https://www.carbondesignsystem.com/components/dropdown/usage/#modifiers

#### Changelog

**Changed**

* Make list box respect the light theme modifier
