### PR TITLE
fix: adds size control for skeleton placeholder

### DIFF
--- a/src/skeleton/skeleton-placeholder.component.ts
+++ b/src/skeleton/skeleton-placeholder.component.ts
@@ -3,6 +3,18 @@ import { Component } from "@angular/core";
 @Component({
 	selector: "ibm-skeleton-placeholder",
 	template: `
-		<div class="bx--skeleton__placeholder"></div>`
+		<div class="bx--skeleton__placeholder"></div>`,
+	styles: [
+		`
+		:host {
+			display: block;
+		}
+
+		.bx--skeleton__placeholder {
+			width: 100%;
+			height: 100%;
+		}
+		`
+	]
 })
 export class SkeletonPlaceholder { }

--- a/src/skeleton/skeleton.stories.ts
+++ b/src/skeleton/skeleton.stories.ts
@@ -10,7 +10,11 @@ storiesOf("Components|Skeleton", module).addDecorator(
 )
 	.addDecorator(withKnobs)
 	.add("Skeleton Placeholder", () => ({
-		template: `<ibm-skeleton-placeholder></ibm-skeleton-placeholder>`
+		template: `<ibm-skeleton-placeholder [ngStyle]="{'width.px': width, 'height.px': height }"></ibm-skeleton-placeholder>`,
+		props: {
+			width: number("Width (in px)", 100),
+			height: number("Height (in px)", 100)
+		}
 	}))
 	.add("Skeleton Text", () => ({
 		template: `


### PR DESCRIPTION
Addresses #1607 

The current `bx--skeleton__placeholder` class has a fixed `6.5rem` width and height. This PR changes `ibm-skeleton-placholder` to render as a block element, and sets the `bx--skeleton__placeholder` element inside of it to fill the width/height of its container.

Using these changes, we can freely manipulate the size of the skeleton placeholder to fit any need.

#### Changelog

**Changed**

* `skeleton-placeholder.component.ts`
* `skeleton.stories.ts`

#### Screenshot

![image](https://user-images.githubusercontent.com/2348003/98711596-8d9ffa80-235b-11eb-921a-50a2a5a94e35.png)
