### PR TITLE
fix(dropdown): prevent form requirement div from being rendered if there is no invalid text

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -116,7 +116,7 @@ import { ElementService } from "./../utils/utils.module";
 			<ng-content *ngIf="!menuIsClosed"></ng-content>
 		</div>
 	</div>
-	<div *ngIf="invalid" class="bx--form-requirement">
+	<div *ngIf="invalid && invalidText" class="bx--form-requirement">
 		{{invalidText}}
 	</div>
 	`,


### PR DESCRIPTION
closes #1446