### PR TITLE
chore: switch to typedoc with a custom theme

### DIFF
--- a/carbon-angular-typedoc-theme/helpers/helpers.js
+++ b/carbon-angular-typedoc-theme/helpers/helpers.js
@@ -1,0 +1,69 @@
+const getMembersByDecoratorName = (groups, name) => {
+	let members = [];
+	if (Array.isArray(groups)) {
+		for (const group of groups) {
+			for (const child of group.children) {
+				if (child.decorators) {
+					if (child.decorators.some((value) => value.name === name)) {
+						members.push(child);
+					}
+				}
+			}
+		}
+	}
+	return members;
+}
+
+module.exports = {
+	toJSON: function(object) {
+		return JSON.stringify(object, (key, value) => {
+			if (typeof value === 'string') {
+				return value.replace(/"/g, '');
+			}
+			return value;
+		}, '');
+	},
+	isEmpty: function(object, options) {
+		if (Object.entries(object).length === 0) {
+			return options.fn(this);
+		}
+		return options.inverse(this);
+	},
+	info: function(groups) {
+		if (Array.isArray(groups)) {
+			for (const group of groups) {
+				for (const child of group.children) {
+					if (child.decorators) {
+						const clone = Object.assign({}, child);
+						delete clone.parent;
+						delete clone.children;
+						delete clone.groups;
+						console.log(clone);
+					}
+				}
+			}
+		}
+	},
+	withInputs: function(groups, options) {
+		const members = getMembersByDecoratorName(groups, "Input");
+		return options.fn({members})
+	},
+	withOutputs: function(groups, options) {
+		const members = getMembersByDecoratorName(groups, "Output");
+		return options.fn({ members })
+	},
+	hasInputs: function(groups, options) {
+		const members = getMembersByDecoratorName(groups, "Input");
+		if (members.length > 0) {
+			return options.fn(this);
+		}
+		return options.inverse(this);
+	},
+	hasOutputs: function (groups, options) {
+		const members = getMembersByDecoratorName(groups, "Output");
+		if (members.length > 0) {
+			return options.fn(this);
+		}
+		return options.inverse(this);
+	}
+}

--- a/carbon-angular-typedoc-theme/partials/index.hbs
+++ b/carbon-angular-typedoc-theme/partials/index.hbs
@@ -1,0 +1,64 @@
+{{#if groups}}
+	<section class="tsd-panel-group tsd-index-group">
+		<h2>Index</h2>
+		<section class="tsd-panel tsd-index-panel">
+			<div class="tsd-index-content">
+				{{#hasInputs groups}}
+					<section class="tsd-index-section">
+						<h3>Inputs</h3>
+						{{#withInputs groups}}
+							<ul class="tsd-index-list">
+								{{#each members}}
+									<li>
+										<a href="{{relativeURL url}}" class="tsd-kind-icon">{{name}}</a>
+									</li>
+								{{/each}}
+							</ul>
+						{{/withInputs}}
+					</section>
+				{{/hasInputs}}
+				{{#hasOutputs groups}}
+					<section class="tsd-index-section">
+						<h3>Outputs</h3>
+						{{#withOutputs groups}}
+							<ul class="tsd-index-list">
+								{{#each members}}
+									<li>
+										<a href="{{relativeURL url}}" class="tsd-kind-icon">{{name}}</a>
+									</li>
+								{{/each}}
+							</ul>
+						{{/withOutputs}}
+					</section>
+				{{/hasOutputs}}
+				{{#each groups}}
+					<section class="tsd-index-section {{cssClasses}}">
+						{{#if categories}}
+							{{#each categories}}
+								<h3>{{#if title}}{{title}} {{/if}}{{../title}}</h3>
+								<ul class="tsd-index-list">
+									{{#each children}}
+										<li class="{{cssClasses}}">
+											<a href="{{relativeURL url}}" class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a>
+										</li>
+									{{/each}}
+								</ul>
+							{{/each}}
+						{{else}}
+							<h3>{{title}}</h3>
+							<ul class="tsd-index-list">
+								{{#each children}}
+									<li class="{{cssClasses}}"><a href="{{relativeURL url}}"
+											class="tsd-kind-icon">{{#if name}}{{{wbr name}}}{{else}}<em>{{{wbr kindString}}}</em>{{/if}}</a>
+									</li>
+								{{/each}}
+							</ul>
+						{{/if}}
+					</section>
+				{{/each}}
+			</div>
+		</section>
+	</section>
+{{/if}}
+
+{{!-- {{info groups}} --}}

--- a/carbon-angular-typedoc-theme/partials/member.hbs
+++ b/carbon-angular-typedoc-theme/partials/member.hbs
@@ -1,0 +1,39 @@
+<section class="tsd-panel tsd-member {{cssClasses}}">
+	<a name="{{anchor}}" class="tsd-anchor"></a>
+	{{#if name}}
+		<h3>{{#each flags}}<span class="tsd-flag ts-flag{{this}}">{{this}}</span> {{/each}}{{{wbr name}}}</h3>
+	{{/if}}
+
+	{{#if decorators}}
+		<div class="tsd-signature" style="border-bottom: none; margin-bottom: 0; padding-left: 20px;">
+			{{#each decorators}}
+				<span>
+					{{#isEmpty arguments}}
+						@{{name}}()
+					{{else}}
+						@{{name}}({{toJSON arguments}})
+					{{/isEmpty}}
+				</span>
+				<br />
+			{{/each}}
+		</div>
+	{{/if}}
+
+	{{#if signatures}}
+		{{> member.signatures}}
+	{{else}}{{#if hasGetterOrSetter}}
+		{{> member.getterSetter}}
+	{{else}}{{#if isReference}}
+		{{> member.reference}}
+	{{else}}
+		{{> member.declaration}}
+	{{/if}}{{/if}}{{/if}}
+
+	{{#each groups}}
+		{{#each children}}
+			{{#unless hasOwnDocument}}
+				{{> member}}
+			{{/unless}}
+		{{/each}}
+	{{/each}}
+</section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3640,119 +3640,6 @@
         }
       }
     },
-    "@compodoc/compodoc": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.1.7.tgz",
-      "integrity": "sha512-bTqkv75T9b+3OxG517YL+5B0npAG0Q5nOMAk562Idr/fICTTHQ/xzSBsTptZ4QqYmtzRMV1OqOlk74FXfGPZWw==",
-      "dev": true,
-      "requires": {
-        "@compodoc/ngd-transformer": "^2.0.0",
-        "chalk": "^2.4.1",
-        "cheerio": "^1.0.0-rc.2",
-        "chokidar": "^2.0.4",
-        "colors": "^1.3.2",
-        "commander": "2.19.0",
-        "cosmiconfig": "^5.0.7",
-        "fancy-log": "^1.3.2",
-        "findit2": "^2.2.3",
-        "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "handlebars": "4.0.10",
-        "html-entities": "^1.2.1",
-        "i18next": "^12.1.0",
-        "inside": "^1.0.0",
-        "json5": "^2.1.0",
-        "live-server": "1.2.1",
-        "lodash": "^4.17.11",
-        "lunr": "2.3.5",
-        "marked": "^0.4.0",
-        "opencollective": "^1.0.3",
-        "os-name": "^3.0.0",
-        "traverse": "^0.6.6",
-        "ts-simple-ast": "12.4.0",
-        "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-          "dev": true
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
-      }
-    },
-    "@compodoc/ngd-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.0.0.tgz",
-      "integrity": "sha512-6HpYvXRZBdIYFojWxW5EVNkhYPmblytCve62CNoYBSWfy++vTGH7Ypg2Bhjg2CsqeV8JOVxrPO7JM9M3MgWKEA==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "^1.0.1",
-        "fancy-log": "^1.3.2",
-        "typescript": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-colors": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-          "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-          "dev": true,
-          "requires": {
-            "ansi-wrap": "^0.1.0"
-          }
-        },
-        "typescript": {
-          "version": "2.9.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
-          "dev": true
-        }
-      }
-    },
-    "@compodoc/ngd-transformer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@compodoc/ngd-transformer/-/ngd-transformer-2.0.0.tgz",
-      "integrity": "sha512-9J0KkmuuuvDHxH0oREgrgbqdEFqcltQXIBofeYdIyMKzI3A+pN1Ji4zfi7x1ql0Ax7qQKemp8XWP+cCpP0qY+w==",
-      "dev": true,
-      "requires": {
-        "@compodoc/ngd-core": "~2.0.0",
-        "dot": "^1.1.1",
-        "fs-extra": "^4.0.1",
-        "viz.js": "^1.8.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        }
-      }
-    },
-    "@dsherret/to-absolute-glob": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
-      "dev": true,
-      "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
-      }
-    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -7328,6 +7215,40 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/fs-extra": {
+      "version": "5.1.0",
+      "resolved": "http://localhost:4873/@types%2ffs-extra/-/fs-extra-5.1.0.tgz",
+      "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "http://localhost:4873/@types%2fglob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/handlebars": {
+      "version": "4.1.0",
+      "resolved": "http://localhost:4873/@types%2fhandlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
+    },
+    "@types/highlight.js": {
+      "version": "9.12.4",
+      "resolved": "http://localhost:4873/@types%2fhighlight.js/-/highlight.js-9.12.4.tgz",
+      "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
+      "dev": true
+    },
     "@types/history": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
@@ -7362,6 +7283,24 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.161",
+      "resolved": "http://localhost:4873/@types%2flodash/-/lodash-4.14.161.tgz",
+      "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "dev": true
+    },
+    "@types/marked": {
+      "version": "0.4.2",
+      "resolved": "http://localhost:4873/@types%2fmarked/-/marked-0.4.2.tgz",
+      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "http://localhost:4873/@types%2fminimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
@@ -7471,6 +7410,16 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.8",
+      "resolved": "http://localhost:4873/@types%2fshelljs/-/shelljs-0.8.8.tgz",
+      "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -7875,7 +7824,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "resolved": "http://localhost:4873/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "optional": true,
@@ -7887,7 +7836,7 @@
       "dependencies": {
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "http://localhost:4873/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "optional": true,
@@ -8019,21 +7968,6 @@
         "normalize-path": "^2.1.1"
       }
     },
-    "apache-crypt": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.4.tgz",
-      "integrity": "sha512-Icze5ny5W5uv3xgMgl8U+iGmRCC0iIDrb2PVPuRBtL3Zy1Y5TMewXP1Vtc4r5X9eNNBEk7KYPu0Qby9m/PmcHg==",
-      "dev": true,
-      "requires": {
-        "unix-crypt-td-js": "^1.1.4"
-      }
-    },
-    "apache-md5": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.5.tgz",
-      "integrity": "sha512-sbLEIMQrkV7RkIruqTPXxeCMkAAycv4yzTkBzRgOR1BrR5UB7qZtupqxkersTJSf0HZ3sbaNRrNV80TnnM7cUw==",
-      "dev": true
-    },
     "app-root-dir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
@@ -8145,12 +8079,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
-    },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-each": {
@@ -9186,15 +9114,6 @@
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -9215,12 +9134,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=",
-      "dev": true
     },
     "before-after-hook": {
       "version": "2.1.0",
@@ -9892,7 +9805,7 @@
     },
     "center-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "resolved": "http://localhost:4873/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "optional": true,
@@ -9966,31 +9879,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
-    },
-    "cheerio": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
-      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
-      "dev": true,
-      "requires": {
-        "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.1",
-        "entities": "~1.1.1",
-        "htmlparser2": "^3.9.1",
-        "lodash": "^4.15.0",
-        "parse5": "^3.0.1"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        }
-      }
     },
     "chokidar": {
       "version": "2.0.4",
@@ -10258,12 +10146,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-block-writer": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-7.3.1.tgz",
-      "integrity": "sha512-3Jfe6ZmmGzvdQWFo3MUzobn3WdX++jc3Tj0rsviJWYPnP7NGMFEE4qheNeOXeJgB1TTgxYT8XuNvhS/u596yGg==",
       "dev": true
     },
     "code-point-at": {
@@ -12032,16 +11914,6 @@
         }
       }
     },
-    "cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
-      "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
-      }
-    },
     "cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -12863,12 +12735,6 @@
         "domelementtype": "1"
       }
     },
-    "dot": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.3.tgz",
-      "integrity": "sha512-/nt74Rm+PcfnirXGEdhZleTwGC2LMnuKTeeTIlI82xb5loBBoXNYzr2ezCroPSMtilK8EZIfcNZwOcHN+ib1Lg==",
-      "dev": true
-    },
     "dot-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
@@ -13519,21 +13385,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1",
-        "from": "~0",
-        "map-stream": "~0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3",
-        "stream-combiner": "~0.0.4",
-        "through": "~2.3.1"
-      }
-    },
     "eventemitter3": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
@@ -14130,12 +13981,6 @@
         "semver-regex": "^2.0.0"
       }
     },
-    "findit2": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/findit2/-/findit2-2.2.3.tgz",
-      "integrity": "sha1-WKRmaX34piBc39vzlVNri9d3pfY=",
-      "dev": true
-    },
     "findup-sync": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
@@ -14376,12 +14221,6 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
-    },
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -14403,7 +14242,7 @@
     },
     "fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "resolved": "http://localhost:4873/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
@@ -15175,7 +15014,7 @@
     },
     "handlebars": {
       "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+      "resolved": "http://localhost:4873/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
       "requires": {
@@ -15187,13 +15026,13 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://localhost:4873/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "http://localhost:4873/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -15561,18 +15400,6 @@
         }
       }
     },
-    "http-auth": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-3.1.3.tgz",
-      "integrity": "sha1-lFz63WZSHq+PfISRPTd9exXyTjE=",
-      "dev": true,
-      "requires": {
-        "apache-crypt": "^1.1.2",
-        "apache-md5": "^1.0.6",
-        "bcryptjs": "^2.3.0",
-        "uuid": "^3.0.0"
-      }
-    },
     "http-cache-semantics": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
@@ -15866,12 +15693,6 @@
           "dev": true
         }
       }
-    },
-    "i18next": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-12.1.0.tgz",
-      "integrity": "sha512-AexmwGkKxwKfo5fGeXTWEY4xqzRPigQ1S/0InOUUVziGO54cd4fKyYK8ED1Thx9fd+WA3fRSZ+1iekvFQMbsFw==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -16168,12 +15989,6 @@
           }
         }
       }
-    },
-    "inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/inside/-/inside-1.0.0.tgz",
-      "integrity": "sha1-20Xpk1c82z23C5gy6ChbrUZCR3A=",
-      "dev": true
     },
     "internal-ip": {
       "version": "3.0.1",
@@ -17311,7 +17126,7 @@
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "resolved": "http://localhost:4873/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true,
       "optional": true
@@ -17639,86 +17454,6 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
-    "live-server": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.2.1.tgz",
-      "integrity": "sha512-Yn2XCVjErTkqnM3FfTmM7/kWy3zP7+cEtC7x6u+wUzlQ+1UW3zEYbbyJrc0jNDwiMDZI0m4a0i3dxlGHVyXczw==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^2.0.4",
-        "colors": "^1.4.0",
-        "connect": "^3.6.6",
-        "cors": "^2.8.5",
-        "event-stream": "3.3.4",
-        "faye-websocket": "0.11.x",
-        "http-auth": "3.1.x",
-        "morgan": "^1.9.1",
-        "object-assign": "^4.1.1",
-        "opn": "^6.0.0",
-        "proxy-middleware": "^0.15.0",
-        "send": "^0.17.1",
-        "serve-index": "^1.9.1"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "dev": true
-        },
-        "faye-websocket": {
-          "version": "0.11.3",
-          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
-          "dev": true,
-          "requires": {
-            "websocket-driver": ">=0.5.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "opn": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
-          "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
-          "dev": true,
-          "requires": {
-            "is-wsl": "^1.1.0"
-          }
-        },
-        "send": {
-          "version": "0.17.1",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-          "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
-            "fresh": "0.5.2",
-            "http-errors": "~1.7.2",
-            "mime": "1.6.0",
-            "ms": "2.1.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.1",
-            "statuses": "~1.5.0"
-          }
-        }
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -18003,12 +17738,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "lunr": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.5.tgz",
-      "integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ==",
-      "dev": true
-    },
     "macos-release": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
@@ -18178,12 +17907,6 @@
       "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg=",
       "dev": true
     },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -18205,7 +17928,7 @@
     },
     "marked": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
+      "resolved": "http://localhost:4873/marked/-/marked-0.4.0.tgz",
       "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
       "dev": true
     },
@@ -18761,19 +18484,6 @@
       "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
-    "morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
-      "dev": true,
-      "requires": {
-        "basic-auth": "~2.0.0",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -18809,26 +18519,6 @@
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
-    },
-    "multimatch": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-      "dev": true,
-      "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
-      },
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        }
-      }
     },
     "mute-stdout": {
       "version": "1.0.1",
@@ -19319,16 +19009,6 @@
       "dev": true,
       "requires": {
         "lodash.toarray": "^4.4.0"
-      }
-    },
-    "node-fetch": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-      "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-fetch-npm": {
@@ -23325,157 +23005,6 @@
         "is-wsl": "^1.1.0"
       }
     },
