### PR TITLE
fix(table): Change bx--table-header-label to div

### DIFF
--- a/src/table/head/table-head-cell.component.ts
+++ b/src/table/head/table-head-cell.component.ts
@@ -65,14 +65,14 @@ import { TableHeaderItem } from "./../table-header-item.class";
 				<path d="M13.8 10.3L12 12.1V2h-1v10.1l-1.8-1.8-.7.7 3 3 3-3zM4.5 2l-3 3 .7.7L4 3.9V14h1V3.9l1.8 1.8.7-.7z"></path>
 			</svg>
 		</button>
-		<span
+		<div
 			class="bx--table-header-label"
 			*ngIf="!skeleton && this.sort.observers.length === 0 || (this.sort.observers.length > 0 && !column.sortable) || !sortable">
 			<span *ngIf="!column.template" [title]="column.data">{{column.data}}</span>
 			<ng-template
 				[ngTemplateOutlet]="column.template" [ngTemplateOutletContext]="{data: column.data}">
 			</ng-template>
-		</span>
+		</div>
 		<button
 			[ngClass]="{'active': column.filterCount > 0}"
 			*ngIf="column.filterTemplate"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Change `bx--table-header-label` from `span` to `div` to be consistent with Carbon design and React implementation.

https://github.com/carbon-design-system/carbon/blob/4538ba9816f15e50d56045af4c149f8d1eebd336/packages/react/src/components/DataTable/TableHeader.js#L73

Visual example:

`span` & wrapped text:

![image](https://user-images.githubusercontent.com/34791554/85248073-d04d4e80-b41d-11ea-83dd-24783dd83159.png)

`div` & wrapped text:

![image](https://user-images.githubusercontent.com/34791554/85248114-e6f3a580-b41d-11ea-91fb-95469b989533.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
