### PR TITLE
Add inline variant for links

### DIFF
--- a/src/link/link.directive.ts
+++ b/src/link/link.directive.ts
@@ -47,5 +47,19 @@ export class Link {
 		return this._disabled;
 	}
 
+	/**
+	 * Set to true to inline link.
+	 */
+	@Input()
+	@HostBinding("class.bx--link--inline")
+	set inline(inline: boolean) {
+		this._inline = inline;
+	}
+
+	get inline(): boolean {
+		return this._inline;
+	}
+
 	private _disabled;
+	private _inline;
 }

--- a/src/link/link.directive.ts
+++ b/src/link/link.directive.ts
@@ -33,6 +33,12 @@ export class Link {
 	@HostBinding("attr.tabindex") tabindex;
 
 	/**
+	 * Set to true to show links inline in a sentence or paragraph.
+	 */
+	@Input()
+	@HostBinding("class.bx--link--inline") inline = false;
+
+	/**
 	 * Set to true to disable link.
 	 */
 	@Input()
@@ -47,19 +53,5 @@ export class Link {
 		return this._disabled;
 	}
 
-	/**
-	 * Set to true to inline link.
-	 */
-	@Input()
-	@HostBinding("class.bx--link--inline")
-	set inline(inline: boolean) {
-		this._inline = inline;
-	}
-
-	get inline(): boolean {
-		return this._inline;
-	}
-
 	private _disabled;
-	private _inline;
 }

--- a/src/link/link.spec.ts
+++ b/src/link/link.spec.ts
@@ -17,7 +17,7 @@ class TestDisabledLinkComponent {
 }
 
 @Component({
-	template: `<a href="https://angular.carbondesignsystem.com/" [inline]="1+1===2" ibmLink>link</a>`
+	template: `<a href="https://angular.carbondesignsystem.com/" [inline]="true" ibmLink>link</a>`
 })
 class TestInlineLinkComponent {
 }

--- a/src/link/link.spec.ts
+++ b/src/link/link.spec.ts
@@ -16,6 +16,12 @@ class TestLinkComponent {
 class TestDisabledLinkComponent {
 }
 
+@Component({
+	template: `<a href="https://angular.carbondesignsystem.com/" [inline]="1+1===2" ibmLink>link</a>`
+})
+class TestInlineLinkComponent {
+}
+
 describe("Link", () => {
 	it("should create a Link", () => {
 		TestBed.configureTestingModule({
@@ -47,6 +53,16 @@ describe("Link", () => {
 		expect(directiveEl.attributes["aria-disabled"]).toBe("true");
 		expect(directiveEl.attributes["tabindex"]).toBe("-1");
 	});
+
+	it("should create an inline link", () => {
+		TestBed.configureTestingModule({
+			declarations: [TestInlineLinkComponent, Link]
+		});
+
+		let fixture: ComponentFixture<TestInlineLinkComponent> = TestBed.createComponent(TestInlineLinkComponent);
+		fixture.detectChanges();
+
+		const directiveEl = fixture.debugElement.query(By.directive(Link));
+		expect(directiveEl.nativeElement.classList.contains("bx--link--inline")).toBeTruthy();
+	});
 });
-
-

--- a/src/link/link.stories.ts
+++ b/src/link/link.stories.ts
@@ -16,10 +16,11 @@ storiesOf("Components|Link", module)
 	.addDecorator(withKnobs)
 	.add("Basic", () => ({
 		template: `
-			<a href="#" ibmLink [disabled]="disabled">link</a>
+			<a href="#" ibmLink [disabled]="disabled" [inline]="inline">link</a>
 		`,
 		props: {
-			disabled: boolean("disabled", false)
+			disabled: boolean("disabled", false),
+			inline: boolean("inline", false)
 		}
 	}))
 	.add("Documentation", () => ({


### PR DESCRIPTION
Adds the Carbon [inline link variant](https://carbondesignsystem.com/components/link/usage#inline-link) intended for links within sentences/text.

![image](https://user-images.githubusercontent.com/1717398/90027952-18068e80-dc87-11ea-8dc0-43d344053ccf.png)


#### Changelog

**New**

* Adds `inline` input to link directive