### PR TITLE
Add title to sidenav anchor

### DIFF
--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -25,6 +25,7 @@ import { Router } from "@angular/router";
 				[href]="href"
 				[attr.role]="(isSubMenu ? 'menuitem' : null)"
 				[attr.aria-current]="(active ? 'page' : null)"
+				[title]="title"
 				(click)="navigate($event)">
 				<div *ngIf="!isSubMenu" class="bx--side-nav__icon">
 					<ng-content select="svg, [icon]"></ng-content>

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -73,6 +73,11 @@ export class SideNavItem implements OnChanges {
 	@Input() routeExtras: any;
 
 	/**
+	 * Title attribute of the anchor element.
+	 */
+	@Input() title: string;
+
+	/**
 	 * Emits the navigation status promise when the link is activated
 	 */
 	@Output() navigation = new EventEmitter<Promise<boolean>>();


### PR DESCRIPTION
Adds a "Title" attribute to an anchor on the sidenav. 

The reason for this is for a better support on long words that might be obfuscated or links that might need a descriptive title. 