### PR TITLE
refactor(progress-indicator): Changes updating strategy for current field

### DIFF
--- a/src/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/progress-indicator/progress-indicator.component.spec.ts
@@ -129,19 +129,19 @@ describe("ProgressIndicator", () => {
 		expect(element.nativeElement.querySelector(".bx--progress-step--current").textContent).toContain("First step");
 	});
 
-	it("should handle steps and current being updated after the component is initialized", () => {
+	it("should handle steps and current being updated individually after the component is initialized", () => {
 		fixture = TestBed.createComponent(ProgressIndicatorTest);
 		wrapper = fixture.componentInstance;
 		fixture.detectChanges();
-		const newSteps = wrapper.steps.concat([{
+		wrapper.steps = wrapper.steps.concat([{
 			text: "Sixth step",
 			state: ["incomplete"]
 		}]);
-		wrapper.steps = newSteps;
+		fixture.detectChanges();
 		wrapper.current = 5;
 		fixture.detectChanges();
 		element = fixture.debugElement.query(By.css("ibm-progress-indicator"));
-		expect(element.nativeElement.querySelector(".bx--progress").children.length).toBe(newSteps.length);
+		expect(element.nativeElement.querySelector(".bx--progress").children.length).toBe(6);
 		expect(element.nativeElement.querySelector(".bx--progress-step--current").textContent).toContain("Sixth step");
 	});
 });

--- a/src/progress-indicator/progress-indicator.component.spec.ts
+++ b/src/progress-indicator/progress-indicator.component.spec.ts
@@ -118,4 +118,30 @@ describe("ProgressIndicator", () => {
 		fixture.detectChanges();
 		expect(wrapper.stepSelected.emit).toHaveBeenCalledWith({ step: wrapper.steps[index], index: index });
 	});
+
+	it("should handle current being set to 0 after the component is initialized",  () => {
+		fixture = TestBed.createComponent(ProgressIndicatorTest);
+		wrapper = fixture.componentInstance;
+		fixture.detectChanges();
+		wrapper.current = 0;
+		fixture.detectChanges();
+		element = fixture.debugElement.query(By.css("ibm-progress-indicator"));
+		expect(element.nativeElement.querySelector(".bx--progress-step--current").textContent).toContain("First step");
+	});
+
+	it("should handle steps and current being updated after the component is initialized", () => {
+		fixture = TestBed.createComponent(ProgressIndicatorTest);
+		wrapper = fixture.componentInstance;
+		fixture.detectChanges();
+		const newSteps = wrapper.steps.concat([{
+			text: "Sixth step",
+			state: ["incomplete"]
+		}]);
+		wrapper.steps = newSteps;
+		wrapper.current = 5;
+		fixture.detectChanges();
+		element = fixture.debugElement.query(By.css("ibm-progress-indicator"));
+		expect(element.nativeElement.querySelector(".bx--progress").children.length).toBe(newSteps.length);
+		expect(element.nativeElement.querySelector(".bx--progress-step--current").textContent).toContain("Sixth step");
+	});
 });

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -20,9 +20,9 @@ import { Step } from "./progress-indicator-step.interface";
 		data-progress-current
 		class="bx--progress"
 		[ngClass]="{
-		'bx--skeleton': skeleton,
-		'bx--progress--vertical': (orientation === 'vertical')
-	}">
+			'bx--skeleton': skeleton,
+			'bx--progress--vertical': (orientation === 'vertical')
+		}">
 		<li
 			class="bx--progress-step bx--progress-step--{{step.state[0]}}"
 			*ngFor="let step of steps; let i = index"

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -2,7 +2,7 @@ import {
 	Component,
 	Input,
 	Output,
-	EventEmitter, OnInit, OnChanges, SimpleChanges
+	EventEmitter, OnChanges, SimpleChanges
 } from "@angular/core";
 import { ExperimentalService } from "carbon-components-angular/experimental";
 import { Step } from "./progress-indicator-step.interface";
@@ -59,7 +59,7 @@ import { Step } from "./progress-indicator-step.interface";
 	</ul>
 	`
 })
-export class ProgressIndicator implements OnInit, OnChanges {
+export class ProgressIndicator implements OnChanges {
 	static skeletonSteps(stepCount: number) {
 		const steps = [];
 		for (let i = 0; i < stepCount; i++) {
@@ -84,10 +84,6 @@ export class ProgressIndicator implements OnInit, OnChanges {
 	private _current: number;
 
 	constructor(protected experimental: ExperimentalService) {}
-
-	ngOnInit() {
-		this.setProgressIndicatorStates();
-	}
 
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.steps || changes.current) {

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -74,6 +74,7 @@ export class ProgressIndicator implements OnInit, OnChanges {
 	@Input() steps: Array<Step>;
 	@Input() orientation: "horizontal" | "vertical" = "horizontal";
 	@Input() skeleton = false;
+
 	@Input() get current() {
 		return this.steps.findIndex(step => step.state.includes("current"));
 	}

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -15,48 +15,48 @@ import { Step } from "./progress-indicator-step.interface";
 @Component({
 	selector: "ibm-progress-indicator",
 	template: `
