### PR TITLE
fix(position): fix no placeholder case with position, add animatio…

### DIFF
--- a/src/dialog/dialog.component.ts
+++ b/src/dialog/dialog.component.ts
@@ -18,7 +18,7 @@ import {
 import Position, { position, AbsolutePosition, Positions } from "@carbon/utils-position";
 import { cycleTabs, getFocusElementList } from "carbon-components-angular/common";
 import { CloseMeta, CloseReasons, DialogConfig } from "./dialog-config.interface";
-import { ElementService } from "carbon-components-angular/utils";
+import { AnimationFrameService, ElementService } from "carbon-components-angular/utils";
 
 /**
  * Implements a `Dialog` that can be positioned anywhere on the page.
@@ -55,6 +55,9 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 	public placement: string;
 
 	protected visibilitySubscription = new Subscription();
+
+	protected animationFrameSubscription = new Subscription();
+
 	/**
 	 * Handles offsetting the `Dialog` item based on the defined position
 	 * to not obscure the content beneath.
@@ -80,7 +83,8 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 	 */
 	constructor(
 		protected elementRef: ElementRef,
-		protected elementService: ElementService
+		protected elementService: ElementService,
+		protected animationFrameService: AnimationFrameService
 	) {}
 
 	/**
@@ -115,6 +119,10 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 		}
 
 		const parentElement = this.dialogConfig.parentRef.nativeElement;
+
+		this.animationFrameSubscription = this.animationFrameService.tick.subscribe(() => {
+			this.placeDialog();
+		});
 
 		if (this.dialogConfig.closeWhenHidden) {
 			this.visibilitySubscription = this.elementService

--- a/src/dialog/dialog.component.ts
+++ b/src/dialog/dialog.component.ts
@@ -8,7 +8,8 @@ import {
 	OnInit,
 	AfterViewInit,
 	OnDestroy,
-	HostListener
+	HostListener,
+	Optional
 } from "@angular/core";
 import {
 	Observable,
@@ -84,7 +85,7 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 	constructor(
 		protected elementRef: ElementRef,
 		protected elementService: ElementService,
-		protected animationFrameService: AnimationFrameService
+		@Optional() protected animationFrameService: AnimationFrameService = null
 	) {}
 
 	/**
@@ -120,9 +121,11 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 
 		const parentElement = this.dialogConfig.parentRef.nativeElement;
 
-		this.animationFrameSubscription = this.animationFrameService.tick.subscribe(() => {
-			this.placeDialog();
-		});
+		if (this.animationFrameService) {
+			this.animationFrameSubscription = this.animationFrameService.tick.subscribe(() => {
+				this.placeDialog();
+			});
+		}
 
 		if (this.dialogConfig.closeWhenHidden) {
 			this.visibilitySubscription = this.elementService
@@ -247,5 +250,8 @@ export class Dialog implements OnInit, AfterViewInit, OnDestroy {
 	 */
 	ngOnDestroy() {
 		this.visibilitySubscription.unsubscribe();
+		if (this.animationFrameSubscription) {
+			this.animationFrameSubscription.unsubscribe();
+		}
 	}
 }

