### PR TITLE
🛠 [Enhancement]: Update modal header close button a11y support

### DIFF
--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -26,8 +26,8 @@ import { ExperimentalService } from "./../experimental.service";
 			<button
 				type="button"
 				class="bx--modal-close"
-				[attr.aria-label]="closeLabel"
 				(click)="onClose()">
+				<span class="bx--assistive-text">{{ closeLabel }}</span>
 				<svg ibmIconClose size="20" class="bx--modal-close__icon"></svg>
 			</button>
 		</header>


### PR DESCRIPTION
According to WCAG and Accessibility Checker plugin, buttons require "visible" text. Because of this, `aria-label` is insufficient... Adding the text as a child node of the button, but visually hiding it, meets all a11y requirements, and the `aria-label` is not longer necessary.
Voiceover and JAWS will read the button label when they announce the button element, using this approach.

#### Changelog

**New**

* close button label added as "assistive text" `span` element

**Removed**

* close button `aria-label` is no longer needed.
