### PR TITLE
fix(table): Remove JSON.stringify in TableItem.title

### DIFF
--- a/src/table/table-item.class.ts
+++ b/src/table/table-item.class.ts
@@ -126,7 +126,8 @@ export class TableItem {
 			return this.data.toString();
 		}
 
-		return JSON.stringify(this.data);
+		// data can’t be reasonably converted to an end user readable string
+		return "";
 	}
 
 	set title(title) {


### PR DESCRIPTION
Closes https://github.com/IBM/carbon-components-angular/issues/1730

Remove `JSON.stringify` call in `TableItem.title` that broke some data tables. Return empty string if the data can’t be reasonably converted to an end user readable string. The caller can provide the title attribute in those cases.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
