### PR TITLE
fix(tooltip): remove preventDefault from onTouchStart

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -139,7 +139,6 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	 */
 	onTouchStart(event) {
 		event.stopImmediatePropagation();
-		event.preventDefault();
 		this.toggle({
 			reason: CloseReasons.interaction
 		});


### PR DESCRIPTION
Closes #1556 

`onTouchStart` is a callback that gets passed into the event service https://github.com/IBM/carbon-components-angular/blob/master/src/utils/event.service.ts which subscribes to the `touchstart` observable https://github.com/IBM/carbon-components-angular/blob/master/src/utils/event-observable.ts. Since the `touchstart` observable has passive set to true, we get the following error on chrome on mobile: `Unable to preventDefault inside passive event listener`. After removing `preventDefault` it doesn't seem to have any effect other than removing the errors that come up in the console.