### PR TITLE
feat(notification): add support for links

### DIFF
--- a/src/notification/notification-content.interface.ts
+++ b/src/notification/notification-content.interface.ts
@@ -14,6 +14,7 @@ export interface NotificationContent {
 	lowContrast?: boolean;
 	template?: TemplateRef<any>;
 	actions?: NotificationAction[];
+	links?: NotificationLink[];
 }
 
 export interface ToastContent extends NotificationContent {
@@ -22,8 +23,13 @@ export interface ToastContent extends NotificationContent {
 	template?: TemplateRef<any>;
 }
 
-interface NotificationAction {
+export interface NotificationAction {
 	text: string;
 	click: Subject<{event: Event, action: any}> | ((event: {event: Event, action: any}) => any);
 	[x: string]: any;
+}
+
+export interface NotificationLink {
+	text: string;
+	href: string;
 }

--- a/src/notification/notification.component.spec.ts
+++ b/src/notification/notification.component.spec.ts
@@ -87,7 +87,7 @@ describe("Notification", () => {
 		};
 		fixture.detectChanges();
 
-		let p = fixture.nativeElement.querySelector(".bx--inline-notification__text-wrapper").querySelectorAll("p")[1];
+		let p = fixture.nativeElement.querySelector(".bx--inline-notification__text-wrapper div span");
 
 		expect(p.innerHTML.trim()).toEqual("sample message");
 	});

--- a/src/notification/notification.component.ts
+++ b/src/notification/notification.component.ts
@@ -50,7 +50,12 @@ import { of, isObservable, Subject } from "rxjs";
 			</svg>
 			<div class="bx--inline-notification__text-wrapper">
 				<p *ngIf="!notificationObj.template" ibmNotificationTitle [innerHTML]="notificationObj.title"></p>
-				<p *ngIf="!notificationObj.template" ibmNotificationSubtitle [innerHTML]="notificationObj.message"></p>
+				<div *ngIf="!notificationObj.template" ibmNotificationSubtitle>
+					<span [innerHTML]="notificationObj.message"></span>
+					<ng-container *ngFor="let link of notificationObj.links">
+						<a ibmLink [href]="link.href"> {{link.text}}</a>
+					</ng-container>
+				</div>
 				<ng-container *ngTemplateOutlet="notificationObj.template; context: { $implicit: notificationObj}"></ng-container>
 			</div>
 		</div>

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -20,6 +20,7 @@ import { NotificationService } from "./notification.service";
 import { NotificationDisplayService } from "./notification-display.service";
 import { I18nModule } from "./../i18n/index";
 import { ExperimentalModule } from "./../experimental.module";
+import { LinkModule } from "./../link/index";
 
 @NgModule({
 	declarations: [
@@ -50,7 +51,8 @@ import { ExperimentalModule } from "./../experimental.module";
 		ErrorFilledModule,
 		CheckmarkFilledModule,
 		WarningFilledModule,
-		InformationFilledModule
+		InformationFilledModule,
+		LinkModule
 	],
 	providers: [NotificationService, NotificationDisplayService]
 })

--- a/src/notification/notification.stories.ts
+++ b/src/notification/notification.stories.ts
@@ -51,6 +51,15 @@ import { Subject } from "rxjs";
 			lowContrast: lowContrast,
 			actions: actions}">
 		</ibm-notification>
+		<ibm-notification [notificationObj]="{
+			type: 'error',
+			title: 'Sample notification',
+			message: 'Sample error message',
+			showClose: showClose,
+			lowContrast: lowContrast,
+			actions: actions,
+			links: links}">
+		</ibm-notification>
 		`,
 	providers: [NotificationService]
 })
@@ -66,6 +75,17 @@ class NotificationActionStory implements OnInit {
 		{
 			text: "Action",
 			click: this.actionSubject
+		}
+	];
+
+	links = [
+		{
+			href: "https://ibm.com",
+			text: "Link"
+		},
+		{
+			href: "https://ibm.com",
+			text: "Link"
 		}
 	];
 
@@ -225,10 +245,29 @@ storiesOf("Components|Notification", module)
 				lowContrast: lowContrast,
 				showClose: showClose
 			}"></ibm-toast>
+			<ibm-toast [notificationObj]="{
+				type: 'error',
+				title: 'Sample toast',
+				subtitle: 'Sample subtitle message',
+				caption: 'Sample caption',
+				lowContrast: lowContrast,
+				showClose: showClose,
+				links: links
+			}"></ibm-toast>
 		`,
 		props: {
 			showClose: boolean("Show close icon", true),
-			lowContrast: boolean("Low Contrast", false)
+			lowContrast: boolean("Low Contrast", false),
+			links: [
+				{
+					href: "https://ibm.com",
+					text: "Link"
+				},
+				{
+					href: "https://ibm.com",
+					text: "Link"
+				}
+			]
 		}
 	}))
 	.add("With custom content", () => ({

--- a/src/notification/toast.component.ts
+++ b/src/notification/toast.component.ts
@@ -47,7 +47,12 @@ import { I18n } from "./../i18n/index";
 		</svg>
 		<div class="bx--toast-notification__details">
 			<h3 *ngIf="!notificationObj.template" ibmToastTitle [innerHTML]="notificationObj.title"></h3>
-			<p *ngIf="!notificationObj.template" ibmToastSubtitle [innerHTML]="notificationObj.subtitle"></p>
+			<div *ngIf="!notificationObj.template" ibmToastSubtitle>
+				<span [innerHTML]="notificationObj.subtitle"></span>
+				<ng-container *ngFor="let link of notificationObj.links">
+					<a ibmLink [href]="link.href"> {{link.text}}</a>
+				</ng-container>
+			</div>
 			<p *ngIf="!notificationObj.template" ibmToastCaption [innerHTML]="notificationObj.caption"></p>
 			<ng-container *ngTemplateOutlet="notificationObj.template; context: { $implicit: notificationObj}"></ng-container>
 		</div>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1240

Adds support for links in notifications as part of the `NotificationContent` interface