### PR TITLE
fix(modal) Change ibm-modal-placeholder to ibm-placeholder in documentation

### DIFF
--- a/src/modal/alert-modal.component.ts
+++ b/src/modal/alert-modal.component.ts
@@ -12,11 +12,11 @@ import { BaseModal } from "./base-modal.class";
  * It can show as a passive modal showing only text or show as a transactional modal with
  * multiple buttons for different actions for the user to choose from.
  *
- * Using a modal in your application requires `ibm-modal-placeholder` which would generally be
+ * Using a modal in your application requires `ibm-placeholder` which would generally be
  * placed near the end of your app component template (app.component.ts or app.component.html) as:
  *
  * ```html
- * <ibm-modal-placeholder></ibm-modal-placeholder>
+ * <ibm-placeholder></ibm-placeholder>
  * ```
  *
  * Example of opening the modal:
@@ -26,7 +26,7 @@ import { BaseModal } from "./base-modal.class";
  *  selector: "app-modal-demo",
  *  template: `
  *   <button class="btn--primary" (click)="openModal()">Open modal</button>
- *   <ibm-modal-placeholder></ibm-modal-placeholder>`
+ *   <ibm-placeholder></ibm-placeholder>`
  * })
  * export class ModalDemo {
  * 	openModal() {

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -22,7 +22,7 @@ import { cycleTabs, getFocusElementList } from "./../common/tab.service";
  * placed near the end of your app component template (app.component.ts or app.component.html) as:
  *
 ```html
-<ibm-modal-placeholder></ibm-modal-placeholder>
+<ibm-placeholder></ibm-placeholder>
 ```
  *
  * A more complete example for `Modal` is given as follows:


### PR DESCRIPTION
Modal documentation contains ibm-modal-placeholder instead of correct ibm-placeholder. 
https://angular.carbondesignsystem.com/?path=/story/components-modal--documentation

#### Changelog

**Changed**

* Change ibm-modal-placeholder to ibm-placeholder in documentation