-    "opencollective": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
-      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "6.23.0",
-        "chalk": "1.1.3",
-        "inquirer": "3.0.6",
-        "minimist": "1.2.0",
-        "node-fetch": "1.6.3",
-        "opn": "4.0.2"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "babel-polyfill": {
-          "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-          "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.22.0",
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.10.0"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-          "dev": true
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-          "dev": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "inquirer": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
-          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
-          "dev": true,
-          "requires": {
-            "ansi-escapes": "^1.1.0",
-            "chalk": "^1.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.0.1",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rx": "^4.1.0",
-            "string-width": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "through": "^2.3.6"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-          "dev": true,
-          "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
@@ -24085,15 +23614,6 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "~2.3"
-      }
-    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -24499,6 +24019,12 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "http://localhost:4873/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -24587,12 +24113,6 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "proxy-middleware": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
-      "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
-      "dev": true
     },
     "prr": {
       "version": "1.0.1",
@@ -25836,7 +25356,7 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "resolved": "http://localhost:4873/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
       "optional": true,
@@ -25947,12 +25467,6 @@
       "requires": {
         "aproba": "^1.1.1"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
     },
     "rxjs": {
       "version": "6.4.0",
@@ -27492,15 +27006,6 @@
         "chalk": "^2.0.1"
       }
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -27622,15 +27127,6 @@
       "requires": {
         "inherits": "~2.0.1",
         "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "~0.1.1"
       }
     },
     "stream-combiner2": {
@@ -28567,74 +28063,6 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
     },
