### PR TITLE
fix(table): fix table arrow not changing on expansion

### DIFF
--- a/src/table/cell/table-expand-button.component.ts
+++ b/src/table/cell/table-expand-button.component.ts
@@ -17,7 +17,7 @@ import { Observable } from "rxjs";
 			class="bx--table-expand__button"
 			[attr.aria-label]="getAriaLabel() | async"
 			(click)="expandRow.emit()">
-			<svg ibmIcon="chevron--right" size="16" innerClass="bx--table-expand__svg"></svg>
+			<svg ibmIcon="chevron--right" size="16" class="bx--table-expand__svg"></svg>
 		</button>
 	`
 })


### PR DESCRIPTION
Expansion arrow doesn't seem to rotate on expansion. This fixes that