### PR TITLE
feat(ui-shell): Add icon input to header-menu

### DIFF
--- a/src/ui-shell/header/header-menu.component.ts
+++ b/src/ui-shell/header/header-menu.component.ts
@@ -2,7 +2,8 @@ import {
 	Component,
 	Input,
 	HostListener,
-	ElementRef
+	ElementRef,
+	TemplateRef
 } from "@angular/core";
 import { DomSanitizer } from "@angular/platform-browser";
 import { HeaderItemInterface } from "./header-navigation-items.interface";
@@ -24,9 +25,12 @@ import { HeaderItemInterface } from "./header-navigation-items.interface";
 				aria-haspopup="true"
 				[attr.aria-expanded]="expanded">
 				{{title}}
-				<svg class="bx--header__menu-arrow" width="12" height="7" aria-hidden="true">
-					<path d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
-				</svg>
+				<ng-template *ngIf="icon; else defaultIcon" [ngTemplateOutlet]="icon"></ng-template>
+				<ng-template #defaultIcon>
+					<svg class="bx--header__menu-arrow" width="12" height="7" aria-hidden="true">
+						<path d="M6.002 5.55L11.27 0l.726.685L6.003 7 0 .685.726 0z" />
+					</svg>
+				</ng-template>
 			</a>
 			<ul class="bx--header__menu" role="menu" [attr.aria-label]="title">
 				<ng-content></ng-content>
@@ -61,6 +65,11 @@ export class HeaderMenu {
 	 * Used to create header items through a model.
 	 */
 	@Input() headerItems: HeaderItemInterface[];
+
+	/**
+	 * Optional icon
+	 */
+	@Input() icon: TemplateRef<any>;
 
 	public expanded = false;
 


### PR DESCRIPTION
Sometimes for custom menu it is necessary to change a header menu icon. 

For example I want to create language menu (without text, only icon). It can look like this:
![image](https://user-images.githubusercontent.com/1833101/97330496-e32fce00-18aa-11eb-97b0-826b01fc410f.png)

To support icon changing this PR will add optional icon input for header-menu

#### Changelog

**New**
- feat(ui-shell): Add icon input to header-menu