### PR TITLE
fix(select): synchronize inner select value with ngmodel on change

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -193,6 +193,7 @@ export class Select implements ControlValueAccessor {
 	 * Sends events to the change handler and emits a `selected` event.
 	 */
 	onChange(event) {
+		this.value = event.target.value;
 		this.onChangeHandler(event.target.value);
 		this.valueChange.emit(event.target.value);
 	}


### PR DESCRIPTION
Fixes #1536 

After select change inner value was not updated and that's why value and ngModel was not in sync and it looks like view is not updated

#### Changelog

**Changed**

*  synchronize  inner value on select changes

