### PR TITLE
fix(Checkbox): not changing checked value on first click

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -55,7 +55,7 @@ export type CheckboxValue = boolean | "on" | "off";
 				#inputCheckbox
 				class="bx--checkbox"
 				type="checkbox"
-				[id]="id"
+				[id]="id + '_input'"
 				[value]="value"
 				[name]="name"
 				[required]="required"
@@ -63,13 +63,13 @@ export type CheckboxValue = boolean | "on" | "off";
 				[disabled]="disabled"
 				[indeterminate]="indeterminate"
 				[attr.aria-labelledby]="ariaLabelledby"
-				[attr.aria-checked]="(indeterminate ? 'mixed' : checked)">
+				[attr.aria-checked]="(indeterminate ? 'mixed' : checked)"
+				(change)="onChange($event)"
+				(click)="onClick($event)">
 			<label
-				[for]="id"
+				[for]="id + '_input'"
 				[attr.aria-label]="ariaLabel"
 				class="bx--checkbox-label"
-				(change)="onChange($event)"
-				(click)="onClick($event)"
 				[ngClass]="{
 					'bx--skeleton' : skeleton
 				}">


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1367

This issue was introduced by https://github.com/IBM/carbon-components-angular/commit/a6bbc5f0a645fd149858213d886a2d3f1a77f965 that is generating 2 events for every state change of the checkbox. But the issue that fix was trying to address was instead generated by `id`s duplication when setting the `id` property of checkbox component. That would make both the `ibm-checkbox` element and the inner `input` element have the same `id`, but the label pointing only to the first in line (in this case the `ibm-checkbox`) so any click performed there when `id` property is set was no longer going to the `input`. With this solution i'm preventing the `id` duplication, so the label will point to the right element.

#### Changelog

**Changed**

* Defining `id` property, the inner input will had its `id` set to `id + '_input'`
