### PR TITLE
fix(file-uploader): remove nesting for `ibm-file` items

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -63,12 +63,12 @@ const noop = () => { };
 					(change)="onFilesAdded()"
 					[disabled]="disabled"/>
 				<div class="bx--file-container">
-					<div *ngFor="let fileItem of files">
+					<ng-container *ngFor="let fileItem of files">
 						<ibm-file [fileItem]="fileItem" (remove)="removeFile(fileItem)"></ibm-file>
 						<div *ngIf="fileItem.invalid" class="bx--form-requirement">
 							{{fileItem.invalidText}}
 						</div>
-					</div>
+					</ng-container>
 				</div>
 			</div>
 		</ng-container>


### PR DESCRIPTION
Closes #1570

Due to nesting wrong style is being applied to each item of file
uploader list:
`.bx--file__selected-file:last-child`
https://www.carbondesignsystem.com/components/file-uploader/style

Thanks!