### PR TITLE
fix(dropdown): Set dropdown button type

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -78,6 +78,7 @@ import { hasScrollableParents } from "../utils";
 		}">
 		<button
 			#dropdownButton
+			type="button"
 			class="bx--list-box__field"
 			[ngClass]="{'a': !menuIsClosed}"
 			[attr.aria-expanded]="!menuIsClosed"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Set dropdown button's type to "button" so it works nicely inside a form. Otherwise the default value is "submit". https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
