### PR TITLE
feat: swap to new internal icon component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9772,9 +9772,9 @@
       "dev": true
     },
     "carbon-components": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.20.0.tgz",
-      "integrity": "sha512-MysxXg4/DpDt9GJPV3zmxi9X6HyGxr7DyROvVjf4SCyYrBqTeLOoajd3sbPhKxPjDdRIyqEb2roLq5DbbtazLg==",
+      "version": "10.23.2",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.23.2.tgz",
+      "integrity": "sha512-rw/FzEEP4XILoz1S8a90k7xSNJR0Nrp1piSwAIj87OQp116Bui7tudAHq4gXZfgXF6OJaiOSKwnRA6kLBuMBUg==",
       "dev": true,
       "requires": {
         "flatpickr": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/jasmine": "2.8.2",
     "@types/node": "11.13.0",
     "babel-loader": "8.0.5",
-    "carbon-components": "10.20.0",
+    "carbon-components": "10.23.2",
     "chai": "4.2.0",
     "codelyzer": "5.0.0",
     "commitizen": "4.0.3",

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -16,7 +16,7 @@ import {
 			[attr.aria-controls]="id"
 			(click)="toggleExpanded()"
 			class="bx--accordion__heading">
-			<ibm-icon-chevron-right size="16" class="bx--accordion__arrow"></ibm-icon-chevron-right>
+			<svg ibmIcon="chevron--right" size="16" class="bx--accordion__arrow"></svg>
 			<p *ngIf="!isTemplate(title)"
 				class="bx--accordion__title"
 				[ngClass]="{

--- a/src/accordion/accordion.component.spec.ts
+++ b/src/accordion/accordion.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { FormsModule } from "@angular/forms";
 import { By } from "@angular/platform-browser";
 import { Component } from "@angular/core";
-import { ChevronRightModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { AccordionItem } from "./accordion-item.component";
 import { Accordion } from "./accordion.component";
 
@@ -32,7 +32,7 @@ describe("Accordion", () => {
 			],
 			imports: [
 				FormsModule,
-				ChevronRightModule
+				IconModule
 			]
 		});
 	});

--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { ChevronRightModule } from "@carbon/icons-angular";
 
 import { Accordion } from "./accordion.component";
 import { AccordionItem } from "./accordion-item.component";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -16,7 +16,7 @@ import { AccordionItem } from "./accordion-item.component";
 	],
 	imports: [
 		CommonModule,
-		ChevronRightModule
+		IconModule
 	]
 })
 export class AccordionModule { }

--- a/src/code-snippet/code-snippet.component.spec.ts
+++ b/src/code-snippet/code-snippet.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { I18nModule } from "../i18n/index";
+import { IconModule } from "../icon/index";
 
 import { CodeSnippet } from "./code-snippet.component";
-import { CopyModule, ChevronDownModule } from "@carbon/icons-angular";
 
 describe("CodeSnippet", () => {
 	let component: CodeSnippet;
@@ -13,8 +13,7 @@ describe("CodeSnippet", () => {
 			declarations: [CodeSnippet],
 			imports: [
 				I18nModule,
-				CopyModule,
-				ChevronDownModule
+				IconModule
 			]
 		});
 

--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -50,7 +50,7 @@ export enum SnippetType {
 				[attr.aria-label]="translations.COPY_CODE"
 				(click)="onCopyButtonClicked()"
 				tabindex="0">
-				<ibm-icon-copy size="16" class="bx--snippet__icon"></ibm-icon-copy>
+				<svg ibmIcon="copy" size="16" class="bx--snippet__icon"></svg>
 				<ng-container *ngTemplateOutlet="feedbackTemplate"></ng-container>
 			</button>
 			<button
@@ -59,7 +59,7 @@ export enum SnippetType {
 				(click)="toggleSnippetExpansion()"
 				type="button">
 				<span class="bx--snippet-btn--text">{{expanded ? translations.SHOW_LESS : translations.SHOW_MORE}}</span>
-				<ibm-icon-chevron-down size="16" class="bx--icon-chevron--down" [ariaLabel]="translations.SHOW_MORE_ICON"></ibm-icon-chevron-down>
+				<svg ibmIcon="chevron--down" size="16" class="bx--icon-chevron--down" [ariaLabel]="translations.SHOW_MORE_ICON"></svg>
 			</button>
 		</ng-template>
 

--- a/src/code-snippet/code-snippet.module.ts
+++ b/src/code-snippet/code-snippet.module.ts
@@ -2,7 +2,7 @@
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { CommonModule } from "@angular/common";
-import { CopyModule, ChevronDownModule } from "@carbon/icons-angular";
+import { IconModule } from "carbon-components-angular/icon";
 
 import { I18nModule } from "carbon-components-angular/i18n";
 
@@ -20,8 +20,7 @@ import { CodeSnippet } from "./code-snippet.component";
 		CommonModule,
 		FormsModule,
 		I18nModule,
-		CopyModule,
-		ChevronDownModule
+		IconModule
 	]
 })
 export class CodeSnippetModule { }

--- a/src/combobox/combobox.component.spec.ts
+++ b/src/combobox/combobox.component.spec.ts
@@ -1,11 +1,8 @@
 import { Component } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { By	} from "@angular/platform-browser";
-import {
-	ChevronDownModule,
-	WarningFilledModule,
-	CloseModule
-} from "@carbon/icons-angular";
+
+import { IconModule } from "../icon/index";
 import { I18nModule } from "../i18n/index";
 
 import { ListItem } from "./../dropdown/list-item.interface";
@@ -48,9 +45,7 @@ describe("Combo box", () => {
 				ScrollableList
 			],
 			imports: [
-				ChevronDownModule,
-				WarningFilledModule,
-				CloseModule,
+				IconModule,
 				I18nModule,
 				FormsModule,
 				UtilsModule,

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -107,7 +107,12 @@ import { Observable } from "rxjs";
 					aria-haspopup="true"
 					[autocomplete]="autocomplete"
 					[placeholder]="placeholder"/>
-				<ibm-icon-warning-filled size="16" *ngIf="invalid" class="bx--list-box__invalid-icon"></ibm-icon-warning-filled>
+				<svg
+					*ngIf="invalid"
+					ibomIcon="warning--filled"
+					size="16"
+					class="bx--list-box__invalid-icon">
+				</svg>
 				<div
 					*ngIf="showClearButton"
 					role="button"
@@ -118,14 +123,16 @@ import { Observable } from "rxjs";
 					(keyup.enter)="clearInput($event)"
 					(click)="clearInput($event)"
 					(blur)="onBlur()">
-					<svg ibmIconClose size="16"></svg>
+					<svg ibmIcon="close" size="16"></svg>
 				</div>
-				<ibm-icon-chevron-down size="16"
+				<svg
+					ibmIcon="chevron--down"
+					size="16"
 					[ngClass]="{'bx--list-box__menu-icon--open': open}"
 					class="bx--list-box__menu-icon"
 					[title]="open ? closeMenuAria : openMenuAria"
 					[ariaLabel]="open ? closeMenuAria : openMenuAria">
-				</ibm-icon-chevron-down>
+				</svg>
 			</div>
 			<div #dropdownMenu>
 				<ng-content *ngIf="open"></ng-content>

--- a/src/combobox/combobox.module.ts
+++ b/src/combobox/combobox.module.ts
@@ -1,15 +1,11 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import {
-	ChevronDownModule,
-	CloseModule,
-	WarningFilledModule
-} from "@carbon/icons-angular";
 
 import { ComboBox } from "./combobox.component";
 import { DropdownModule, DropdownService } from "carbon-components-angular/dropdown";
 import { I18nModule } from "carbon-components-angular/i18n";
 import { UtilsModule } from "carbon-components-angular/utils";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -22,11 +18,9 @@ import { UtilsModule } from "carbon-components-angular/utils";
 	imports: [
 		CommonModule,
 		DropdownModule,
-		ChevronDownModule,
-		CloseModule,
-		WarningFilledModule,
 		I18nModule,
-		UtilsModule
+		UtilsModule,
+		IconModule
 	],
 	providers: [ DropdownService ]
 })

--- a/src/datepicker-input/datepicker-input.component.spec.ts
+++ b/src/datepicker-input/datepicker-input.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { Component } from "@angular/core";
 import { DatePickerInput } from "./datepicker-input.component";
-import { CalendarModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { CommonModule } from "@angular/common";
 
 @Component({
@@ -40,7 +40,7 @@ describe("Select", () => {
 			],
 			imports: [
 				CommonModule,
-				CalendarModule,
+				IconModule,
 				FormsModule
 			]
 		});

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -43,7 +43,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[id]= "id"
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
-						<svg ibmIconCalendar size="16" class="bx--date-picker__icon"></svg>
+						<svg ibmIcon="calendar" size="16" class="bx--date-picker__icon"></svg>
 				</div>
 				<div *ngIf="invalid" class="bx--form-requirement">
 					<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>

--- a/src/datepicker-input/datepicker-input.module.ts
+++ b/src/datepicker-input/datepicker-input.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { DatePickerInput } from "./datepicker-input.component";
-import { CalendarModule } from "@carbon/icons-angular";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -12,7 +12,7 @@ import { CalendarModule } from "@carbon/icons-angular";
 	],
 	imports: [
 		CommonModule,
-		CalendarModule
+		IconModule
 	]
 })
 export class DatePickerInputModule { }

