### PR TITLE
1581 - Render custom template content for an overflow menu

### DIFF
--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -15,6 +15,7 @@ import { EllipsisTooltip } from "./tooltip/ellipsis-tooltip.directive";
 
 import { OverflowMenu } from "./overflow-menu/overflow-menu.component";
 import { OverflowMenuPane } from "./overflow-menu/overflow-menu-pane.component";
+import { OverflowMenuCustomPane } from "./overflow-menu/overflow-menu-custom-pane.component";
 import { OverflowMenuDirective } from "./overflow-menu/overflow-menu.directive";
 import { OverflowMenuOption } from "./overflow-menu/overflow-menu-option.component";
 import { I18nModule } from "carbon-components-angular/i18n";
@@ -32,6 +33,7 @@ import { OverflowMenuVerticalModule } from "@carbon/icons-angular";
 		TooltipIcon,
 		OverflowMenu,
 		OverflowMenuPane,
+		OverflowMenuCustomPane,
 		DialogDirective,
 		TooltipDirective,
 		EllipsisTooltip,
@@ -45,6 +47,7 @@ import { OverflowMenuVerticalModule } from "@carbon/icons-angular";
 		TooltipIcon,
 		OverflowMenu,
 		OverflowMenuPane,
+		OverflowMenuCustomPane,
 		DialogDirective,
 		TooltipDirective,
 		EllipsisTooltip,