-    "ts-simple-ast": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/ts-simple-ast/-/ts-simple-ast-12.4.0.tgz",
-      "integrity": "sha512-7GJFZlyTZY7uMAEhX62ZLxdwOpGDJzc/nwpi1nRPZ7N2ICcqqrMjDtRnki15IUBv2ZjIGu6KBqk/pUqJFODFsg==",
-      "dev": true,
-      "requires": {
-        "@dsherret/to-absolute-glob": "^2.0.2",
-        "code-block-writer": "^7.2.0",
-        "fs-extra": "^6.0.1",
-        "glob-parent": "^3.1.0",
-        "globby": "^8.0.1",
-        "is-negated-glob": "^1.0.0",
-        "multimatch": "^2.1.0",
-        "object-assign": "^4.1.1",
-        "tslib": "^1.9.0",
-        "typescript": "2.9.1"
-      },
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
-          "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "path-type": "^3.0.0"
-          }
-        },
-        "fs-extra": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
-          "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "globby": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
-          "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
-          "dev": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "dir-glob": "2.0.0",
-            "fast-glob": "^2.0.2",
-            "glob": "^7.1.2",
-            "ignore": "^3.3.5",
-            "pify": "^3.0.0",
-            "slash": "^1.0.0"
-          }
-        },
-        "typescript": {
-          "version": "2.9.1",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.1.tgz",
-          "integrity": "sha512-h6pM2f/GDchCFlldnriOhs1QHuwbnmj6/v7499eMHqPeW4V2G0elua2eIc2nu8v2NdHV0Gm+tzX83Hr6nUFjQA==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -28782,6 +28210,55 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedoc": {
+      "version": "0.14.2",
+      "resolved": "http://localhost:4873/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
+      "dev": true,
+      "requires": {
+        "@types/fs-extra": "^5.0.3",
+        "@types/handlebars": "^4.0.38",
+        "@types/highlight.js": "^9.12.3",
+        "@types/lodash": "^4.14.110",
+        "@types/marked": "^0.4.0",
+        "@types/minimatch": "3.0.3",
+        "@types/shelljs": "^0.8.0",
+        "fs-extra": "^7.0.0",
+        "handlebars": "^4.0.6",
+        "highlight.js": "^9.13.1",
+        "lodash": "^4.17.10",
+        "marked": "^0.4.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.0",
+        "shelljs": "^0.8.2",
+        "typedoc-default-themes": "^0.5.0",
+        "typescript": "3.2.x"
+      }
+    },
+    "typedoc-default-themes": {
+      "version": "0.5.0",
+      "resolved": "http://localhost:4873/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
+      "dev": true
+    },
+    "typedoc-plugin-external-module-name": {
+      "version": "4.0.3",
+      "resolved": "http://localhost:4873/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.3.tgz",
+      "integrity": "sha512-2PjEN9kdmkB7NxN3DEax6yDIPjq7HV8qELQhkSRJGxJs/8G/ZwPPvXT0z6hUqtWVr6MeCjpAoYJFzHo04C14Aw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.1.2",
+        "semver": "^7.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "http://localhost:4873/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
+      }
+    },
     "typescript": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