-		<ul
-			data-progress
-			data-progress-current
-			class="bx--progress"
-			[ngClass]="{
-			'bx--skeleton': skeleton,
-			'bx--progress--vertical': (orientation === 'vertical')
-		}">
-			<li
-				class="bx--progress-step bx--progress-step--{{step.state[0]}}"
-				*ngFor="let step of steps; let i = index"
-				[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
-				<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
-					<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state.includes('complete')"></svg>
-					<svg *ngIf="step.state.includes('current')">
-						<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
-					</svg>
-					<svg *ngIf="step.state.includes('incomplete')">
-						<path
-							d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
-						</path>
-					</svg>
-					<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" class="bx--progress__warning"></svg>
-					<p
-						class="bx--progress-label"
-						*ngIf="step.tooltip"
-						[ibmTooltip]="step.tooltip.content"
-						[trigger]="step.tooltip.trigger"
-						[placement]="step.tooltip.placement"
-						[title]="step.tooltip.title"
-						[gap]="step.tooltip.gap"
-						[appendInline]="step.tooltip.appendInline"
-						[data]="step.tooltip.data"
-						(click)="stepSelected.emit({ step: step, index: i })">
-						{{step.text}}
-					</p>
-					<p class="bx--progress-label" *ngIf="!step.tooltip" (click)="stepSelected.emit({ step: step, index: i })">{{step.text}}</p>
-					<p *ngIf="step.optionalText" class="bx--progress-optional">{{step.optionalText}}</p>
-					<span class="bx--progress-line"></span>
-				</div>
-			</li>
-		</ul>
+	<ul
+		data-progress
+		data-progress-current
+		class="bx--progress"
+		[ngClass]="{
+		'bx--skeleton': skeleton,
+		'bx--progress--vertical': (orientation === 'vertical')
+	}">
+		<li
+			class="bx--progress-step bx--progress-step--{{step.state[0]}}"
+			*ngFor="let step of steps; let i = index"
+			[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
+			<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
+				<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state.includes('complete')"></svg>
+				<svg *ngIf="step.state.includes('current')">
+					<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
+				</svg>
+				<svg *ngIf="step.state.includes('incomplete')">
+					<path
+						d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
+					</path>
+				</svg>
+				<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" class="bx--progress__warning"></svg>
+				<p
+					class="bx--progress-label"
+					*ngIf="step.tooltip"
+					[ibmTooltip]="step.tooltip.content"
+					[trigger]="step.tooltip.trigger"
+					[placement]="step.tooltip.placement"
+					[title]="step.tooltip.title"
+					[gap]="step.tooltip.gap"
+					[appendInline]="step.tooltip.appendInline"
+					[data]="step.tooltip.data"
+					(click)="stepSelected.emit({ step: step, index: i })">
+					{{step.text}}
+				</p>
+				<p class="bx--progress-label" *ngIf="!step.tooltip" (click)="stepSelected.emit({ step: step, index: i })">{{step.text}}</p>
+				<p *ngIf="step.optionalText" class="bx--progress-optional">{{step.optionalText}}</p>
+				<span class="bx--progress-line"></span>
+			</div>
+		</li>
+	</ul>
 	`
 })
 export class ProgressIndicator implements OnInit, OnChanges {

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -2,7 +2,7 @@ import {
 	Component,
 	Input,
 	Output,
-	EventEmitter
+	EventEmitter, OnInit, OnChanges, SimpleChanges
 } from "@angular/core";
 import { ExperimentalService } from "carbon-components-angular/experimental";
 import { Step } from "./progress-indicator-step.interface";
@@ -15,51 +15,51 @@ import { Step } from "./progress-indicator-step.interface";
 @Component({
 	selector: "ibm-progress-indicator",
 	template: `
-	<ul
-		data-progress
-		data-progress-current
-		class="bx--progress"
-		[ngClass]="{
+		<ul
+			data-progress
+			data-progress-current
+			class="bx--progress"
+			[ngClass]="{
 			'bx--skeleton': skeleton,
 			'bx--progress--vertical': (orientation === 'vertical')
 		}">