--- a/src/datepicker/datepicker.component.spec.ts
+++ b/src/datepicker/datepicker.component.spec.ts
@@ -3,7 +3,7 @@ import { By } from "@angular/platform-browser";
 import { Component } from "@angular/core";
 import { DatePicker } from "./datepicker.component";
 import { DatePickerInput } from "../datepicker-input/datepicker-input.component";
-import { CalendarModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { FormsModule } from "@angular/forms";
 import { UtilsModule } from "../utils/utils.module";
 import { I18nModule } from "../i18n/i18n.module";
@@ -40,7 +40,7 @@ describe("DatePicker", () => {
 				DatePickerInput
 			],
 			imports: [
-				CalendarModule,
+				IconModule,
 				UtilsModule,
 				FormsModule,
 				I18nModule

--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -22,8 +22,7 @@ import { I18nModule } from "carbon-components-angular/i18n";
 import { PlaceholderModule } from "carbon-components-angular/placeholder";
 import { ExperimentalModule } from "carbon-components-angular/experimental";
 import { UtilsModule } from "carbon-components-angular/utils";
-
-import { OverflowMenuVerticalModule } from "@carbon/icons-angular";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -67,7 +66,7 @@ import { OverflowMenuVerticalModule } from "@carbon/icons-angular";
 		PlaceholderModule,
 		ExperimentalModule,
 		UtilsModule,
-		OverflowMenuVerticalModule
+		IconModule
 	]
 })
 export class DialogModule {}

--- a/src/dialog/overflow-menu/overflow-menu.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu.component.ts
@@ -50,7 +50,7 @@ import { OverflowMenuDirective } from "./overflow-menu.directive";
 			<ng-content></ng-content>
 		</ng-template>
 		<ng-template #defaultIcon>
-			<svg ibmIconOverflowMenuVertical size="16" class="bx--overflow-menu__icon"></svg>
+			<svg ibmIcon="overflow-menu--vertical" size="16" class="bx--overflow-menu__icon"></svg>
 		</ng-template>
 	`,
 	styles: [`

--- a/src/dropdown/dropdown.component.spec.ts
+++ b/src/dropdown/dropdown.component.spec.ts
@@ -11,7 +11,7 @@ import { DropdownService } from "./dropdown.service";
 import { PlaceholderModule } from "./../placeholder/index";
 import { FormsModule } from "@angular/forms";
 import { UtilsModule } from "../utils/utils.module";