@@ -28790,7 +28267,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "http://localhost:4873/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
@@ -28802,14 +28279,14 @@
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "resolved": "http://localhost:4873/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "resolved": "http://localhost:4873/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
@@ -28821,21 +28298,21 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "http://localhost:4873/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "http://localhost:4873/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "http://localhost:4873/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true,
@@ -28850,7 +28327,7 @@
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "resolved": "http://localhost:4873/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
@@ -28992,12 +28469,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
-    },
-    "unix-crypt-td-js": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
-      "integrity": "sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==",
       "dev": true
     },
     "unpipe": {
@@ -29511,12 +28982,6 @@
         "remove-bom-buffer": "^3.0.0",
         "vinyl": "^2.0.0"
       }
-    },
-    "viz.js": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.2.tgz",
-      "integrity": "sha512-W+1+N/hdzLpQZEcvz79n2IgUE9pfx6JLdHh3Kh8RGvLL8P1LdJVQmi2OsDcLdY4QVID4OUy+FPelyerX0nJxIQ==",
-      "dev": true
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -30300,7 +29765,7 @@
     },
     "window-size": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "resolved": "http://localhost:4873/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -15014,7 +15014,7 @@
     },
     "handlebars": {
       "version": "4.0.10",
-      "resolved": "http://localhost:4873/handlebars/-/handlebars-4.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
       "requires": {
@@ -15026,13 +15026,13 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://localhost:4873/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "source-map": {
           "version": "0.4.4",
-          "resolved": "http://localhost:4873/source-map/-/source-map-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
@@ -28267,7 +28267,7 @@
     },
     "uglify-js": {
       "version": "2.8.29",
-      "resolved": "http://localhost:4873/uglify-js/-/uglify-js-2.8.29.tgz",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
@@ -28279,14 +28279,14 @@
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
-          "resolved": "http://localhost:4873/camelcase/-/camelcase-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "http://localhost:4873/cliui/-/cliui-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
@@ -28298,21 +28298,21 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://localhost:4873/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
-          "resolved": "http://localhost:4873/wordwrap/-/wordwrap-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://localhost:4873/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "optional": true,

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "bash scripts/build.sh",
     "storybook": "start-storybook -s .storybook/public -p 6006",
-    "docs:build": "compodoc -p tsconfig.json",
-    "docs:server": "compodoc -p tsconfig.json -s -w",
+    "docs:build": "typedoc",
     "lint": "tslint 'src/**/*.ts'",
     "lint:fix": "tslint --fix 'src/**/*.ts'",
     "test": "ng test --no-watch",
@@ -86,7 +85,6 @@
     "@carbon/themes": "10.15.0",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",
-    "@compodoc/compodoc": "1.1.7",
     "@storybook/addon-actions": "5.3.19",
     "@storybook/addon-knobs": "5.3.19",
     "@storybook/addon-links": "5.3.19",
@@ -129,6 +127,8 @@
     "tsickle": "0.35.0",
     "tslib": "1.9.3",
     "tslint": "5.15.0",
+    "typedoc": "0.14.2",
+    "typedoc-plugin-external-module-name": "^4.0.3",
     "typescript": "3.2.4",
     "whatwg-fetch": "3.0.0",
     "zone.js": "0.8.26"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,4 +13,4 @@ gulp buildMeta
 # generate ALL the documentation
 mkdir dist/docs
 npm run build-storybook
-# npm run docs:build && mv documentation dist/docs/
+npm run docs:build && mv documentation dist/docs/

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,13 +28,13 @@ if [[ $TRAVIS_BRANCH == "master" ]]; then
 	rm *.js
 
 	mkdir -p documentation
-	# cp -R ../dist/docs/documentation/* ./documentation
+	cp -R ../dist/docs/documentation/* ./documentation
 	cp -R ../dist/docs/storybook/* ./
 
 	version=$(node -e 'const package = require("./../dist/package.json"); console.log(package.version);')
 	mkdir -p $version
-	# mkdir -p $version/documentation
-	# cp -R ../dist/docs/documentation/* $version/documentation
+	mkdir -p $version/documentation
+	cp -R ../dist/docs/documentation/* $version/documentation
 	cp -R ../dist/docs/storybook/* $version
 
 	echo "angular.carbondesignsystem.com" > CNAME

--- a/src/link/link.directive.ts
+++ b/src/link/link.directive.ts
@@ -5,13 +5,13 @@ import {
 } from "@angular/core";
 
 /**
- * A convinence directive for applying styling to a link.
+ * A convenience directive for applying styling to a link.
  *
  * [See demo](../../?path=/story/link--basic)
  *
  * Example:
  *
- * ```hmtl
+ * ```html
  * <a href="#" ibmLink>A link</a>
  * ```
  *

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
 		"**/*.stories.ts",
 		"**/stories/**",
 		"**/*.spec.ts",
-		"**/node_modules/**"
+		"**/node_modules/**",
+		"**/dist/**"
 	],
 	"angularCompilerOptions": {
 		"skipTemplateCodegen": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"downlevelIteration": true,
+		"esModuleInterop": true,
 		"importHelpers": true,
 		"lib": [
 			"es2016",

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,6 +5,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"downlevelIteration": true,
+		"esModuleInterop": true,
 		"importHelpers": true,
 		"lib": [
 			"es2016",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,10 @@
+{
+	"inputFiles": [ "./src" ],
+	"mode": "modules",
+	"out": "documentation",
+	"exclude": [ "**/node_modules/**" ],
+	"externalPattern": [ "@storybook/*" ],
+	"excludeExternals": true,
+	"ignoreCompilerErrors": true,
+	"theme": "./carbon-angular-typedoc-theme"
+}


### PR DESCRIPTION
I don't think we had an issue open for this, but this adds back some auto-generated documentation.

Context: When we switched to individual modules compodoc suddenly took well over half an hour to render _anything_. Obviously that wasn't sustainable. This PR switches us over to typedoc, with a basic custom theme that includes decorators where applicable, and calls out all the `@Input`s and `@Output`s in each classes Index.

typdoc also seems to be actively maintained and updated, so it's unlikely we'll need to switch again any time soon.