### PR TITLE
fix(combobox): prevent search from emitting when items are replaced

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -354,7 +354,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 			this.view.items = changes.items.currentValue;
 			// If new items are added into the combobox while there is search input,
 			// repeat the search.
-			this.onSearch(this.input.nativeElement.value);
+			this.onSearch(this.input.nativeElement.value, false);
 			this.updateSelected();
 		}
 	}
@@ -509,8 +509,10 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 	/**
 	 * Sets the list group filter, and manages single select item selection.
 	 */
-	public onSearch(searchString) {
-		this.search.emit(searchString);
+	public onSearch(searchString, shouldEmitSearch = true) {
+		if (shouldEmitSearch) {
+			this.search.emit(searchString);
+		}
 		if (searchString && this.type === "single") {
 			this.showClearButton = true;
 		} else {

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -561,6 +561,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 		event.preventDefault();
 
 		this.clearSelected();
+		this.input.nativeElement.value = "";
 		this.selectedValue = "";
 		this.closeDropdown();
 

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -3,6 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { withKnobs, text, boolean, number } from "@storybook/addon-knobs/angular";
 
 import { ComboBoxModule } from "./combobox.module";
+import { LoadingModule } from "../loading/loading.module";
 import { ButtonModule } from "../button/button.module";
 import { DocumentationModule } from "./../documentation-component/documentation.module";
 import {
@@ -141,15 +142,61 @@ class ReactiveFormsCombobox implements OnInit {
 	}
 }
 
+@Component({
+	selector: "app-mock-query-search",
+	template: `
+		<ibm-loading [isActive]="loading" size="sm"></ibm-loading>
+		<ibm-combo-box
+			appendInline="true"
+			[items]="filterItems"
+			(search)="onSearch($event)">
+			<ibm-dropdown-list></ibm-dropdown-list>
+		</ibm-combo-box>
+	`
+})
+class TestComponent {
+	filterItems = [
+		{
+			content: "one"
+		},
+		{
+			content: "two"
+		},
+		{
+			content: "three"
+		},
+		{
+			content: "four"
+		}
+	];
+
+	loading = false;
+
+	onSearch() {
+		this.loading = true;
+		setTimeout(() => {
+			const newItems = JSON.parse(JSON.stringify(this.filterItems));
+			newItems.push({ content: `New ${newItems.length}` });
+			this.filterItems = newItems;
+			this.loading = false;
+		}, 1000);
+	}
+}
+
 storiesOf("Components|Combobox", module)
 	.addDecorator(
 		moduleMetadata({
-			declarations: [DynamicListComboBox, ReactiveFormsCombobox],
+			declarations: [
+				DynamicListComboBox,
+				ReactiveFormsCombobox,
+				TestComponent
+			],
 			imports: [
 				ComboBoxModule,
 				ButtonModule,
 				ReactiveFormsModule,
-				DocumentationModule
+				DocumentationModule,
+				LoadingModule
 			]
 		})
 	)
@@ -352,6 +399,11 @@ storiesOf("Components|Combobox", module)
 		props: getOptions({
 			model:  { "content": "three", "selected": true }
 		})
+	}))
+	.add("Mock query search", () => ({
+		template: `
+			<app-mock-query-search></app-mock-query-search>
+		`
 	}))
 	.add("Documentation", () => ({
 		template: `

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -155,29 +155,19 @@ class ReactiveFormsCombobox implements OnInit {
 	`
 })
 class TestComponent {
-	filterItems = [
-		{
-			content: "one"
-		},
-		{
-			content: "two"
-		},
-		{
-			content: "three"
-		},
-		{
-			content: "four"
-		}
-	];
+	filterItems = [];
 
 	loading = false;
 
 	onSearch() {
 		this.loading = true;
 		setTimeout(() => {
-			const newItems = JSON.parse(JSON.stringify(this.filterItems));
-			newItems.push({ content: `New ${newItems.length}` });
-			this.filterItems = newItems;
+			this.filterItems = [
+				{ content: `Random ${Math.random()}` },
+				{ content: `Random ${Math.random()}` },
+				{ content: `Random ${Math.random()}` },
+				{ content: `Random ${Math.random()}` }
+			];
 			this.loading = false;
 		}, 1000);
 	}


### PR DESCRIPTION
Closes #1338 

This PR adds an optional second parameter to the `onSearch` function of the combobox `shouldEmitSearch` which controls the emitting of the search event. `shouldEmitSearch` only needs to be set to false when onChanges repeats the search when a new item is introduced to the combobox to prevent an infinite loop if a function bound to the `search` event introduces a new item.