-import { ChevronDownModule, WarningFilledModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 
 @Component({
 	template: `
@@ -43,9 +43,8 @@ describe("Dropdown", () => {
 			imports: [
 				I18nModule,
 				PlaceholderModule,
-				ChevronDownModule,
 				FormsModule,
-				WarningFilledModule,
+				IconModule,
 				UtilsModule
 			],
 			providers: [ DropdownService ]

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -111,18 +111,20 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 				[ngTemplateOutletContext]="getRenderTemplateContext()"
 				[ngTemplateOutlet]="displayValue">
 			</ng-template>
-			<svg ibmIconWarningFilled
-				size="16"
+			<svg
 				*ngIf="invalid"
-				class="bx--dropdown__invalid-icon">
+				class="bx--dropdown__invalid-icon"
+				ibomIcon="warning--filled"
+				size="16">
 			</svg>
-			<ibm-icon-chevron-down
-				size="16"
+			<svg
 				*ngIf="!skeleton"
+				ibmIcon="chevron--down"
+				size="16"
 				class="bx--list-box__menu-icon"
 				[attr.aria-label]="menuButtonLabel"
 				[ngClass]="{'bx--list-box__menu-icon--open': !menuIsClosed }">
-			</ibm-icon-chevron-down>
+			</svg>
 		</button>
 		<div
 			#dropdownMenu

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -10,8 +10,8 @@ import { ScrollableList } from "./scrollable-list.directive";
 import { I18nModule } from "carbon-components-angular/i18n";
 import { PlaceholderModule } from "carbon-components-angular/placeholder";
 import { DropdownService } from "./dropdown.service";
-import { ChevronDownModule, WarningFilledModule, CheckmarkModule } from "@carbon/icons-angular";
 import { UtilsModule } from "carbon-components-angular/utils";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -28,13 +28,11 @@ import { UtilsModule } from "carbon-components-angular/utils";
 	],
 	imports: [
 		CommonModule,
-		CheckmarkModule,
 		FormsModule,
 		I18nModule,
 		PlaceholderModule,
-		ChevronDownModule,
-		WarningFilledModule,
-		UtilsModule
+		UtilsModule,
+		IconModule
 	],
 	providers: [ DropdownService ]
 })

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -91,7 +91,7 @@ import { ScrollCustomEvent } from "./scroll-custom-event.interface";
 					<ng-container *ngIf="!listTpl && type === 'single'">{{item.content}}</ng-container>
 					<svg
 						*ngIf="!listTpl && type === 'single'"
-						ibmIconCheckmark
+						ibmIcon="checkmark"
 						size="16"
 						class="bx--list-box__menu-item__selected-icon">
 					</svg>

--- a/src/file-uploader/file-uploader.component.spec.ts
+++ b/src/file-uploader/file-uploader.component.spec.ts
@@ -6,11 +6,7 @@ import { LoadingModule } from "carbon-components-angular/loading";
 import { FileUploader } from "./file-uploader.component";
 import { FileComponent } from "./file.component";
 import { CommonModule } from "@angular/common";
-import {
-	CheckmarkFilledModule,
-	WarningFilledModule,
-	CloseModule
-} from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { By } from "@angular/platform-browser";
 import { FileItem } from "./file-item.interface";
 
@@ -44,9 +40,7 @@ describe("FileUploader", () => {
 				CommonModule,
 				ButtonModule,
 				LoadingModule,
-				CloseModule,
-				CheckmarkFilledModule,
-				WarningFilledModule
+				IconModule
 			]
 		});
 	});

--- a/src/file-uploader/file-uploader.module.ts
+++ b/src/file-uploader/file-uploader.module.ts
@@ -1,15 +1,11 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import {
-	CloseModule,
-	CheckmarkFilledModule,
-	WarningFilledModule
-} from "@carbon/icons-angular";
 
 import { FileUploader } from "./file-uploader.component";
 import { FileComponent } from "./file.component";
 import { ButtonModule } from "carbon-components-angular/button";
 import { LoadingModule } from "carbon-components-angular/loading";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [FileUploader, FileComponent],
@@ -18,9 +14,7 @@ import { LoadingModule } from "carbon-components-angular/loading";
 		CommonModule,
 		ButtonModule,
 		LoadingModule,
-		CloseModule,
-		CheckmarkFilledModule,
-		WarningFilledModule
+		IconModule
 	]
 })
 export class FileUploaderModule { }

--- a/src/file-uploader/file.component.ts
+++ b/src/file-uploader/file.component.ts
@@ -21,16 +21,18 @@ import { FileItem } from "./file-item.interface";
 			(keyup.enter)="remove.emit()"
 			(keyup.space)="remove.emit()"
 			tabindex="0">
-			<ibm-icon-warning-filled
-				size="16"
+			<svg
 				*ngIf="isInvalidText"
-				class="bx--file--invalid">
-			</ibm-icon-warning-filled>
-			<ibm-icon-close
+				ibomIcon="warning--filled"
+				class="bx--file--invalid"
+				size="16">
+			</svg>
+			<svg
+				ibmIcon="close"
 				size="16"
 				class="bx--file-close"
 				[ariaLabel]="translations.REMOVE_BUTTON">
-			</ibm-icon-close>
+			</svg>
 		</span>
 		<span *ngIf="fileItem.state === 'upload'">
 			<div class="bx--inline-loading__animation">
@@ -41,11 +43,13 @@ import { FileItem } from "./file-item.interface";
 			*ngIf="fileItem.state === 'complete'"
 			class="bx--file__state-container"
 			tabindex="0">
-			<ibm-icon-checkmark-filled
+
+			<svg
+				ibmIcon="checkmark--filled"
 				size="16"
 				class="bx--file-complete"
 				[ariaLabel]="translations.CHECKMARK">
-			</ibm-icon-checkmark-filled>
+			</svg>
 		</span>
 	`
 })

--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -6,12 +6,42 @@ import { CommonModule } from "@angular/common";
 import { IconDirective } from "./icon.directive";
 import { IconService } from "./icon.service";
 
+// icon imports
+import {
+	Add16,
+	Calendar16,
+	CaretDown16,
+	CaretLeft16,
+	CaretRight16,
+	CaretUp16,
+	Checkmark16,
+	CheckmarkFilled16,
+	CheckmarkOutline16,
+	ChevronDown16,
+	ChevronRight16,
+	Close16,
+	Close20,
+	Copy16,
+	Delete16,
+	Download16,
+	ErrorFilled16,
+	InformationFilled16,
+	Menu16,
+	Menu20,
+	OverflowMenuVertical16,
+	Save16,
+	Search16,
+	Settings16,
+	Warning16,
+	WarningFilled16
+} from "@carbon/icons";
+
 // either provides a new instance of IconService, or returns the parent
 export function ICON_SERVICE_PROVIDER_FACTORY(parentService: IconService) {
 	return parentService || new IconService();
 }
 
-// placeholder service *must* be a singleton to ensure the placeholder viewRef is accessible globally
+// icon service *must* be a singleton to ensure that icons are accessible globally and not duplicated
 export const ICON_SERVICE_PROVIDER = {
 	provide: IconService,
 	deps: [[new Optional(), new SkipSelf(), IconService]],
@@ -33,8 +63,34 @@ export const ICON_SERVICE_PROVIDER = {
 	]
 })
 export class IconModule {
-	constructor(iconService: IconService) {
-		// TODO register icons used in the library here to ensure they're available anywhere
-		// iconService.register(Icon);
+	constructor(protected iconService: IconService) {
+		iconService.registerAll([
+			Add16,
+			Calendar16,
+			CaretDown16,
+			CaretLeft16,
+			CaretRight16,
+			CaretUp16,
+			Checkmark16,
+			CheckmarkFilled16,
+			CheckmarkOutline16,
+			ChevronDown16,
+			ChevronRight16,
+			Close16,
+			Close20,
+			Copy16,
+			Delete16,
+			Download16,
+			ErrorFilled16,
+			InformationFilled16,
+			Menu16,
+			Menu20,
+			OverflowMenuVertical16,
+			Save16,
+			Search16,
+			Settings16,
+			Warning16,
+			WarningFilled16
+		]);
 	}
 }

--- a/src/icon/icon.service.ts
+++ b/src/icon/icon.service.ts
@@ -176,10 +176,6 @@ export class IconMemoryCache extends IconCache {
 export class IconService {
 	private iconCache: IconCache = new IconMemoryCache();
 
-	constructor() {
-		console.log(this.iconCache);
-	}
-
 	/**
 	 * Registers an array of icons based on the metadata provided by `@carbon/cions`
 	 */

--- a/src/icon/icon.service.ts
+++ b/src/icon/icon.service.ts
@@ -1,6 +1,33 @@
 import { Injectable } from "@angular/core";
 import { toString } from "@carbon/icon-helpers";
 
+// icon imports
+import {
+	Add16,
+	Calendar16,
+	CaretDown16,
+	CaretLeft16,
+	CaretRight16,
+	CaretUp16,
+	Checkmark16,
+	CheckmarkFilled16,
+	CheckmarkOutline16,
+	ChevronDown16,
+	ChevronRight16,
+	Close16,
+	Copy16,
+	Delete16,
+	Download16,
+	ErrorFilled16,
+	InformationFilled16,
+	Menu16,
+	OverflowMenuVertical16,
+	Save16,
+	Settings16,
+	Warning16,
+	WarningFilled16
+} from "@carbon/icons";
+
 /**
  * An object that represents a parsed icon
  */
@@ -148,6 +175,18 @@ export class IconMemoryCache extends IconCache {
 @Injectable()
 export class IconService {
 	private iconCache: IconCache = new IconMemoryCache();
+
+	constructor() {
+		console.log(this.iconCache);
+	}
+
+	/**
+	 * Registers an array of icons based on the metadata provided by `@carbon/cions`
+	 */
+	public registerAll(descriptors: object[]) {
+		descriptors.forEach(icon => this.register(icon));
+	}
+
 	/**
 	 * Registers an icon based on the metadata provided by `@carbon/icons`
 	 */

--- a/src/inline-loading/inline-loading.component.ts
+++ b/src/inline-loading/inline-loading.component.ts
@@ -42,13 +42,13 @@ export enum InlineLoadingState {
 			</div>
 			<svg
 				*ngIf="state === InlineLoadingState.Finished"
-				ibmIconCheckmarkFilled
+				ibmIcon="checkmark--filled"
 				size="16"
 				class="bx--inline-loading__checkmark-container">
 			</svg>
 			<svg
 				*ngIf="state === InlineLoadingState.Error"
-				ibmIconErrorFilled
+				ibmIcon="error--filled"
 				size="16"
 				class="bx--inline-loading--error">
 			</svg>

--- a/src/inline-loading/inline-loading.module.ts
+++ b/src/inline-loading/inline-loading.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { CheckmarkModule, ErrorFilledModule, CheckmarkFilledModule } from "@carbon/icons-angular";
 
 import { InlineLoading } from "./inline-loading.component";
+import { IconModule } from "carbon-components-angular/icon";
+
 
 @NgModule({
 	declarations: [InlineLoading],
 	exports: [InlineLoading],
-	imports: [CommonModule, CheckmarkModule, CheckmarkFilledModule, ErrorFilledModule]
+	imports: [CommonModule, IconModule]
 })
 export class InlineLoadingModule { }

--- a/src/input/input.module.ts
+++ b/src/input/input.module.ts
@@ -7,7 +7,7 @@ import { CommonModule } from "@angular/common";
 import { Label } from "./label.component";
 import { TextInput } from "./input.directive";
 import { TextArea } from "./text-area.directive";
-import { WarningFilledModule } from "@carbon/icons-angular";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -23,7 +23,7 @@ import { WarningFilledModule } from "@carbon/icons-angular";
 	imports: [
 		CommonModule,
 		FormsModule,
-		WarningFilledModule
+		IconModule
 	]
 })
 export class InputModule { }

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -46,11 +46,12 @@ import { TextArea } from "./text-area.directive";
 			<ng-content></ng-content>
 		</label>
 		<div [class]="wrapperClass" [attr.data-invalid]="(invalid ? true : null)" #wrapper>
-			<ibm-icon-warning-filled
-				size="16"
+			<svg
 				*ngIf="invalid"
+				ibmIcon="warning--filled"
+				size="16"
 				class="bx--text-input__invalid-icon bx--text-area__invalid-icon">
-			</ibm-icon-warning-filled>
+			</svg>
 			<ng-content select="input,textarea,div"></ng-content>
 		</div>
 		<div *ngIf="!skeleton && helperText && !invalid" class="bx--form__helper-text">

--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -28,7 +28,7 @@ import { ExperimentalService } from "carbon-components-angular/experimental";
 				class="bx--modal-close"
 				(click)="onClose()">
 				<span class="bx--assistive-text">{{ closeLabel }}</span>
-				<svg ibmIconClose size="20" class="bx--modal-close__icon"></svg>
+				<svg ibmIcon="close" size="20" class="bx--modal-close__icon"></svg>
 			</button>
 		</header>
 

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -38,7 +38,7 @@ import { cycleTabs, getFocusElementList } from "carbon-components-angular/common
 						<section class="modal-body">
 							<h1>Sample modal works.</h1>
 							<button class="btn--icon-link" nPopover="Hello there" title="Popover title" placement="right" appendInline="true">
-								<ibm-icon icon="info" size="sm"></ibm-icon>
+								<svg ibmIcon="info" size="sm"></ibm-icon>
 							</button>
 							{{modalText}}
 						</section>

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,7 +1,6 @@
 // modules
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { CloseModule } from "@carbon/icons-angular";
 
 // imports
 import { ModalService } from "./modal.service";
@@ -19,6 +18,7 @@ import { ModalContentText } from "./modal-content-text.directive";
 import { ModalHeaderHeading } from "./modal-header-heading.directive";
 import { ModalHeaderLabel } from "./modal-header-label.directive";
 import { BaseModal } from "./base-modal.class";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -57,7 +57,7 @@ import { BaseModal } from "./base-modal.class";
 		I18nModule,
 		PlaceholderModule,
 		ExperimentalModule,
-		CloseModule
+		IconModule
 	]
 })
 export class ModalModule { }

--- a/src/notification/notification.component.spec.ts
+++ b/src/notification/notification.component.spec.ts
@@ -2,13 +2,7 @@ import { TestBed } from "@angular/core/testing";
 
 import { Notification, NotificationDisplayService } from "./index";
 import { I18nModule } from "../i18n/index";
-import {
-	CloseModule,
-	ErrorFilledModule,
-	CheckmarkFilledModule,
-	WarningFilledModule
-} from "@carbon/icons-angular";
-
+import { IconModule } from "../icon/index";
 
 describe("Notification", () => {
 	beforeEach(() => {
@@ -17,10 +11,7 @@ describe("Notification", () => {
 			providers: [NotificationDisplayService],
 			imports: [
 				I18nModule,
-				CloseModule,
-				ErrorFilledModule,
-				CheckmarkFilledModule,
-				WarningFilledModule
+				IconModule
 			]
 		});
 	});

--- a/src/notification/notification.component.ts
+++ b/src/notification/notification.component.ts
@@ -25,25 +25,25 @@ import { of, isObservable, Subject } from "rxjs";
 	template: `
 		<div class="bx--inline-notification__details">
 			<svg
-				ibmIconErrorFilled
+				ibmIcon="error--filled"
 				size="16"
 				*ngIf="notificationObj.type === 'error'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
-				ibmIconWarningFilled
+				ibmIcon="warning--filled"
 				size="16"
 				*ngIf="notificationObj.type === 'warning'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
-				ibmIconCheckmarkFilled
+				ibmIcon="checkmark--filled"
 				size="16"
 				*ngIf="notificationObj.type === 'success'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
-				ibmIconInformationFilled
+				ibmIcon="information--filled"
 				size="16"
 				*ngIf="notificationObj.type === 'info'"
 				class="bx--inline-notification__icon">
@@ -75,7 +75,7 @@ import { of, isObservable, Subject } from "rxjs";
 			class="bx--inline-notification__close-button"
 			[attr.aria-label]="notificationObj.closeLabel | async"
 			type="button">
-			<ibm-icon-close size="16" class="bx--inline-notification__close-icon"></ibm-icon-close>
+			<svg ibmIcon="close" size="16" class="bx--inline-notification__close-icon"></svg>
 		</button>
 	`
 })

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -1,13 +1,6 @@
 import { NgModule } from "@angular/core";
 import { ButtonModule } from "carbon-components-angular/button";
 import { CommonModule } from "@angular/common";
-import {
-	CloseModule,
-	ErrorFilledModule,
-	CheckmarkFilledModule,
-	WarningFilledModule,
-	InformationFilledModule
-} from "@carbon/icons-angular";
 
 import { Toast } from "./toast.component";
 import { ToastTitle } from "./toast-title.directive";
@@ -21,6 +14,7 @@ import { NotificationDisplayService } from "./notification-display.service";
 import { I18nModule } from "carbon-components-angular/i18n";
 import { ExperimentalModule } from "carbon-components-angular/experimental";
 import { LinkModule } from "carbon-components-angular/link";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -47,12 +41,8 @@ import { LinkModule } from "carbon-components-angular/link";
 		CommonModule,
 		I18nModule,
 		ExperimentalModule,
-		CloseModule,
-		ErrorFilledModule,
-		CheckmarkFilledModule,
-		WarningFilledModule,
-		InformationFilledModule,
-		LinkModule
+		LinkModule,
+		IconModule
 	],
 	providers: [NotificationService, NotificationDisplayService]
 })

