### PR TITLE
fix(helper): fix helper text location select, dropdown, combobox, input

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -42,13 +42,6 @@ import { Observable } from "rxjs";
 			<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 		</label>
 		<div
-			*ngIf="helperText"
-			class="bx--form__helper-text"
-			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
-			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
-			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
-		</div>
-		<div
 			#listbox
 			[ngClass]="{
 				'bx--multi-select': type === 'multi',
@@ -137,6 +130,13 @@ import { Observable } from "rxjs";
 			<div #dropdownMenu>
 				<ng-content *ngIf="open"></ng-content>
 			</div>
+		</div>
+		<div
+			*ngIf="helperText && !invalid"
+			class="bx--form__helper-text"
+			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
+			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 		</div>
 		<div *ngIf="invalid" class="bx--form-requirement">
 			<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -56,10 +56,6 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 		<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 		<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 	</label>
-	<div *ngIf="helperText" class="bx--form__helper-text">
-		<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
-		<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
-	</div>
 	<div
 		[id]="id"
 		class="bx--list-box"
@@ -135,6 +131,10 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			}">
 			<ng-content *ngIf="!menuIsClosed"></ng-content>
 		</div>
+	</div>
+	<div *ngIf="helperText && !invalid" class="bx--form__helper-text">
+		<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+		<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 	</div>
 	<div *ngIf="invalid" class="bx--form-requirement">
 		<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -53,7 +53,7 @@ import { TextArea } from "./text-area.directive";
 			</ibm-icon-warning-filled>
 			<ng-content select="input,textarea,div"></ng-content>
 		</div>
-		<div *ngIf="!skeleton && helperText" class="bx--form__helper-text">{{helperText}}</div>
+		<div *ngIf="!skeleton && helperText && !invalid" class="bx--form__helper-text">{{helperText}}</div>
 		<div *ngIf="invalid" class="bx--form-requirement">
 			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -43,10 +43,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 					<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 				</label>
-				<div *ngIf="helperText" class="bx--form__helper-text">
-					<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
-					<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
-				</div>
 				<div class="bx--select-input__wrapper" [attr.data-invalid]="(invalid ? true : null)">
 					<select
 						[attr.id]="id"
@@ -79,6 +75,10 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 						aria-hidden="true">
 						<path d="M5 6L0 1 .7.3 5 4.6 9.3.3l.7.7z"></path>
 					</svg>
+				</div>
+				<div *ngIf="helperText && !invalid" class="bx--form__helper-text">
+					<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+					<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
 					<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>


### PR DESCRIPTION
Fix helper text location for select, input, dropdown and combobox

before:
![Screen Shot 2020-10-01 at 12 18 17 PM](https://user-images.githubusercontent.com/302239/94841877-3dd72680-03e0-11eb-9f1d-398bc52fddf7.png)

after:
![Screen Shot 2020-10-01 at 12 18 30 PM](https://user-images.githubusercontent.com/302239/94841881-416aad80-03e0-11eb-93e2-3e7d7d801152.png)
