### PR TITLE
fix(dialog): Remove onTouchStart

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -134,16 +134,6 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 		protected eventService: EventService
 	) {}
 
-	/**
-	 * Overrides 'touchstart' event to trigger a toggle on the Dialog.
-	 */
-	onTouchStart(event) {
-		event.stopImmediatePropagation();
-		this.toggle({
-			reason: CloseReasons.interaction
-		});
-	}
-
 	ngOnChanges(changes: SimpleChanges) {
 		// set the config object (this can [and should!] be added to in child classes depending on what they need)
 		this.dialogConfig = {
@@ -186,8 +176,6 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 		this.dialogService.singletonClickListen();
 
 		const element = this.elementRef.nativeElement;
-
-		this.eventService.on(element, "touchstart", this.onTouchStart.bind(this));
 
 		this.eventService.on(element, "keydown", (event: KeyboardEvent) => {
 			// "Esc" is an IE specific value


### PR DESCRIPTION
closes #1669

Touch and click both get registered and toggle the dialog. Touch toggles it open, click toggles it close.
Tested in chrome compatibility and safary in xcode with overflow menu.