--- a/src/notification/toast.component.ts
+++ b/src/notification/toast.component.ts
@@ -22,25 +22,25 @@ import { I18n } from "carbon-components-angular/i18n";
 	selector: "ibm-toast",
 	template: `
 		<svg
-			ibmIconErrorFilled
+			ibmIcon="error--filled"
 			size="16"
 			*ngIf="notificationObj.type === 'error'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
-			ibmIconWarningFilled
+			ibmIcon="warning--filled"
 			size="16"
 			*ngIf="notificationObj.type === 'warning'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
-			ibmIconCheckmarkFilled
+			ibmIcon="checkmark--filled"
 			size="16"
 			*ngIf="notificationObj.type === 'success'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
-			ibmIconInformationFilled
+			ibmIcon="information--filled"
 			size="16"
 			*ngIf="notificationObj.type === 'info'"
 			class="bx--toast-notification__icon">
@@ -62,7 +62,7 @@ import { I18n } from "carbon-components-angular/i18n";
 			type="button"
 			[attr.aria-label]="notificationObj.closeLabel"
 			(click)="onClose()">
-			<ibm-icon-close size="16" class="bx--toast-notification__close-icon"></ibm-icon-close>
+			<svg ibmIcon="close" size="16" class="bx--toast-notification__close-icon"></svg>
 		</button>
 	`
 })

