### PR TITLE
fix(error): fix error not visually appearing on dropdown and combobox

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -137,8 +137,8 @@ import { Observable } from "rxjs";
 				<ng-content *ngIf="open"></ng-content>
 			</div>
 		</div>
-		<div *ngIf="invalid">
-			<div *ngIf="!isTemplate(invalidText)" class="bx--form-requirement">{{ invalidText }}</div>
+		<div *ngIf="invalid" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>
 			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
 		</div>
 	`,

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -136,8 +136,8 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			<ng-content *ngIf="!menuIsClosed"></ng-content>
 		</div>
 	</div>
-	<div *ngIf="invalid">
-		<div *ngIf="!isTemplate(invalidText)" class="bx--form-requirement">{{ invalidText }}</div>
+	<div *ngIf="invalid" class="bx--form-requirement">
+		<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>
 		<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
 	</div>
 	`,


### PR DESCRIPTION
Fixing error text not appearing for dropdown and combobox.
This makes error text handling the same across all components

Should fix: https://github.com/IBM/carbon-components-angular/issues/1446

#### Changelog

**Changed**

* Class location for error text in dropdown and combobox