### PR TITLE
fix(build): Update datepicker I18nModule import

### DIFF
--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { DatePicker } from "./datepicker.component";
 import { UtilsModule } from "../utils/utils.module";
-import { I18nModule } from "./../i18n";
+import { I18nModule } from "./../i18n/index";
 
 @NgModule({
 	declarations: [


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Update datepicker I18nModule import to include index, which may solve a build issue for Angular 8 projects (so far reproduced in 3 Angular 8 projects).

`ERROR in Unexpected value 'undefined' imported by the module 'DatePickerModule in .../node_modules/carbon-components-angular/carbon-components-angular.d.ts'`

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