--- a/src/number-input/number.component.spec.ts
+++ b/src/number-input/number.component.spec.ts
@@ -4,11 +4,7 @@ import { By } from "@angular/platform-browser";
 import { Number } from "./number.component";
 import { FormsModule } from "@angular/forms";
 import { I18nModule } from "../i18n/index";
-import {
-	CaretUpModule,
-	CaretDownModule,
-	WarningFilledModule
-} from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 
 describe("Number", () => {
 	let component: Number;
@@ -26,9 +22,7 @@ describe("Number", () => {
 			imports: [
 				I18nModule,
 				FormsModule,
-				CaretUpModule,
-				CaretDownModule,
-				WarningFilledModule
+				IconModule
 			],
 			providers: []
 		});

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -61,12 +61,12 @@ export class NumberChange {
 					[disabled]="disabled"
 					[required]="required"
 					(input)="onNumberInputChange($event)"/>
-				<ibm-icon-warning-filled
-					size="16"
+				<svg
 					*ngIf="!skeleton && invalid"
-					class="bx--number__invalid"
-					style="display: inherit;">
-				</ibm-icon-warning-filled>
+					ibmIcon="warning--filled"
+					size="16"
+					class="bx--number__invalid">
+				</svg>
 				<div *ngIf="!skeleton" class="bx--number__controls">
 					<button
 						class="bx--number__control-btn up-icon"
@@ -75,7 +75,7 @@ export class NumberChange {
 						aria-atomic="true"
 						[attr.aria-label]="getIncrementLabel() | async"
 						(click)="onIncrement()">
-						<ibm-icon-caret-up size="16"></ibm-icon-caret-up>
+						<svg ibmIcon="caret--up" size="16"></svg>
 					</button>
 					<button
 						class="bx--number__control-btn down-icon"
@@ -84,7 +84,7 @@ export class NumberChange {
 						aria-atomic="true"
 						[attr.aria-label]="getDecrementLabel() | async"
 						(click)="onDecrement()">
-						<ibm-icon-caret-down size="16"></ibm-icon-caret-down>
+						<svg ibmIcon="caret--down" size="16"></svg>
 					</button>
 				</div>
 			</div>

--- a/src/number-input/number.module.ts
+++ b/src/number-input/number.module.ts
@@ -2,15 +2,11 @@
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { CommonModule } from "@angular/common";
-import {
-	CaretUpModule,
-	CaretDownModule,
-	WarningFilledModule
-} from "@carbon/icons-angular";
 
 // imports
 import { Number } from "./number.component";
 import { I18nModule } from "carbon-components-angular/i18n";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -23,9 +19,7 @@ import { I18nModule } from "carbon-components-angular/i18n";
 		FormsModule,
 		CommonModule,
 		I18nModule,
-		CaretUpModule,
-		CaretDownModule,
-		WarningFilledModule
+		IconModule
 	]
 })
 export class NumberModule { }

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -78,7 +78,7 @@ export interface PaginationTranslations {
 					</option>
 				</select>
 				<svg
-					ibmIconChevronDown
+					ibmIcon="chevron--down"
 					size="16"
 					style="display: inherit"
 					class="bx--select__arrow"
@@ -125,7 +125,7 @@ export interface PaginationTranslations {
 				</select>
 				<svg
 					*ngIf="pageOptions.length <= 1000"
-					ibmIconChevronDown
+					ibmIcon="chevron--down"
 					size="16"
 					style="display: inherit;"
 					class="bx--select__arrow"
@@ -151,7 +151,7 @@ export interface PaginationTranslations {
 				[attr.aria-label]="backwardText.subject | async"
 				(click)="selectPage.emit(previousPage)"
 				[disabled]="(currentPage <= 1 || disabled ? true : null)">
-				<ibm-icon-caret-left size="16"></ibm-icon-caret-left>
+				<svg ibmIcon="caret--left" size="16"></svg>
 			</button>
 
 			<button
@@ -163,7 +163,7 @@ export interface PaginationTranslations {
 				[attr.aria-label]="forwardText.subject | async"
 				(click)="selectPage.emit(nextPage)"
 				[disabled]="(currentPage >= lastPage || disabled ? true : null)">
-				<ibm-icon-caret-right size="16"></ibm-icon-caret-right>
+				<svg ibmIcon="caret--right" size="16"></svg>
 			</button>
 		</div>
 	</div>

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -1,15 +1,11 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import {
-	ChevronDownModule,
-	CaretLeftModule,
-	CaretRightModule
-} from "@carbon/icons-angular";
 
 import { Pagination } from "./pagination.component";
 import { I18nModule } from "carbon-components-angular/i18n";
 import { ExperimentalModule } from "carbon-components-angular/experimental";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -23,9 +19,7 @@ import { ExperimentalModule } from "carbon-components-angular/experimental";
 		FormsModule,
 		I18nModule,
 		ExperimentalModule,
-		ChevronDownModule,
-		CaretLeftModule,
-		CaretRightModule
+		IconModule
 	]
 })
 export class PaginationModule {}

--- a/src/progress-indicator/progress-indicator-step.interface.ts
+++ b/src/progress-indicator/progress-indicator-step.interface.ts
@@ -18,4 +18,5 @@ export interface Step {
 	 * Determines whether the step is disabled or not
 	 */
 	disabled?: boolean;
+	optionalText: string;
 }

--- a/src/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/progress-indicator/progress-indicator.component.spec.ts
@@ -5,7 +5,7 @@ import { By } from "@angular/platform-browser";
 import { ProgressIndicator } from "./progress-indicator.component";
 import { CommonModule } from "@angular/common";
 import { DialogModule, ExperimentalModule } from "..";
-import { CheckmarkOutlineModule, WarningModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { Step } from "./progress-indicator-step.interface";
 
 @Component({
@@ -64,8 +64,7 @@ describe("ProgressIndicator", () => {
 				CommonModule,
 				DialogModule,
 				ExperimentalModule,
-				CheckmarkOutlineModule,
-				WarningModule
+				IconModule
 			]
 		});
 	});

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -28,16 +28,16 @@ import { Step } from "./progress-indicator-step.interface";
 			*ngFor="let step of steps; let i = index"
 			[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
 			<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
-				<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state == 'complete'"></svg>
-				<svg *ngIf="step.state == 'current'">
+				<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state.includes('complete')"></svg>
+				<svg *ngIf="step.state.includes('current')">
 					<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
 				</svg>
-				<svg *ngIf="step.state == 'incomplete'">
+				<svg *ngIf="step.state.includes('incomplete')">
 					<path
 						d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
 					</path>
 				</svg>
-				<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" innerClass="bx--progress__warning"></svg>
+				<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" class="bx--progress__warning"></svg>
 				<p
 					class="bx--progress-label"
 					*ngIf="step.tooltip"

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -28,7 +28,7 @@ import { Step } from "./progress-indicator-step.interface";
 			*ngFor="let step of steps; let i = index"
 			[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
 			<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
-				<ibm-icon-checkmark-outline size="16" *ngIf="step.state == 'complete'"></ibm-icon-checkmark-outline>
+				<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state == 'complete'"></svg>
 				<svg *ngIf="step.state == 'current'">
 					<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
 				</svg>
@@ -37,7 +37,7 @@ import { Step } from "./progress-indicator-step.interface";
 						d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
 					</path>
 				</svg>
-				<ibm-icon-warning size="16" *ngIf="step.state.includes('error')" innerClass="bx--progress__warning"></ibm-icon-warning>
+				<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" innerClass="bx--progress__warning"></svg>
 				<p
 					class="bx--progress-label"
 					*ngIf="step.tooltip"

--- a/src/progress-indicator/progress-indicator.module.ts
+++ b/src/progress-indicator/progress-indicator.module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { CheckmarkOutlineModule, WarningModule } from "@carbon/icons-angular";
 
 import { ProgressIndicator } from "./progress-indicator.component";
 import { DialogModule } from "carbon-components-angular/dialog";
 import { ExperimentalModule } from "carbon-components-angular/experimental";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -17,8 +17,7 @@ import { ExperimentalModule } from "carbon-components-angular/experimental";
 		CommonModule,
 		DialogModule,
 		ExperimentalModule,
-		CheckmarkOutlineModule,
-		WarningModule
+		IconModule
 	]
 })
 export class ProgressIndicatorModule { }

--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -28,16 +28,17 @@
 			(input)="onSearch($event.target.value)"
 			(keyup.enter)="onEnter()"/>
 		<button *ngIf="!tableSearch && toolbar" class="bx--toolbar-search__btn" (click)="openSearch()">
-			<ibm-icon-search size="16" class="bx--search-magnifier"></ibm-icon-search>
+			<svg ibmIcon="search" size="16" class="bx--search-magnifier"></svg>
 		</button>
-		<ibm-icon-search
+		<svg
+			ibmIcon="search"
 			*ngIf="tableSearch || !toolbar"
 			class="bx--search-magnifier"
 			size="16"
 			role="button"
 			tabindex="0"
 			(click)="openSearch()">
-		</ibm-icon-search>
+		</svg>
 	</ng-template>
 
 	<button
@@ -49,6 +50,6 @@
 		[title]="clearButtonTitle"
 		(click)="clearSearch()">
 		<span class="bx--visually-hidden">{{ clearButtonTitle }}</span>
-		<ibm-icon-close size="16"></ibm-icon-close>
+		<svg ibmIcon="close" size="16"></svg>
 	</button>
 </div>

--- a/src/search/search.component.spec.ts
+++ b/src/search/search.component.spec.ts
@@ -4,7 +4,7 @@ import { By } from "@angular/platform-browser";
 import { Search } from "./search.component";
 import { FormsModule } from "@angular/forms";
 import { I18nModule } from "../i18n/index";
-import { CloseModule, SearchModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 
 describe("Search", () => {
 	let component: Search;
@@ -19,8 +19,7 @@ describe("Search", () => {
 			imports: [
 				FormsModule,
 				I18nModule,
-				SearchModule,
-				CloseModule
+				IconModule
 			],
 			providers: []
 		})

--- a/src/search/search.module.ts
+++ b/src/search/search.module.ts
@@ -2,11 +2,11 @@
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { CommonModule } from "@angular/common";
-import { SearchModule as SearchIconModule, CloseModule } from "@carbon/icons-angular";
 
 // imports
 import { I18nModule } from "carbon-components-angular/i18n";
 import { Search } from "./search.component";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -19,8 +19,7 @@ import { Search } from "./search.component";
 		FormsModule,
 		CommonModule,
 		I18nModule,
-		SearchIconModule,
-		CloseModule
+		IconModule
 	]
 })
 export class SearchModule { }

--- a/src/select/select.component.spec.ts
+++ b/src/select/select.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { Component } from "@angular/core";
-import { ChevronDownModule, WarningFilledModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { Select } from "./select.component";
 
 @Component({
@@ -30,8 +30,7 @@ describe("Select", () => {
 			],
 			imports: [
 				FormsModule,
-				ChevronDownModule,
-				WarningFilledModule
+				IconModule
 			]
 		});
 	});

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -85,12 +85,12 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					aria-hidden="true">
 					<path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
 				</svg>
-				<ibm-icon-warning-filled
-					size="16"
+				<svg
 					*ngIf="invalid"
-					class="bx--select__invalid-icon"
-					style="display: inherit;">
-				</ibm-icon-warning-filled>
+					ibomIcon="warning--filled"
+					size="16"
+					class="bx--select__invalid-icon">
+				</svg>
 			</div>
 			<div *ngIf="invalid && invalidText" role="alert" class="bx--form-requirement" aria-live="polite">
 				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>

--- a/src/select/select.module.ts
+++ b/src/select/select.module.ts
@@ -2,12 +2,12 @@
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { CommonModule } from "@angular/common";
-import { ChevronDownModule, WarningFilledModule } from "@carbon/icons-angular";
 
 // imports
 import { Select } from "./select.component";
 import { Option } from "./option.directive";
 import { OptGroup } from "./optgroup.directive";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -23,8 +23,7 @@ import { OptGroup } from "./optgroup.directive";
 	imports: [
 		CommonModule,
 		FormsModule,
-		ChevronDownModule,
-		WarningFilledModule
+		IconModule
 	]
 })
 export class SelectModule { }

