### PR TITLE
fix(datepicker): Pass left and right arrow HTML to flatpickr

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -536,10 +536,10 @@ export class DatePicker implements
 	 */
 	protected rightArrowHTML() {
 		return `
-      <svg width="16px" height="16px" viewBox="0 0 16 16">
-        <polygon points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3 "/>
-        <rect width="16" height="16" style="fill:none" />
-      </svg>`;
+			<svg width="16px" height="16px" viewBox="0 0 16 16">
+				<polygon points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3 "/>
+				<rect width="16" height="16" style="fill:none" />
+			</svg>`;
 	}
 
 	/**
@@ -547,9 +547,9 @@ export class DatePicker implements
 	 */
 	protected leftArrowHTML() {
 		return `
-      <svg width="16px" height="16px" viewBox="0 0 16 16">
-        <polygon points="5,8 10,3 10.7,3.7 6.4,8 10.7,12.3 10,13 "/>
-        <rect width="16" height="16" style="fill:none" />
-      </svg>`;
+			<svg width="16px" height="16px" viewBox="0 0 16 16">
+				<polygon points="5,8 10,3 10.7,3.7 6.4,8 10.7,12.3 10,13 "/>
+				<rect width="16" height="16" style="fill:none" />
+			</svg>`;
 	}
 }

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -221,6 +221,8 @@ export class DatePicker implements
 		onDayCreate: (_dObj, _dStr, _fp, dayElem) => {
 			dayElem.classList.add("bx--date-picker__day");
 		},
+		nextArrow: this.rightArrowHTML(),
+		prevArrow: this.leftArrowHTML(),
 		value: this.value
 	};
 
@@ -527,5 +529,42 @@ export class DatePicker implements
 	protected isFlatpickrLoaded() {
 		// cast the instance to a boolean, and some method that has to exist for the library to be loaded in this case `setDate`
 		return !!this.flatpickrInstance && !!this.flatpickrInstance.setDate;
+	}
+
+	/**
+	 * Right arrow HTML passed to flatpickr
+	 */
+	protected rightArrowHTML() {
+		return `
+      <svg
+        focusable="false"
+        preserveAspectRatio="xMidYMid meet"
+        style="will-change: transform;"
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        aria-hidden="true">
+          <path d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"></path>
+      </svg>`;
+	}
+
+	/**
+	 * Left arrow HTML passed to flatpickr
+	 */
+	protected leftArrowHTML() {
+		return `
+      <svg
+        focusable="false"
+        preserveAspectRatio="xMidYMid meet"
+        style="will-change: transform;"
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+      >
+        <path d="M5 8l5-5 .7.7L6.4 8l4.3 4.3-.7.7z"></path>
+      </svg>`;
 	}
 }

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -536,16 +536,9 @@ export class DatePicker implements
 	 */
 	protected rightArrowHTML() {
 		return `
-      <svg
-        focusable="false"
-        preserveAspectRatio="xMidYMid meet"
-        style="will-change: transform;"
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        aria-hidden="true">
-          <path d="M11 8l-5 5-.7-.7L9.6 8 5.3 3.7 6 3z"></path>
+      <svg width="16px" height="16px" viewBox="0 0 16 16">
+        <polygon points="11,8 6,13 5.3,12.3 9.6,8 5.3,3.7 6,3 "/>
+        <rect width="16" height="16" style="fill:none" />
       </svg>`;
 	}
 
@@ -554,17 +547,9 @@ export class DatePicker implements
 	 */
 	protected leftArrowHTML() {
 		return `
-      <svg
-        focusable="false"
-        preserveAspectRatio="xMidYMid meet"
-        style="will-change: transform;"
-        xmlns="http://www.w3.org/2000/svg"
-        width="16"
-        height="16"
-        viewBox="0 0 16 16"
-        aria-hidden="true"
-      >
-        <path d="M5 8l5-5 .7.7L6.4 8l4.3 4.3-.7.7z"></path>
+      <svg width="16px" height="16px" viewBox="0 0 16 16">
+        <polygon points="5,8 10,3 10.7,3.7 6.4,8 10.7,12.3 10,13 "/>
+        <rect width="16" height="16" style="fill:none" />
       </svg>`;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-angular/issues/1417

When using latest Carbon styles with Carbon Angular, the left and right arrow icons can't be displayed correctly:

![image](https://user-images.githubusercontent.com/34791554/89133146-b6f0f500-d4e7-11ea-969b-e93c34e19fce.png)

This is due to the fact that some obsoleted svg styles have been removed in Carbon, see this PR: https://github.com/carbon-design-system/carbon/pull/6248/files

The React/official way is to pass the left and right arrow HTML to flatpickr:

https://github.com/carbon-design-system/carbon/blob/bf20ecda79b48d19f363b16c274a114424b0cab2/packages/react/src/components/DatePicker/DatePicker.js#L465

This PR copies the React implementation.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
