### PR TITLE
fix(dialog): fix dialog position or overflow menu

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -54,7 +54,7 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 			* we also move the element by half of it's own width, since
 			* position service will try and center everything
 			*/
-			const closestRel = this.closestAttr('position', ['relative', 'fixed', 'absolute']);
+			const closestRel = this.closestAttr("position", ["relative", "fixed", "absolute"]);
 			const topFix = closestRel ? closestRel.getBoundingClientRect().top * -1 : 0;
 			const leftFix = closestRel ? closestRel.getBoundingClientRect().left * -1 : 0;
 

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -86,7 +86,7 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 			el = el.parentElement || el.parentNode;
 		} while (el !== null && el.nodeType === 1);
 		return null;
-	};
+	}
 
 	matchesAttr(el, attr, val) {
 		const styles = window.getComputedStyle(el);

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -90,12 +90,7 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 
 	matchesAttr(el, attr, val) {
 		const styles = window.getComputedStyle(el);
-
-		if (val.includes(styles[attr])) {
-			return true;
-		} else {
-			return false;
-		}
+		return val.includes(styles[attr]);
 	}
 
 	@HostListener("keydown", ["$event"])

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -54,11 +54,15 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 			* we also move the element by half of it's own width, since
 			* position service will try and center everything
 			*/
+			const closestRel = this.closestAttr('position', ['relative', 'fixed', 'absolute']);
+			const topFix = closestRel ? closestRel.getBoundingClientRect().top * -1 : 0;
+			const leftFix = closestRel ? closestRel.getBoundingClientRect().left * -1 : 0;
+
 			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 16;
 			if (this.dialogConfig.flip) {
-				return position.addOffset(pos, 0, -offset);
+				return position.addOffset(pos, topFix, (-offset + leftFix));
 			}
-			return position.addOffset(pos, 0, offset);
+			return position.addOffset(pos, topFix, (offset + leftFix));
 		};
 
 		this.addGap["bottom"] = positionOverflowMenu;
@@ -67,6 +71,30 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 
 		if (!this.dialogConfig.menuLabel) {
 			this.dialogConfig.menuLabel = this.i18n.get().OVERFLOW_MENU.OVERFLOW;
+		}
+	}
+
+	closestAttr(s, t) {
+		let el = this.elementRef.nativeElement;
+
+		do {
+			if (
+				this.matchesAttr(el, s, t)
+			) {
+				return el;
+			}
+			el = el.parentElement || el.parentNode;
+		} while (el !== null && el.nodeType === 1);
+		return null;
+	};
+
+	matchesAttr(el, attr, val) {
+		const styles = window.getComputedStyle(el);
+
+		if (val.includes(styles[attr])) {
+			return true;
+		} else {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Open to feedback and discussion.
I know you can pass an offset to the component but it seems wrong for the component to break by default because some parent has some position set with some modifying positions. It should work as expected by default.

Fixes: https://github.com/IBM/carbon-components-angular/issues/1557

I've even tested this with multiple nesting elements: https://codepen.io/dusanmilko/pen/pobzbqR

Before:
![Screen Shot 2020-10-05 at 10 50 29 AM](https://user-images.githubusercontent.com/302239/95104510-8736b700-06fb-11eb-9092-c9cad5242677.png)

After:
![Screen Shot 2020-10-05 at 10 50 40 AM](https://user-images.githubusercontent.com/302239/95104533-8d2c9800-06fb-11eb-9f05-4271d1d5cefc.png)


Before:
![Screen Shot 2020-10-05 at 10 51 36 AM](https://user-images.githubusercontent.com/302239/95104585-9b7ab400-06fb-11eb-9ddb-d839911cd6e2.png)

After:
![Screen Shot 2020-10-05 at 10 51 22 AM](https://user-images.githubusercontent.com/302239/95104562-9584d300-06fb-11eb-8146-64944dc6e6ac.png)