--- a/src/structured-list/list-row.component.ts
+++ b/src/structured-list/list-row.component.ts
@@ -47,7 +47,7 @@ import { ListColumn } from "./list-column.component";
 				(change)="onChange($event)"
 				[checked]="selected"/>
 			<div class="bx--structured-list-td">
-				<ibm-icon-checkmark-filled size="16" class="bx--structured-list-svg"></ibm-icon-checkmark-filled>
+				<svg ibmIcon="checkmark--filled" size="16" class="bx--structured-list-svg"></svg>
 			</div>
 		</ng-container>
 	`

--- a/src/structured-list/structured-list.component.spec.ts
+++ b/src/structured-list/structured-list.component.spec.ts
@@ -6,7 +6,7 @@ import { StructuredList } from "./structured-list.component";
 import { ListRow } from "./list-row.component";
 import { ListHeader } from "./list-header.component";
 import { ListColumn } from "./list-column.component";
-import { CheckmarkFilledModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 
 @Component({
 	template: `
@@ -54,7 +54,7 @@ describe("StructuredList", () => {
 			],
 			imports: [
 				FormsModule,
-				CheckmarkFilledModule
+				IconModule
 			]
 		});
 	});

--- a/src/structured-list/structured-list.module.ts
+++ b/src/structured-list/structured-list.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { CheckmarkFilledModule } from "@carbon/icons-angular";
 
 import { StructuredList } from "./structured-list.component";
 import { ListRow } from "./list-row.component";
 import { ListHeader } from "./list-header.component";
 import { ListColumn } from "./list-column.component";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -22,7 +22,7 @@ import { ListColumn } from "./list-column.component";
 	],
 	imports: [
 		CommonModule,
-		CheckmarkFilledModule
+		IconModule
 	]
 })
 export class StructuredListModule { }

