### PR TITLE
fix(combobox): fix multi combobox closing on selection

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -475,7 +475,8 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	 */
 	ngAfterViewInit() {
 		this.documentService.handleClick(event => {
-			if (!this.elementRef.nativeElement.contains(event.target)) {
+			if (!this.elementRef.nativeElement.contains(event.target) &&
+				!this.dropdownMenu.nativeElement.contains(event.target)) {
 				if (this.open) {
 					this.closeDropdown();
 				}


### PR DESCRIPTION
Combobox multiselect currently closes on selection. It should stay open like how the dropdown multiselect does so user can keep making selections if needed.

This code is borrowed from dropdown logic.

Fixes: https://github.com/IBM/carbon-components-angular/issues/1584