@@ -55,7 +58,8 @@ import { OverflowMenuVerticalModule } from "@carbon/icons-angular";
 	entryComponents: [
 		Dialog,
 		Tooltip,
-		OverflowMenuPane
+		OverflowMenuPane,
+		OverflowMenuCustomPane
 	],
 	imports: [
 		CommonModule,

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -10,6 +10,7 @@ export { EllipsisTooltip } from "./tooltip/ellipsis-tooltip.directive";
 
 export { OverflowMenu } from "./overflow-menu/overflow-menu.component";
 export { OverflowMenuPane } from "./overflow-menu/overflow-menu-pane.component";
+export { OverflowMenuCustomPane } from "./overflow-menu/overflow-menu-custom-pane.component";
 export { OverflowMenuDirective } from "./overflow-menu/overflow-menu.directive";
 export { OverflowMenuOption } from "./overflow-menu/overflow-menu-option.component";
 

--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -3,7 +3,7 @@ import { position } from "@carbon/utils-position";
 import { I18n } from "carbon-components-angular/i18n";
 import { ElementService } from "carbon-components-angular/utils";
 
-import { Dialog } from '../dialog.component';
+import { Dialog } from "../dialog.component";
 
 @Component({
 	selector: "ibm-overflow-custom-menu-pane",
@@ -30,7 +30,7 @@ export class OverflowMenuCustomPane extends Dialog implements AfterViewInit {
 		// mark `elementService` as optional since making it mandatory would be a breaking change
 		@Optional() protected elementService: ElementService = null
 	) {
-		super(elementRef, elementService)
+		super(elementRef, elementService);
 	}
 
 	onDialogInit() {

--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -1,0 +1,82 @@
+import { AfterViewInit, Component, ElementRef, Optional } from "@angular/core";
+import { position } from "@carbon/utils-position";
+import { I18n } from "carbon-components-angular/i18n";
+import { ElementService } from "carbon-components-angular/utils";
+
+import { Dialog } from '../dialog.component';
+
+@Component({
+	selector: "ibm-overflow-custom-menu-pane",
+	template: `
+		<div
+			[attr.aria-label]="dialogConfig.menuLabel"
+			[ngClass]="{'bx--overflow-menu--flip': dialogConfig.flip}"
+			class="bx--overflow-menu-options bx--overflow-menu-options--open"
+			role="menu"
+			(click)="doClose()"
+			#dialog
+			[attr.aria-label]="dialogConfig.menuLabel">
+			<ng-template
+				[ngTemplateOutlet]="dialogConfig.content"
+				[ngTemplateOutletContext]="{overflowMenu: this}">
+			</ng-template>
+		</div>
+	`
+})
+export class OverflowMenuCustomPane extends Dialog implements AfterViewInit {
+	constructor(
+		protected elementRef: ElementRef,
+		protected i18n: I18n,
+		// mark `elementService` as optional since making it mandatory would be a breaking change
+		@Optional() protected elementService: ElementService = null
+	) {
+		super(elementRef, elementService)
+	}
+
+	onDialogInit() {
+		const positionOverflowMenu = pos => {
+			let offset;
+			/*
+			* 16 is half the width of the overflow menu trigger element.
+			* we also move the element by half of it's own width, since
+			* position service will try and center everything
+			*/
+			const closestRel = this.closestAttr("position", ["relative", "fixed", "absolute"]);
+			const topFix = closestRel ? closestRel.getBoundingClientRect().top * -1 : 0;
+			const leftFix = closestRel ? closestRel.getBoundingClientRect().left * -1 : 0;
+
+			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 16;
+			if (this.dialogConfig.flip) {
+				return position.addOffset(pos, topFix, (-offset + leftFix));
+			}
+			return position.addOffset(pos, topFix, (offset + leftFix));
+		};
+
+		this.addGap["bottom"] = positionOverflowMenu;
+
+		this.addGap["top"] = positionOverflowMenu;
+
+		if (!this.dialogConfig.menuLabel) {
+			this.dialogConfig.menuLabel = this.i18n.get().OVERFLOW_MENU.OVERFLOW;
+		}
+	}
+
+	closestAttr(s, t) {
+		let el = this.elementRef.nativeElement;
+
+		do {
+			if (
+				this.matchesAttr(el, s, t)
+			) {
+				return el;
+			}
+			el = el.parentElement || el.parentNode;
+		} while (el !== null && el.nodeType === 1);
+		return null;
+	}
+
+	matchesAttr(el, attr, val) {
+		const styles = window.getComputedStyle(el);
+		return val.includes(styles[attr]);
+	}
+}

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -4,11 +4,13 @@ import {
 	ViewContainerRef,
 	Input,
 	TemplateRef,
-	HostListener
+	HostListener,
+	AfterContentInit
 } from "@angular/core";
 import { DialogDirective } from "../dialog.directive";
 import { DialogService } from "../dialog.service";
 import { OverflowMenuPane } from "./overflow-menu-pane.component";
+import { OverflowMenuCustomPane } from './overflow-menu-custom-pane.component';
 import { EventService } from "carbon-components-angular/utils";
 
 
@@ -27,6 +29,13 @@ import { EventService } from "carbon-components-angular/utils";
  * 	<!-- overflow menu options here -->
  * </ng-template>
  * ```
+ *
+ * ```html
+ * <div [ibmOverflowMenu]="templateRef" [customPane]="true"></div>
+ * <ng-template #templateRef>
+ *  <!-- custom content goes here -->
+ * </ng-template>
+ * ```
  */
 @Directive({
 	selector: "[ibmOverflowMenu]",
@@ -35,7 +44,7 @@ import { EventService } from "carbon-components-angular/utils";
 		DialogService
 	]
 })
-export class OverflowMenuDirective extends DialogDirective {
+export class OverflowMenuDirective extends DialogDirective implements AfterContentInit {
 	/**
 	 * Takes a template ref of `OverflowMenuOptions`s
 	 */
@@ -52,6 +61,10 @@ export class OverflowMenuDirective extends DialogDirective {
 	 * Classes to add to the dialog container
 	 */
 	@Input() wrapperClass = "";
+	/**
+	 * Set to true to for custom content
+	 */
+	@Input() customPane = false;
 
 	/**
 	 * Creates an instance of `OverflowMenuDirective`.
@@ -63,7 +76,10 @@ export class OverflowMenuDirective extends DialogDirective {
 		protected eventService: EventService
 	) {
 		super(elementRef, viewContainerRef, dialogService, eventService);
-		dialogService.setContext({ component: OverflowMenuPane });
+	}
+
+	ngAfterContentInit() {
+		this.dialogService.setContext({ component: this.customPane ? OverflowMenuCustomPane : OverflowMenuPane });
 	}
 
 	updateConfig() {

--- a/src/dialog/overflow-menu/overflow-menu.directive.ts
+++ b/src/dialog/overflow-menu/overflow-menu.directive.ts
@@ -10,7 +10,7 @@ import {
 import { DialogDirective } from "../dialog.directive";
 import { DialogService } from "../dialog.service";
 import { OverflowMenuPane } from "./overflow-menu-pane.component";
-import { OverflowMenuCustomPane } from './overflow-menu-custom-pane.component';
+import { OverflowMenuCustomPane } from "./overflow-menu-custom-pane.component";
 import { EventService } from "carbon-components-angular/utils";
 
 

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -6,11 +6,12 @@ import {
 	object
 } from "@storybook/addon-knobs";
 
-import { DialogModule } from "../../index";
-import { PlaceholderModule } from "../../placeholder/index";
+import { DialogModule } from "../../dialog";
+import { PlaceholderModule } from "../../placeholder";
 import { DocumentationModule } from "./../../documentation-component/documentation.module";
+import { CheckboxModule } from "../../checkbox";
 
-import { DocumentModule } from "@carbon/icons-angular";
+import { DocumentModule, SettingsModule } from "@carbon/icons-angular";
 
 let options;
 
@@ -29,7 +30,9 @@ storiesOf("Components|Overflow Menu", module)
 				DialogModule,
 				DocumentModule,
 				PlaceholderModule,
-				DocumentationModule
+				DocumentationModule,
+				CheckboxModule,
+				SettingsModule
 			]
 		})
 	)
@@ -188,6 +191,25 @@ storiesOf("Components|Overflow Menu", module)
 		props: {
 			open: boolean("Open", false)
 		}
+	}))
+	.add("With custom template", () => ({
+		template: `
+			<p style="padding-bottom: 1rem;">When writing a custom template to be inserted into an overflow menu it becomes your responsibility to make sure tab order/keyboard nav is implemented correctly</p>
+			<button
+				style="border: none; width: 3rem; height: 3rem; background-color: lightgrey; display: flex; align-items: center; justify-content: center;"
+				[ibmOverflowMenu]="templateRef"
+				[customPane]="true"
+				placement="bottom"
+				[offset]="{ x: -8, y: 0 }"
+			><svg ibmIconSettings size="16"></svg></button>
+			<ng-template #templateRef>
+				<div style="padding: 0 1rem;">
+					<div style="padding-top: 0.5rem; color: grey;">Columns</div>
+					<div><ibm-checkbox [checked]="true">Status</ibm-checkbox></div>
+					<div><ibm-checkbox>Last modified</ibm-checkbox></div>
+				</div>
+			</ng-template>
+		`
 	}))
 	.add("Documentation", () => ({
 		template: `

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -194,9 +194,13 @@ storiesOf("Components|Overflow Menu", module)
 	}))
 	.add("With custom template", () => ({
 		template: `
-			<p style="padding-bottom: 1rem;">When writing a custom template to be inserted into an overflow menu it becomes your responsibility to make sure tab order/keyboard nav is implemented correctly</p>
+			<p style="padding-bottom: 1rem;">
+				When writing a custom template to be inserted into an overflow menu
+				it becomes your responsibility to make sure tab order/keyboard nav is implemented correctly
+			</p>
 			<button
-				style="border: none; width: 3rem; height: 3rem; background-color: lightgrey; display: flex; align-items: center; justify-content: center;"
+				style="border: none; width: 3rem; height: 3rem; background-color: lightgrey;
+				display: flex; align-items: center; justify-content: center;"
 				[ibmOverflowMenu]="templateRef"
 				[customPane]="true"
 				placement="bottom"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1581

Adds a new component to allow rendering of custom content into an overflow menu inserted into a div rather than a ul element

#### Changelog

**New**

* `carbon-components-angular/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts`

**Changed**

* `carbon-components-angular/src/dialog/dialog.module.ts`
* `carbon-components-angular/src/dialog/overflow-menu/overflow-menu.diretive.ts`
* `carbon-components-angular/src/dialog/overflow-menu/overflow-menu.stories.ts`