--- a/src/table/cell/table-expand-button.component.ts
+++ b/src/table/cell/table-expand-button.component.ts
@@ -17,7 +17,7 @@ import { Observable } from "rxjs";
 			class="bx--table-expand__button"
 			[attr.aria-label]="getAriaLabel() | async"
 			(click)="expandRow.emit()">
-			<ibm-icon-chevron-right size="16" innerClass="bx--table-expand__svg"></ibm-icon-chevron-right>
+			<svg ibmIcon="chevron--right" size="16" innerClass="bx--table-expand__svg"></svg>
 		</button>
 	`
 })

--- a/src/table/table.module.ts
+++ b/src/table/table.module.ts
@@ -3,19 +3,13 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
 
-// icons
-import {
-	ChevronRightModule,
-	SearchModule as SearchIconModule,
-	CloseModule
-} from "@carbon/icons-angular";
-
 // internal module imports
 import { NFormsModule } from "carbon-components-angular/forms";
 import { DialogModule } from "carbon-components-angular/dialog";
 import { I18nModule } from "carbon-components-angular/i18n";
 import { ButtonModule } from "carbon-components-angular/button";
 import { SearchModule } from "carbon-components-angular/search";
+import { IconModule } from "carbon-components-angular/icon";
 
 // table utilities/toolbar imports
 import { TableToolbar } from "./toolbar/table-toolbar.component";
@@ -117,9 +111,7 @@ export * from "./data-grid-interaction-model.class";
 		ButtonModule,
 		SearchModule,
 		I18nModule,
-		ChevronRightModule,
-		SearchIconModule,
-		CloseModule
+		IconModule
 	]
 })
 export class TableModule {}

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -18,25 +18,25 @@ import { TableRowSize } from "../table.types";
  *		<ibm-table-toolbar-actions>
  *			<button ibmButton="primary">
  *				Delete
- *				<ibm-icon-delete size="16" class="bx--btn__icon"></ibm-icon-delete>
+ *				<svg ibmIcon="delete" size="16" class="bx--btn__icon"></svg>
  *			</button>
  *			<button ibmButton="primary">
  *				Save
- *				<ibm-icon-save size="16" class="bx--btn__icon"></ibm-icon-save>
+ *				<svg ibmIcon="save" size="16" class="bx--btn__icon"></svg>
  *			</button>
  *			<button ibmButton="primary">
  *				Download
- *				<ibm-icon-download size="16" class="bx--btn__icon"></ibm-icon-download>
+ *				<svg ibmIcon="download" size="16" class="bx--btn__icon"></svg>
  *			</button>
  *		</ibm-table-toolbar-actions>
  *			<ibm-table-toolbar-content>
  *			<ibm-table-toolbar-search [expandable]="true"></ibm-table-toolbar-search>
  *			<button ibmButton="toolbar-action">
- *				<ibm-icon-settings size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
+ *				<svg ibmIcon="settings" size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
  *			</button>
  *			<button ibmButton="primary" size="sm">
  *				Primary Button
- *				<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+ *				<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
  *			</button>
  *		</ibm-table-toolbar-content>
  *	</ibm-table-toolbar>

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -37,16 +37,15 @@ let nextId = 0;
 *
 * ```html
 * <ng-template #tabHeading>
