### PR TITLE
 fix(#1533): combobox undefined typeerror

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -545,6 +545,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 				newValue.selected = true;
 				this.view.propagateSelected([newValue]);
 			} else {
+				// all items in propagateSelected must be iterable
 				this.view.propagateSelected([value || ""]);
 			}
 			this.showClearButton = !!(value && this.view.getSelected().length);

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -545,7 +545,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 				newValue.selected = true;
 				this.view.propagateSelected([newValue]);
 			} else {
-				this.view.propagateSelected([value]);
+				this.view.propagateSelected([value || ""]);
 			}
 			this.showClearButton = !!(value && this.view.getSelected().length);
 		} else {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1533

Combobox (type: single) throws TypeError because of bad 

` "TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))"`

#### Changelog

**Changed**

* Added fallback value for combobox, specifically, when:
    * type: single
    * `itemValueKey` is falsey
