### PR TITLE
feat(tabletoolbar): add output for custom cancel method

### DIFF
--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -84,10 +84,6 @@ function getModelWithDisabledRows() {
 	return disabledModel;
 }
 
-function printSomething() {
-	console.log("printing something on cancel");
-}
-
 storiesOf("Components|Table", module).addDecorator(
 		moduleMetadata({
 			imports: [

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -84,6 +84,10 @@ function getModelWithDisabledRows() {
 	return disabledModel;
 }
 
+function printSomething() {
+	console.log("printing something on cancel");
+}
+
 storiesOf("Components|Table", module).addDecorator(
 		moduleMetadata({
 			imports: [
@@ -176,6 +180,7 @@ storiesOf("Components|Table", module).addDecorator(
 				[model]="model"
 				[batchText]="batchText"
 				[size]="size"
+				(cancel)="cancelMethod()"
 				#toolbar>
 				<ibm-table-toolbar-actions>
 					<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
@@ -228,6 +233,9 @@ storiesOf("Components|Table", module).addDecorator(
 		</ibm-table-container>
 	`,
 		props: getProps({
+			cancelMethod: function() {
+				console.log("Custom cancel method");
+			},
 			description: text("Description", "With toolbar"),
 			searchModel: text("Search model", "Initial search value"),
 			enableSingleSelect: boolean("Enable single select", false),

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -106,6 +106,8 @@ export class TableToolbar {
 		return { CANCEL: this._cancelText.value as string };
 	}
 
+	@Output() cancel = new EventEmitter;
+
 	actionBarLabel: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.ACTION_BAR");
 	_cancelText: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.CANCEL");
 	_batchTextLegacy: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.BATCH_TEXT");
@@ -123,5 +125,6 @@ export class TableToolbar {
 
 	onCancel() {
 		this.model.selectAll(false);
+		this.cancel.emit();
 	}
 }

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -106,7 +106,7 @@ export class TableToolbar {
 		return { CANCEL: this._cancelText.value as string };
 	}
 
-	@Output() cancel = new EventEmitter;
+	@Output() cancel = new EventEmitter();
 
 	actionBarLabel: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.ACTION_BAR");
 	_cancelText: Overridable = this.i18n.getOverridable("TABLE_TOOLBAR.CANCEL");

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -10,13 +10,13 @@ import { SideNavMenu } from "./sidenav-menu.component";
 import { RouterModule } from "@angular/router";
 
 @Component({
-	selector:  "app-foo",
-	template:  "<h1>foo</h1>"
+	selector: "app-foo",
+	template: "<h1>foo</h1>"
 })
 class FooComponent {}
 
 @Component({
-	template:  `
+	template: `
 		<ibm-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden">
 			<ibm-sidenav-menu title="Example Title"></ibm-sidenav-menu>
 			<ibm-sidenav-item
@@ -30,61 +30,61 @@ class SideNavTest {
 	route = ["foo"];
 	hidden = false;
 	allowExpansion = false;
-	statusPromise =  null;
+	statusPromise = null;
 	onNavigation(event) {
-		this.statusPromise =  event;
+		this.statusPromise = event;
 	}
 }
 
-describe("SideNav",  () => {
-	let fixture,  wrapper,  element;
+describe("SideNav", () => {
+	let fixture, wrapper, element;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			declarations:  [
+			declarations: [
 				SideNav,
 				SideNavItem,
 				SideNavMenu,
 				SideNavTest,
 				FooComponent
 			],
-			imports:  [
+			imports: [
 				CommonModule,
 				I18nModule,
 				RouterModule.forRoot([
 					{
-						path:  "foo",
-						component:  FooComponent
+						path: "foo",
+						component: FooComponent
 					}
 				],
 				{
-					initialNavigation:  false,
-					useHash:  true
+					initialNavigation: false,
+					useHash: true
 				})
 			]
 		});
 	});
 
-	it("should work",  () => {
-		fixture =  TestBed.createComponent(SideNav);
+	it("should work", () => {
+		fixture = TestBed.createComponent(SideNav);
 		expect(fixture.componentInstance instanceof SideNav).toBe(true);
 	});
 
-	it("should emit the navigation status promise when the link is activated and call onNavigation",  async () => {
-		fixture =  TestBed.createComponent(SideNavTest);
-		wrapper =  fixture.componentInstance;
-		spyOn(wrapper,  "onNavigation").and.callThrough();
+	it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
+		fixture = TestBed.createComponent(SideNavTest);
+		wrapper = fixture.componentInstance;
+		spyOn(wrapper, "onNavigation").and.callThrough();
 		fixture.detectChanges();
-		element =  fixture.debugElement.query(By.css(".bx--side-nav__link"));
+		element = fixture.debugElement.query(By.css(".bx--side-nav__link"));
 		element.nativeElement.click();
 		fixture.detectChanges();
 		expect(wrapper.onNavigation).toHaveBeenCalled();
-		const status =  await wrapper.statusPromise;
+		const status = await wrapper.statusPromise;
 		expect(status).toBe(true);
 	});
 
 	it("should expand sidenav-menu on click", () => {
-		fixture =  TestBed.createComponent(SideNavTest);
-		wrapper =  fixture.componentInstance;
+		fixture = TestBed.createComponent(SideNavTest);
+		wrapper = fixture.componentInstance;
 		fixture.detectChanges();
 		element = fixture.debugElement.query(By.css(".bx--side-nav__submenu"));
 		element.nativeElement.click();

--- a/src/ui-shell/sidenav/side-nav.component.spec.ts
+++ b/src/ui-shell/sidenav/side-nav.component.spec.ts
@@ -10,13 +10,13 @@ import { SideNavMenu } from "./sidenav-menu.component";
 import { RouterModule } from "@angular/router";
 
 @Component({
-	selector: "app-foo",
-	template: "<h1>foo</h1>"
+	selector:  "app-foo",
+	template:  "<h1>foo</h1>"
 })
 class FooComponent {}
 
 @Component({
-	template: `
+	template:  `
 		<ibm-sidenav [allowExpansion]="allowExpansion" [hidden]="hidden">
 			<ibm-sidenav-menu title="Example Title"></ibm-sidenav-menu>
 			<ibm-sidenav-item
@@ -30,61 +30,61 @@ class SideNavTest {
 	route = ["foo"];
 	hidden = false;
 	allowExpansion = false;
-	statusPromise = null;
+	statusPromise =  null;
 	onNavigation(event) {
-		this.statusPromise = event;
+		this.statusPromise =  event;
 	}
 }
 
-describe("SideNav", () => {
-	let fixture, wrapper, element;
+describe("SideNav",  () => {
+	let fixture,  wrapper,  element;
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			declarations: [
+			declarations:  [
 				SideNav,
 				SideNavItem,
 				SideNavMenu,
 				SideNavTest,
 				FooComponent
 			],
-			imports: [
+			imports:  [
 				CommonModule,
 				I18nModule,
 				RouterModule.forRoot([
 					{
-						path: "foo",
-						component: FooComponent
+						path:  "foo",
+						component:  FooComponent
 					}
 				],
 				{
-					initialNavigation: false,
-					useHash: true
+					initialNavigation:  false,
+					useHash:  true
 				})
 			]
 		});
 	});
 
-	it("should work", () => {
-		fixture = TestBed.createComponent(SideNav);
+	it("should work",  () => {
+		fixture =  TestBed.createComponent(SideNav);
 		expect(fixture.componentInstance instanceof SideNav).toBe(true);
 	});
 
-	it("should emit the navigation status promise when the link is activated and call onNavigation", async () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		wrapper = fixture.componentInstance;
-		spyOn(wrapper, "onNavigation").and.callThrough();
+	it("should emit the navigation status promise when the link is activated and call onNavigation",  async () => {
+		fixture =  TestBed.createComponent(SideNavTest);
+		wrapper =  fixture.componentInstance;
+		spyOn(wrapper,  "onNavigation").and.callThrough();
 		fixture.detectChanges();
-		element = fixture.debugElement.query(By.css(".bx--side-nav__link"));
+		element =  fixture.debugElement.query(By.css(".bx--side-nav__link"));
 		element.nativeElement.click();
 		fixture.detectChanges();
 		expect(wrapper.onNavigation).toHaveBeenCalled();
-		const status = await wrapper.statusPromise;
+		const status =  await wrapper.statusPromise;
 		expect(status).toBe(true);
 	});
 
 	it("should expand sidenav-menu on click", () => {
-		fixture = TestBed.createComponent(SideNavTest);
-		wrapper = fixture.componentInstance;
+		fixture =  TestBed.createComponent(SideNavTest);
+		wrapper =  fixture.componentInstance;
 		fixture.detectChanges();
 		element = fixture.debugElement.query(By.css(".bx--side-nav__submenu"));
 		element.nativeElement.click();


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1611

This feature just adds an output to the `ibm-table-toolbar` so developers can execute something else at the moment they click on cancel on the toolbar when items are selected.

#### Changelog

**New**

* `cancel` Output for `ibm-table-toolbar`