-		<li
-			class="bx--progress-step bx--progress-step--{{step.state[0]}}"
-			*ngFor="let step of steps; let i = index"
-			[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
-			<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
-				<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state.includes('complete')"></svg>
-				<svg *ngIf="step.state.includes('current')">
-					<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
-				</svg>
-				<svg *ngIf="step.state.includes('incomplete')">
-					<path
-						d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
-					</path>
-				</svg>
-				<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" class="bx--progress__warning"></svg>
-				<p
-					class="bx--progress-label"
-					*ngIf="step.tooltip"
-					[ibmTooltip]="step.tooltip.content"
-					[trigger]="step.tooltip.trigger"
-					[placement]="step.tooltip.placement"
-					[title]="step.tooltip.title"
-					[gap]="step.tooltip.gap"
-					[appendInline]="step.tooltip.appendInline"
-					[data]="step.tooltip.data"
-					(click)="stepSelected.emit({ step: step, index: i })">
-					{{step.text}}
-				</p>
-				<p class="bx--progress-label" *ngIf="!step.tooltip" (click)="stepSelected.emit({ step: step, index: i })">{{step.text}}</p>
-				<p *ngIf="step.optionalText" class="bx--progress-optional">{{step.optionalText}}</p>
-				<span class="bx--progress-line"></span>
-			</div>
-		</li>
-	</ul>
+			<li
+				class="bx--progress-step bx--progress-step--{{step.state[0]}}"
+				*ngFor="let step of steps; let i = index"
+				[ngClass]="{'bx--progress-step--disabled' : step.disabled}">
+				<div class="bx--progress-step-button bx--progress-step-button--unclickable" role="button" tabindex="-1">
+					<svg ibmIcon="checkmark--outline" size="16" *ngIf="step.state.includes('complete')"></svg>
+					<svg *ngIf="step.state.includes('current')">
+						<path d="M 7, 7 m -7, 0 a 7,7 0 1,0 14,0 a 7,7 0 1,0 -14,0" ></path>
+					</svg>
+					<svg *ngIf="step.state.includes('incomplete')">
+						<path
+							d="M8 1C4.1 1 1 4.1 1 8s3.1 7 7 7 7-3.1 7-7-3.1-7-7-7zm0 13c-3.3 0-6-2.7-6-6s2.7-6 6-6 6 2.7 6 6-2.7 6-6 6z">
+						</path>
+					</svg>
+					<svg ibmIcon="warning" size="16" *ngIf="step.state.includes('error')" class="bx--progress__warning"></svg>
+					<p
+						class="bx--progress-label"
+						*ngIf="step.tooltip"
+						[ibmTooltip]="step.tooltip.content"
+						[trigger]="step.tooltip.trigger"
+						[placement]="step.tooltip.placement"
+						[title]="step.tooltip.title"
+						[gap]="step.tooltip.gap"
+						[appendInline]="step.tooltip.appendInline"
+						[data]="step.tooltip.data"
+						(click)="stepSelected.emit({ step: step, index: i })">
+						{{step.text}}
+					</p>
+					<p class="bx--progress-label" *ngIf="!step.tooltip" (click)="stepSelected.emit({ step: step, index: i })">{{step.text}}</p>
+					<p *ngIf="step.optionalText" class="bx--progress-optional">{{step.optionalText}}</p>
+					<span class="bx--progress-line"></span>
+				</div>
+			</li>
+		</ul>
 	`
 })
-export class ProgressIndicator {
+export class ProgressIndicator implements OnInit, OnChanges {
 	static skeletonSteps(stepCount: number) {
 		const steps = [];
 		for (let i = 0; i < stepCount; i++) {
@@ -74,32 +74,50 @@ export class ProgressIndicator {
 	@Input() steps: Array<Step>;
 	@Input() orientation: "horizontal" | "vertical" = "horizontal";
 	@Input() skeleton = false;
-
 	@Input() get current() {
 		return this.steps.findIndex(step => step.state.includes("current"));
 	}
 	set current(current: number) {
-		if (current === undefined || current < 0) {
+		this._current = current;
+	}
+	private _current: number;
+
+	constructor(protected experimental: ExperimentalService) {}
+
+	ngOnInit() {
+		this.setProgressIndicatorStates();
+	}
+
+	ngOnChanges(changes: SimpleChanges) {
+		if (changes.steps || changes.current) {
+			this.setProgressIndicatorStates();
+		}
+	}
+
+	private setProgressIndicatorStates() {
+		if (this.steps === undefined) {
+			return;
+		}
+
+		if (this._current === undefined || this._current < 0) {
 			for (let i = 0; i < this.steps.length; i++) {
 				this.steps[i].state[0] = "incomplete";
 			}
 			return;
 		}
 
-		if (current > this.steps.length - 1) {
+		if (this._current > this.steps.length - 1) {
 			for (let i = 0; i < this.steps.length; i++) {
 				this.steps[i].state[0] = "complete";
 			}
 			return;
 		}
-		this.steps[current].state[0] = "current";
-		for (let i = 0; i < current; i++) {
+		this.steps[this._current].state[0] = "current";
+		for (let i = 0; i < this._current; i++) {
 			this.steps[i].state[0] = "complete";
 		}
-		for (let i = current + 1; i < this.steps.length; i++) {
+		for (let i = this._current + 1; i < this.steps.length; i++) {
 			this.steps[i].state[0] = "incomplete";
 		}
 	}
-
-	constructor(protected experimental: ExperimentalService) {}
 }


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1576

{{short description}}
Changes updating strategy for the `current` field in the progress indicator from a setter/getter approach to updating inside of the lifecycle hook OnChanges.
#### Changelog

**Changed**

* Updating strategy for the current field changed inside of the progress indicator
