### PR TITLE
fix(combobox): set clear button on updateSelected

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -576,6 +576,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit {
 			this.updatePills();
 		} else if (selected && selected[0]) {
 			this.selectedValue = selected[0].content;
+			this.showClearButton = true;
 			this.propagateChangeCallback(selected[0]);
 		}
 	}

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -31,7 +31,8 @@ const getOptions = (override = {}) => {
 				content: "one"
 			},
 			{
-				content: "two"
+				content: "two",
+				selected: true
 			},
 			{
 				content: "three"


### PR DESCRIPTION
When selected items are initialized or set with the `selected` key, clear button was not being set. This PR sets the clear selected button if any items are selected.