### PR TITLE
fix(checkbox): prevent unexpected indeterminate action

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -59,7 +59,6 @@ export class CheckboxChange {
 				[required]="required"
 				[checked]="checked"
 				[disabled]="disabled"
-				[indeterminate]="indeterminate"
 				[attr.aria-labelledby]="ariaLabelledby"
 				[attr.aria-checked]="(indeterminate ? 'mixed' : checked)"
 				(change)="onChange($event)"
@@ -178,20 +177,15 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Allows double binding with the `indeterminateChange` Output.
 	 */
 	@Input() set indeterminate(indeterminate: boolean) {
-		if (indeterminate === this._indeterminate) {
-			return;
-		}
-		// Set indeterminate and reset checked if indeterminate is true - only one of them can be true
 		this._indeterminate = indeterminate;
-		if (indeterminate && this._checked) {
-			this._checked = false;
-		}
 
 		if (this._indeterminate) {
 			this.transitionCheckboxState(CheckboxState.Indeterminate);
 		} else {
 			this.transitionCheckboxState(this.checked ? CheckboxState.Checked : CheckboxState.Unchecked);
 		}
+
+		this.inputCheckbox.nativeElement.indeterminate = indeterminate;
 		this.changeDetectorRef.markForCheck();
 		this.indeterminateChange.emit(this._indeterminate);
 	}

--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -177,6 +177,10 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Allows double binding with the `indeterminateChange` Output.
 	 */
 	@Input() set indeterminate(indeterminate: boolean) {
+		if (indeterminate === this._indeterminate) {
+			return;
+		}
+
 		this._indeterminate = indeterminate;
 
 		if (this._indeterminate) {
@@ -203,8 +207,7 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Allows double binding with the `checkedChange` Output.
 	 */
 	@Input() set checked (checked: boolean) {
-		// Set checked and reset indeterminate if checked is true - only one of them can be true
-		this.setChecked(checked, checked);
+		this.setChecked(checked, false);
 	}
 
 	/**
@@ -372,7 +375,6 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	ngAfterViewInit() {
 		if (this.indeterminate) {
 			this.inputCheckbox.nativeElement.indeterminate = true;
-			this.checked = false;
 		}
 	}
 

--- a/src/checkbox/checkbox.stories.ts
+++ b/src/checkbox/checkbox.stories.ts
@@ -44,6 +44,55 @@ storiesOf("Components|Checkbox", module).addDecorator(
 			hideLabel: boolean("Hide labels", false)
 		}
 	}))
+	.add("Programmatically", () => ({
+		template: `
+			<ibm-checkbox
+				[indeterminate]="indeterminate"
+				[checked]="checked"
+				(checkedChange)="onChange($event)"
+				(indterminateChange)="onIndeterminateChange($event)">
+				Programmatic checkbox
+			</ibm-checkbox>
+
+			<button (click)="toggle()">Toggle</button>
+			<button (click)="setIndeterminate()">Set indeterminate</button>
+		`,
+		props: {
+			indeterminate: false,
+			checked: false,
+			toggle: function() {
+				this.checked = !this.checked;
+			},
+			setIndeterminate: function() {
+				this.indeterminate = !this.indeterminate;
+			},
+			onChange: function(checkboxChange: boolean) {
+				this.checked = checkboxChange;
+			},
+			onIndeterminateChange: function(indterminateChange: boolean) {
+				this.indeterminate = indterminateChange;
+			}
+		}
+	}))
+	.add("With ngModel", () => ({
+		template: `
+			<ibm-checkbox
+				[(ngModel)]="model">
+				ngModel checkbox
+			</ibm-checkbox>
+
+			<div style="display:flex; flex-direction: column; width: 150px">
+				<button (click)="toggleModel()">Set model</button>
+				Checked: {{ model }}
+			</div>
+		`,
+		props: {
+			model: true,
+			toggleModel: function() {
+				this.model = !this.model;
+			}
+		}
+	}))
 	.add("Skeleton", () => ({
 		template: `<ibm-checkbox skeleton="true"></ibm-checkbox>`
 }))

--- a/src/checkbox/checkbox.stories.ts
+++ b/src/checkbox/checkbox.stories.ts
@@ -44,13 +44,42 @@ storiesOf("Components|Checkbox", module).addDecorator(
 			hideLabel: boolean("Hide labels", false)
 		}
 	}))
+	.add("Enforcing indeterminate to toggle to unchecked state", () => ({
+		template: `
+			<ibm-checkbox
+				[indeterminate]="indeterminate"
+				[checked]="checked"
+				(indeterminateChange)="onIndeterminateChange($event)"
+				(checkedChange)="onCheckedChange($event)">
+				Indeterminate
+			</ibm-checkbox>
+
+			<button (click)="setIndeterminate()">Set indeterminate</button>
+		`,
+		props: {
+			indeterminate: true,
+			checked: true,
+			setIndeterminate: function() {
+				this.indeterminate = true;
+				// sets `checked` to true so that when the checkbox is toggled,
+				// it goes to an unchecked state.
+				this.checked = true;
+			},
+			onIndeterminateChange: function(indeterminateState: boolean) {
+				this.indeterminate = indeterminateState;
+			},
+			onCheckedChange: function(checked: boolean) {
+				this.checked = checked;
+			}
+		}
+	}))
 	.add("Programmatically", () => ({
 		template: `
 			<ibm-checkbox
 				[indeterminate]="indeterminate"
 				[checked]="checked"
-				(checkedChange)="onChange($event)"
-				(indterminateChange)="onIndeterminateChange($event)">
+				(indeterminateChange)="onIndeterminateChange($event)"
+				(checkedChange)="onCheckedChange($event)">
 				Programmatic checkbox
 			</ibm-checkbox>
 
@@ -62,15 +91,16 @@ storiesOf("Components|Checkbox", module).addDecorator(
 			checked: false,
 			toggle: function() {
 				this.checked = !this.checked;
+				this.indeterminate = false;
 			},
 			setIndeterminate: function() {
-				this.indeterminate = !this.indeterminate;
+				this.indeterminate = true;
 			},
-			onChange: function(checkboxChange: boolean) {
-				this.checked = checkboxChange;
+			onIndeterminateChange: function(indeterminateState: boolean) {
+				this.indeterminate = indeterminateState;
 			},
-			onIndeterminateChange: function(indterminateChange: boolean) {
-				this.indeterminate = indterminateChange;
+			onCheckedChange: function(checked: boolean) {
+				this.checked = checked;
 			}
 		}
 	}))

--- a/src/table/head/table-head-checkbox.component.ts
+++ b/src/table/head/table-head-checkbox.component.ts
@@ -20,7 +20,7 @@ import { TableRowSize } from "../table.types";
 			[name]="name"
 			[checked]="checked"
 			[indeterminate]="indeterminate"
-			(change)="change.emit()"
+			(checkedChange)="change.emit()"
 			[aria-label]="getAriaLabel() | async">
 		</ibm-checkbox>
 	`,

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -718,7 +718,7 @@ export class Table implements AfterViewInit, OnDestroy {
 			this.selectAllCheckbox = false;
 			this.selectAllCheckboxSomeSelected = false;
 		} else if (selectedRowsCount < this.model.data.length) {
-			this.selectAllCheckbox = false;
+			this.selectAllCheckbox = true;
 			this.selectAllCheckboxSomeSelected = true;
 		} else {
 			this.selectAllCheckbox = true;


### PR DESCRIPTION
Closes #1728 

#### Changelog

- Previously we were setting `selectAllCheckbox` to `false` if some, but not all the rows in a table were selected so `checked` in the table head checkbox is then set to `false`. When the table head checkbox is toggled again to deselect all the selected rows, `checked` is then set to `true`.

- An assumption was made in https://github.com/IBM/carbon-components-angular/blob/master/src/checkbox/checkbox.component.ts#L184 that either indeterminate is true or checked is true, but both can't be true. The indeterminate state is visual only so the actual checkbox should still either be in an unchecked or checked state. Since it's just masking the real value of the checkbox, automatically setting `checked` to false when `indeterminate` is true causes unexpected behaviors.

- The above issues are what caused the problem #1728.

- A fix was done in the past (#1531) to prevent `selectAll` and `deselectAll` from emitting three times every time you click on the table head checkbox. I believe that `selectAll` and `deselectAll` emitting three times each time the checkbox is toggled somehow got around all the above issues and #1531 reintroduced it. It no longer emits three times and now behaves as expected.

- Target event `change` changed to `checkedChange` since `change` is deprecated.

- Setting `indeterminate` directly on the checkbox input native element since it doesn't pick up the most up-to-date changes occasionally. 