-* 	<ibm-icon
-* 		icon="facebook"
+* 	<svg ibmIcon="facebook"
 * 		size="sm"
 * 		style="margin-right: 7px;">
-* 	</ibm-icon>
+* 	</svg>
 * 	Hello Tab 1
 * </ng-template>
 * <ibm-tabs>
 * 	<ibm-tab [heading]="tabHeading">
-* 		Tab 1 content <ibm-icon icon="alert" size="lg"></ibm-icon>
+* 		Tab 1 content <svg ibmIcon="alert" size="lg"></svg>
 * 	</ibm-tab>
 * 	<ibm-tab heading='Tab2'>
 * 		Tab 2 content

--- a/src/tag/tag-filter.component.ts
+++ b/src/tag/tag-filter.component.ts
@@ -19,7 +19,7 @@ import { Tag } from "./tag.component";
 			[disabled]="disabled"
 			[title]="closeButtonLabel">
 			<span class="bx--visually-hidden">{{closeButtonLabel}}</span>
-			<svg ibmIconClose size="16"></svg>
+			<svg ibmIcon="close" size="16"></svg>
 		</button>
 	`
 })

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
-import { CloseModule } from "@carbon/icons-angular";
 
 import { Tag } from "./tag.component";
 import { TagFilter } from "./tag-filter.component";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [ Tag, TagFilter ],
 	exports: [ Tag, TagFilter ],
-	imports: [ CommonModule, CloseModule ]
+	imports: [ CommonModule, IconModule ]
 })
 export class TagModule { }

--- a/src/timepicker-select/timepicker-select.component.spec.ts
+++ b/src/timepicker-select/timepicker-select.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { FormsModule } from "@angular/forms";
 import { Component } from "@angular/core";
-import { ChevronDownModule, WarningFilledModule } from "@carbon/icons-angular";
+import { IconModule } from "../icon/index";
 import { TimePickerSelect } from "./timepicker-select.component";
 
 @Component({
@@ -27,8 +27,7 @@ describe("TimePickerSelect", () => {
 			],
 			imports: [
 				FormsModule,
-				ChevronDownModule,
-				WarningFilledModule
+				IconModule
 			]
 		});
 	});

--- a/src/timepicker-select/timepicker-select.component.ts
+++ b/src/timepicker-select/timepicker-select.component.ts
@@ -27,7 +27,7 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				class="bx--select-input">
 				<ng-content></ng-content>
 			</select>
-			<svg ibmIconChevronDown size="16" *ngIf="!skeleton" class="bx--select__arrow"></svg>
+			<svg ibmIcon="chevron--down" size="16" *ngIf="!skeleton" class="bx--select__arrow"></svg>
 		</div>
 	`,
 	providers: [

--- a/src/timepicker-select/timepicker-select.module.ts
+++ b/src/timepicker-select/timepicker-select.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { TimePickerSelect } from "./timepicker-select.component";
 import { SelectModule } from "carbon-components-angular/select";
-import { ChevronDownModule } from "@carbon/icons-angular";
+import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
@@ -14,7 +14,7 @@ import { ChevronDownModule } from "@carbon/icons-angular";
 	imports: [
 		SelectModule,
 		CommonModule,
-		ChevronDownModule
+		IconModule
 	]
 })
 export class TimePickerSelectModule { }

--- a/src/ui-shell/header/hamburger.component.ts
+++ b/src/ui-shell/header/hamburger.component.ts
@@ -23,8 +23,8 @@ import { I18n } from "carbon-components-angular/i18n";
 			[attr.title]="active
 				? (i18n.get('UI_SHELL.HEADER.CLOSE_MENU') | async)
 				: (i18n.get('UI_SHELL.HEADER.OPEN_MENU') | async)">
-			<svg *ngIf="!active" ibmIconMenu size="20"></svg>
-			<svg *ngIf="active" ibmIconClose size="20"></svg>
+			<svg *ngIf="!active" ibmIcon="menu" size="20"></svg>
+			<svg *ngIf="active" ibmIcon="close" size="20"></svg>
 		</button>
 	`
 })

--- a/src/ui-shell/header/header.module.ts
+++ b/src/ui-shell/header/header.module.ts
@@ -1,9 +1,8 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
 
-import { CloseModule, MenuModule } from "@carbon/icons-angular";
-
 import { I18nModule } from "carbon-components-angular/i18n";
+import { IconModule } from "carbon-components-angular/icon";
 
 import { Header } from "./header.component";
 import { HeaderItem } from "./header-item.component";
@@ -40,8 +39,7 @@ export {
 	imports: [
 		CommonModule,
 		I18nModule,
-		CloseModule,
-		MenuModule,
+		IconModule,
 		RouterModule
 	],
 	exports: [


### PR DESCRIPTION
This should resolve any bundle size explosion that is being caused by `carbon-components-angular`. `icons-angular` will still have the possibility to explode bundle sizes, but this will decouple `carbon-components-angular` and `icons-angular`, which will allow teams to chose versions that work best for them.

Once we've seen this in the wild for a bit, worked out any bugs, and ensured that this is a net benefit to bundle sizes, we can promote this as a new option for icon usage by teams.