### PR TITLE
fix(content-switcher): Add missing ["$event"] parameter

### DIFF
--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -49,7 +49,7 @@ export class ContentSwitcherOption {
 
 	protected _active = false;
 
-	@HostListener("click")
+	@HostListener("click", ["$event"])
 	hostClick(event: MouseEvent) {
 		this.onClick.emit(event);
 		// skip setting and emitting if the option is already active
@@ -58,7 +58,7 @@ export class ContentSwitcherOption {
 		this.selected.emit(true);
 	}
 
-	@HostListener("focus")
+	@HostListener("focus", ["$event"])
 	doFocus(event: FocusEvent) {
 		this.onFocus.emit(event);
 		// skip setting and emitting if the option is already active


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

PR https://github.com/IBM/carbon-components-angular/pull/1421 added event parameter to the event handlers, however, `["$event"]` wasn't added to `@HostListener()` directive (required by Angular https://angular.io/api/core/HostListener). Therefore, Angular compiler will bark like below with `fullTemplateTypeCheck` enabled:

`ERROR in src/app/product-ingredients/product-ingredients.component.html(48,19): Directive ContentSwitcherOption, Expected 1 arguments, but got 0.`

Of course the Angular error message is misleading in this case.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
