### PR TITLE
fix(dropdown): correct isUpdate behaviour

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -458,13 +458,13 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 					// not guarding these since the nativeElement has to be loaded
 					// for select to even fire
 					// only focus for "organic" selections
-					if (event && event.isUpdate) {
+					if (event && !event.isUpdate) {
 						this.elementRef.nativeElement.querySelector("input").focus();
 						this.view.filterBy("");
 					}
 					this.closeDropdown();
 				}
-				if (event && event.isUpdate) {
+				if (event && !event.isUpdate) {
 					this.selected.emit(event);
 				}
 			});

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -223,7 +223,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 		this.index = this.getListItems().findIndex(item => item.selected);
 		this.setupFocusObservable();
 		setTimeout(() => {
-			this.doEmitSelect(false);
+			this.doEmitSelect(true);
 		});
 	}
 
@@ -486,22 +486,17 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	doClick(event, item) {
 		event.preventDefault();
 		if (!item.disabled) {
-			let selected;
 			if (this.type === "single") {
 				item.selected = true;
 				// reset the selection
 				for (let otherItem of this.getListItems()) {
 					if (item !== otherItem) { otherItem.selected = false; }
 				}
-
-				selected = {item};
 			} else {
 				item.selected = !item.selected;
-				// emit an array of selected items
-				selected = this.getSelected();
 			}
 			this.index = this.displayItems.indexOf(item);
-			this.select.emit(selected);
+			this.doEmitSelect(false);
 		}
 	}
 


### PR DESCRIPTION
Follows from https://github.com/IBM/carbon-components-angular/pull/1693/files `isUpdate = true` is for updates originating from the component, `isUpdate = false` is for organic selections. This standardizes that usage, and expands the usage to `doEmitSelect` (since it wasn't handling everything like it should)