### PR TITLE
fix(combobox): set selected value when use itemValueKey

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -436,10 +436,11 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 				} else {
 					if (event.item && event.item.selected) {
 						this.showClearButton = true;
+						this.selectedValue = event.item.content;
+
 						if (this.itemValueKey) {
 							this.propagateChangeCallback(event.item[this.itemValueKey]);
 						} else {
-							this.selectedValue = event.item.content;
 							this.propagateChangeCallback(event.item);
 						}
 					} else {


### PR DESCRIPTION
Previously itemValueKey input was added for combobox (https://github.com/IBM/carbon-components-angular/commit/33c899d3ee278137e1d9e8bd2d07b737dacdc1c9).

In that commit using of selected value for itemValueKey case wasn't added, this commit fix it.  

#### Changelog
**Changed**

* Fix selection of element in combobox when use itemValueKey