--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -27,7 +27,7 @@ export class OverflowMenuCustomPane extends Dialog implements AfterViewInit {
 	constructor(
 		protected elementRef: ElementRef,
 		protected i18n: I18n,
-		protected animationFrameService: AnimationFrameService,
+		@Optional() protected animationFrameService: AnimationFrameService = null,
 		// mark `elementService` as optional since making it mandatory would be a breaking change
 		@Optional() protected elementService: ElementService = null
 	) {

--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, Optional } from "@angular/core";
 import { position } from "@carbon/utils-position";
 import { I18n } from "carbon-components-angular/i18n";
-import { ElementService } from "carbon-components-angular/utils";
+import { AnimationFrameService, ElementService } from "carbon-components-angular/utils";
 import { closestAttr } from "carbon-components-angular/utils";
 import { Dialog } from "../dialog.component";
 
@@ -27,17 +27,18 @@ export class OverflowMenuCustomPane extends Dialog implements AfterViewInit {
 	constructor(
 		protected elementRef: ElementRef,
 		protected i18n: I18n,
+		protected animationFrameService: AnimationFrameService,
 		// mark `elementService` as optional since making it mandatory would be a breaking change
 		@Optional() protected elementService: ElementService = null
 	) {
-		super(elementRef, elementService);
+		super(elementRef, elementService, animationFrameService);
 	}
 
 	onDialogInit() {
 		const positionOverflowMenu = pos => {
 			let offset;
 			/*
-			* 16 is half the width of the overflow menu trigger element.
+			* 20 is half the width of the overflow menu trigger element.
 			* we also move the element by half of it's own width, since
 			* position service will try and center everything
 			*/
@@ -45,7 +46,7 @@ export class OverflowMenuCustomPane extends Dialog implements AfterViewInit {
 			const topFix = closestRel ? closestRel.getBoundingClientRect().top * -1 : 0;
 			const leftFix = closestRel ? closestRel.getBoundingClientRect().left * -1 : 0;
 
-			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 16;
+			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 20;
 			if (this.dialogConfig.flip) {
 				return position.addOffset(pos, topFix, (-offset + leftFix));
 			}

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -43,7 +43,7 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 		protected elementRef: ElementRef,
 		protected i18n: I18n,
 		protected experimental: ExperimentalService,
-		protected animationFrameService: AnimationFrameService,
+		@Optional() protected animationFrameService: AnimationFrameService = null,
 		// mark `elementService` as optional since making it mandatory would be a breaking change
 		@Optional() protected elementService: ElementService = null) {
 		super(elementRef, elementService, animationFrameService);

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -10,7 +10,7 @@ import { position } from "@carbon/utils-position";
 import { isFocusInLastItem, isFocusInFirstItem } from "carbon-components-angular/common";
 import { I18n } from "carbon-components-angular/i18n";
 import { ExperimentalService } from "carbon-components-angular/experimental";
-import { ElementService } from "carbon-components-angular/utils";
+import { AnimationFrameService, ElementService } from "carbon-components-angular/utils";
 import { CloseReasons } from "../dialog-config.interface";
 import { closestAttr } from "carbon-components-angular/utils";
 
@@ -43,16 +43,17 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 		protected elementRef: ElementRef,
 		protected i18n: I18n,
 		protected experimental: ExperimentalService,
+		protected animationFrameService: AnimationFrameService,
 		// mark `elementService` as optional since making it mandatory would be a breaking change
 		@Optional() protected elementService: ElementService = null) {
-		super(elementRef, elementService);
+		super(elementRef, elementService, animationFrameService);
 	}
 
 	onDialogInit() {
 		const positionOverflowMenu = pos => {
 			let offset;
 			/*
-			* 16 is half the width of the overflow menu trigger element.
+			* 20 is half the width of the overflow menu trigger element.
 			* we also move the element by half of it's own width, since
 			* position service will try and center everything
 			*/
@@ -60,7 +61,7 @@ export class OverflowMenuPane extends Dialog implements AfterViewInit {
 			const topFix = closestRel ? closestRel.getBoundingClientRect().top * -1 : 0;
 			const leftFix = closestRel ? closestRel.getBoundingClientRect().left * -1 : 0;
 
-			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 16;
+			offset = Math.round(this.dialog.nativeElement.offsetWidth / 2) - 20;
 			if (this.dialogConfig.flip) {
 				return position.addOffset(pos, topFix, (-offset + leftFix));
 			}

--- a/src/dialog/tooltip/tooltip.component.ts
+++ b/src/dialog/tooltip/tooltip.component.ts
@@ -9,7 +9,7 @@ import { getFocusElementList } from "carbon-components-angular/common";
 
 import { Dialog } from "../dialog.component";
 import { position } from "@carbon/utils-position";
-import { ElementService } from "carbon-components-angular/utils";
+import { AnimationFrameService, ElementService } from "carbon-components-angular/utils";
 import { closestAttr } from "carbon-components-angular/utils";
 
 /**
@@ -51,32 +51,41 @@ export class Tooltip extends Dialog {
 
 	constructor(
 		protected elementRef: ElementRef,
-		protected elementService: ElementService) {
-		super(elementRef, elementService);
+		protected elementService: ElementService,
+		protected animationFrameService: AnimationFrameService) {
+		super(elementRef, elementService, animationFrameService);
 	}
 
 	/**
 	 * Check whether there is a template for the `Tooltip` content.
 	 */
 	onDialogInit() {
-		const closestWithPos = closestAttr("position", ["relative", "fixed", "absolute"], this.elementRef.nativeElement.parentElement);
-		const topPos = closestWithPos ? closestWithPos.getBoundingClientRect().top * -1 : 0;
-		const leftPos = closestWithPos ? closestWithPos.getBoundingClientRect().left * -1 : 0;
-
 		this.addGap["bottom"] = pos => {
-			return position.addOffset(pos, 3 + topPos, 0 + leftPos);
+			const adjustedOffset = this.getAdjustOffset();
+			return position.addOffset(pos, 3 + adjustedOffset.top, 0 + adjustedOffset.left);
 		};
 		this.addGap["top"] = pos => {
-			return position.addOffset(pos, -10 + topPos, 0 + leftPos);
+			const adjustedOffset = this.getAdjustOffset();
+			return position.addOffset(pos, -10 + adjustedOffset.top, 0 + adjustedOffset.left);
 		};
 		this.addGap["left"] = pos => {
-			return position.addOffset(pos, -3 + topPos, -6 + leftPos);
+			const adjustedOffset = this.getAdjustOffset();
+			return position.addOffset(pos, -3 + adjustedOffset.top, -6 + adjustedOffset.left);
 		};
 		this.addGap["right"] = pos => {
-			return position.addOffset(pos, -3 + topPos, 6 + leftPos);
+			const adjustedOffset = this.getAdjustOffset();
+			return position.addOffset(pos, -3 + adjustedOffset.top, 6 + adjustedOffset.left);
 		};
 
 		this.hasContentTemplate = this.dialogConfig.content instanceof TemplateRef;
+	}
+
+	getAdjustOffset() {
+ 		const closestWithPos = closestAttr("position", ["relative", "fixed", "absolute"], this.elementRef.nativeElement.parentElement);
+		const topPos = closestWithPos ? closestWithPos.getBoundingClientRect().top * -1 : 0;
+		const leftPos = closestWithPos ? closestWithPos.getBoundingClientRect().left * -1 : 0;
+
+		return {top: topPos, left: leftPos};
 	}
 
 	afterDialogViewInit() {

--- a/src/dialog/tooltip/tooltip.component.ts
+++ b/src/dialog/tooltip/tooltip.component.ts
@@ -81,7 +81,7 @@ export class Tooltip extends Dialog {
 	}
 
 	getAdjustOffset() {
- 		const closestWithPos = closestAttr("position", ["relative", "fixed", "absolute"], this.elementRef.nativeElement.parentElement);
+		const closestWithPos = closestAttr("position", ["relative", "fixed", "absolute"], this.elementRef.nativeElement.parentElement);
 		const topPos = closestWithPos ? closestWithPos.getBoundingClientRect().top * -1 : 0;
 		const leftPos = closestWithPos ? closestWithPos.getBoundingClientRect().left * -1 : 0;
 

--- a/src/dialog/tooltip/tooltip.component.ts
+++ b/src/dialog/tooltip/tooltip.component.ts
@@ -52,7 +52,7 @@ export class Tooltip extends Dialog {
 	constructor(
 		protected elementRef: ElementRef,
 		protected elementService: ElementService,
-		protected animationFrameService: AnimationFrameService) {
+		@Optional() protected animationFrameService: AnimationFrameService = null) {
 		super(elementRef, elementService, animationFrameService);
 	}
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -10,6 +10,10 @@ function matchesAttr(el, attr, val) {
 export function closestAttr(s, t, element) {
 	let el = element;
 
+	if (!element) {
+		return null;
+	}
+
 	do {
 		if (matchesAttr(el, s, t)) {
 			return el;


### PR DESCRIPTION
Fixing case where no placeholder exists and element has parents with position set and some spacing. Issue is fixed indirectly by adding animationService tick to mimic what dropdown is doing. Also fixing calculation for overflow menu as menu button is 40px now instead of 32 so half is 20px instead of the previous 16px.

Before:

![Screen Shot 2020-12-14 at 6 09 31 PM](https://user-images.githubusercontent.com/302239/102151516-b6bf1980-3e38-11eb-823f-75e694e77f62.png)

After:

![Screen Shot 2020-12-14 at 6 07 08 PM](https://user-images.githubusercontent.com/302239/102151576-bb83cd80-3e38-11eb-97e4-8f360d1b227d.png)


This should conclude all possible cases:

Case 1: no ibm placeholder and element has no parent with position set with some spacing
Case 2: ibm placeholder and element has no parent with position set with some spacing
Case 3: no ibm placeholder and element has parent with position set with some spacing
Case 4: ibm placeholder present next to element and element has parent with position set with some spacing
Case 5: ibm placeholder present next to some parent of element and element has parent with position set with some spacing