### PR TITLE
fix(accessibility): fix interactive search element not being focusabl…

### DIFF
--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -29,7 +29,14 @@
 		<button *ngIf="!tableSearch && toolbar" class="bx--toolbar-search__btn" (click)="openSearch()">
 			<ibm-icon-search size="16" class="bx--search-magnifier"></ibm-icon-search>
 		</button>
-		<ibm-icon-search size="16" *ngIf="tableSearch || !toolbar" (click)="openSearch()" class="bx--search-magnifier"></ibm-icon-search>
+		<ibm-icon-search
+			*ngIf="tableSearch || !toolbar"
+			class="bx--search-magnifier"
+			size="16"
+			role="button"
+			tabindex="0"
+			(click)="openSearch()">
+		</ibm-icon-search>
 	</ng-template>
 
 	<button

--- a/src/table/body/table-row.component.ts
+++ b/src/table/body/table-row.component.ts
@@ -183,6 +183,10 @@ export class TableRowComponent {
 		return this.expandable ? true : null;
 	}
 
+	@HostBinding("attr.tabindex") get isAccessible() {
+		return this.enableSingleSelect && !this.showSelectionColumn ? 0 : null;
+	}
+
 	protected _checkboxLabel = this.i18n.getOverridable("TABLE.CHECKBOX_ROW");
 	protected _expandButtonAriaLabel = this.i18n.getOverridable("TABLE.EXPAND_BUTTON");
 


### PR DESCRIPTION
Closes: https://github.com/IBM/carbon-components-angular/issues/1510

Fixing accessibility issue for interactive elements

1. The magnify glass in search is clickable so it should be focusable. This causes issue in table toolbar.

2. Some table rows have a host click listener, because rows are missing a tabindex they are not focusable by keyboard