### PR TITLE
fix(toggle): Switch to new Carbon classes

### DIFF
--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -28,11 +28,11 @@ describe("Toggle", () => {
 		expect(component instanceof Toggle).toBe(true);
 	});
 
-	it("should have input with class 'bx--toggle'", () => {
-		expect(buttonElement.className.includes("bx--toggle")).toEqual(true);
+	it("should have input with class 'bx--toggle-input'", () => {
+		expect(buttonElement.className.includes("bx--toggle-input")).toEqual(true);
 		component.size = "sm";
 		fixture.detectChanges();
-		expect(buttonElement.className.includes("bx--toggle")).toEqual(true);
+		expect(buttonElement.className.includes("bx--toggle-input")).toEqual(true);
 	});
 
 	it("should change state", () => {
@@ -46,18 +46,10 @@ describe("Toggle", () => {
 	});
 
 	it("should display small version of toggle when size equals sm", () => {
-		expect(buttonElement.className.includes("bx--toggle--small")).toEqual(false);
+		expect(buttonElement.className.includes("bx--toggle-input--small")).toEqual(false);
 		component.size = "sm";
 		fixture.detectChanges();
-		expect(buttonElement.className.includes("bx--toggle--small")).toEqual(true);
-	});
-
-	it("should display SVG in small version of toggle", () => {
-		component.size = "sm";
-		fixture.detectChanges();
-		labelElement = fixture.debugElement.query(By.css("label")).nativeElement;
-		expect(fixture.debugElement.query(By.css("svg")).nativeElement).not.toBeNull();
-		expect(labelElement.innerHTML).toContain("bx--toggle__check");
+		expect(buttonElement.className.includes("bx--toggle-input--small")).toEqual(true);
 	});
 
 	it("should match the input checked value", () => {

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -55,10 +55,10 @@ export class ToggleChange {
 			<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 		</label>
 		<input
-			class="bx--toggle"
+			class="bx--toggle-input"
 			type="checkbox"
 			[ngClass]="{
-				'bx--toggle--small': size === 'sm',
+				'bx--toggle-input--small': size === 'sm',
 				'bx--skeleton': skeleton
 			}"
 			[id]="id"
@@ -72,18 +72,15 @@ export class ToggleChange {
 			(change)="onChange($event)"
 			(click)="onClick($event)">
 		<label
-			class="bx--toggle__label"
+			class="bx--toggle-input__label"
 			[for]="id"
 			[ngClass]="{
 				'bx--skeleton': skeleton
 			}">
-			<span class="bx--toggle__text--left">{{(!skeleton ? getOffText() : null) | async }}</span>
-			<span class="bx--toggle__appearance">
-				<svg *ngIf="size === 'sm'" class="bx--toggle__check" width="6px" height="5px" viewBox="0 0 6 5">
-					<path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z"/>
-				</svg>
+			<span class="bx--toggle__switch">
+				<span class="bx--toggle__text--off">{{(!skeleton ? getOffText() : null) | async }}</span>
+				<span class="bx--toggle__text--on">{{(!skeleton ? getOnText() : null) | async}}</span>
 			</span>
-			<span class="bx--toggle__text--right">{{(!skeleton ? getOnText() : null) | async}}</span>
 		</label>
 	`,
 	providers: [


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Switch to new Carbon classes (`bx--toggle-input/bx--toggle__switch`) to avoid unwanted text wrapping and also improve accessibility.

According to Carbon code, the old classes are deprecated:
https://github.com/carbon-design-system/carbon/blob/6b68b558739dea743af3582eed6bdb438d53227e/packages/components/src/components/toggle/_toggle.scss#L250

React implementation: https://github.com/carbon-design-system/carbon/blob/6b68b558739dea743af3582eed6bdb438d53227e/packages/react/src/components/Toggle/Toggle.js#L108

Before:

![image](https://user-images.githubusercontent.com/34791554/88448178-d2ce0a00-ce08-11ea-867a-fba552f19aeb.png)

After:

![image](https://user-images.githubusercontent.com/34791554/88448184-db264500-ce08-11ea-8117-d187d8833e30.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
