### PR TITLE
feat(tabs): update to scrollable tabs

### DIFF
--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -323,13 +323,12 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, O
 		const rightEdgeReached =
 			direction === 1 &&
 			scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
-		if (leftEdgeReached || rightEdgeReached) {
-			if (leftEdgeReached) {
-				this.rightOverflowNavButton.nativeElement.focus();
-			}
-			if (rightEdgeReached) {
-				this.leftOverflowNavButton.nativeElement.focus();
-			}
+
+		if (leftEdgeReached) {
+			this.rightOverflowNavButton.nativeElement.focus();
+		}
+		if (rightEdgeReached) {
+			this.leftOverflowNavButton.nativeElement.focus();
 		}
 	}
 

--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -15,9 +15,10 @@ import {
 	OnInit
 } from "@angular/core";
 
+import { Subscription } from "rxjs";
+import { EventService } from "carbon-components-angular/utils";
+
 import { TabHeader } from "./tab-header.component";
-import { fromEvent, Subscription } from "rxjs";
-import { debounceTime } from "rxjs/operators";
 
 @Component({
 	selector: "ibm-tab-header-group",
@@ -93,7 +94,7 @@ import { debounceTime } from "rxjs/operators";
 	</nav>
 	`
 })
-export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, OnInit {
+export class TabHeaderGroup implements AfterContentInit, OnChanges, OnInit {
 	/**
 	 * Set to 'true' to have tabs automatically activated and have their content displayed when they receive focus.
 	 */
@@ -166,9 +167,12 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, O
 	private _cacheActive = false;
 
 	private overflowNavInterval;
-	private windowResizeSubscription;
 
-	constructor(protected elementRef: ElementRef, protected changeDetectorRef: ChangeDetectorRef) { }
+	constructor(
+		protected elementRef: ElementRef,
+		protected changeDetectorRef: ChangeDetectorRef,
+		protected eventService: EventService
+	) { }
 
 	// keyboard accessibility
 	/**
@@ -245,9 +249,7 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, O
 	}
 
 	ngOnInit() {
-		this.windowResizeSubscription = fromEvent(window, "resize", { passive: true })
-			.pipe(debounceTime(200))
-			.subscribe(() => this.handleScroll());
+		this.eventService.on(window as any, "resize", () => this.handleScroll());
 	}
 
 	ngAfterContentInit() {
@@ -355,10 +357,5 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, O
 
 	public handleOverflowNavMouseUp() {
 		clearInterval(this.overflowNavInterval);
-	}
-
-	ngOnDestroy() {
-		this.selectedSubscriptionTracker.unsubscribe();
-		this.windowResizeSubscription.unsubscribe();
 	}
 }

--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -4,7 +4,6 @@ import {
 	Input,
 	HostListener,
 	ContentChildren,
-	OnDestroy,
 	AfterContentInit,
 	ElementRef,
 	TemplateRef,

--- a/src/tabs/tab-header-group.component.ts
+++ b/src/tabs/tab-header-group.component.ts
@@ -9,55 +9,56 @@ import {
 	ElementRef,
 	TemplateRef,
 	OnChanges,
-	SimpleChanges
+	SimpleChanges,
+	ChangeDetectorRef,
+	ViewChild,
+	OnInit
 } from "@angular/core";
 
 import { TabHeader } from "./tab-header.component";
-import { Subscription } from "rxjs";
+import { fromEvent, Subscription } from "rxjs";
+import { debounceTime } from "rxjs/operators";
 
 @Component({
 	selector: "ibm-tab-header-group",
 	template: `
 	<nav
-		class="bx--tabs"
+		class="bx--tabs bx--tabs--scrollable"
 		[ngClass]="{
 			'bx--skeleton': skeleton,
-			'bx--tabs--container': type === 'container'
+			'bx--tabs--container bx--tabs--scrollable--container': type === 'container'
 		}"
 		role="navigation"
 		[attr.aria-label]="ariaLabel"
 		[attr.aria-labelledby]="ariaLabelledby">
-		<div
-			class="bx--tabs-trigger"
-			tabindex="0"
-			(click)="showTabList()"
-			(keydown)="onDropdownKeydown($event)">
-			<a
-				href="javascript:void(0)"
-				class="bx--tabs-trigger-text"
-				tabindex="-1"
-				*ngIf="(!getSelectedTab().headingIsTemplate && getSelectedTab().heading != '') || getSelectedTab().headingIsTemplate">
-				<ng-container *ngIf="!getSelectedTab().headingIsTemplate">
-					{{ getSelectedTab().heading }}
-				</ng-container>
-				<ng-template
-					*ngIf="getSelectedTab().headingIsTemplate"
-					[ngTemplateOutlet]="getSelectedTab().heading"
-					[ngTemplateOutletContext]="{$implicit: getSelectedTab().context}">
-				</ng-template>
-			</a>
-			<svg width="10" height="5" viewBox="0 0 10 5">
-				<path d="M0 0l5 4.998L10 0z" fill-rule="evenodd"></path>
+		<button
+			#leftOverflowNavButton
+			type="button"
+			[ngClass]="{
+				'bx--tab--overflow-nav-button': hasHorizontalOverflow,
+				'bx--tab--overflow-nav-button--hidden': leftOverflowNavButtonHidden
+			}"
+			(click)="handleOverflowNavClick(-1)"
+			(mousedown)="handleOverflowNavMouseDown(-1)"
+			(mouseup)="handleOverflowNavMouseUp()">
+			<svg
+				focusable="false"
+				preserveAspectRatio="xMidYMid meet"
+				xmlns="http://www.w3.org/2000/svg"
+				fill="currentColor"
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				aria-hidden="true">
+				<path d="M5 8L10 3 10.7 3.7 6.4 8 10.7 12.3 10 13z"></path>
 			</svg>
-		</div>
+		</button>
+		<div *ngIf="!leftOverflowNavButtonHidden" class="bx--tabs__overflow-indicator--left"></div>
 		<ul
 			#tabList
-			[ngClass]="{
-				'bx--tabs__nav--hidden': !tabListVisible
-			}"
-			(keydown)="tabDropdownKeydown($event)"
-			class="bx--tabs__nav"
-			role="tablist">
+			class="bx--tabs--scrollable__nav"
+			role="tablist"
+			(scroll)="handleScroll()">
 			<li role="presentation">
 				<ng-container *ngIf="contentBefore" [ngTemplateOutlet]="contentBefore"></ng-container>
 			</li>
@@ -66,10 +67,33 @@ import { Subscription } from "rxjs";
 				<ng-container *ngIf="contentAfter" [ngTemplateOutlet]="contentAfter"></ng-container>
 			</li>
 		</ul>
+		<div *ngIf="!rightOverflowNavButtonHidden" class="bx--tabs__overflow-indicator--right"></div>
+		<button
+			#rightOverflowNavButton
+			type="button"
+			[ngClass]="{
+				'bx--tab--overflow-nav-button': hasHorizontalOverflow,
+				'bx--tab--overflow-nav-button--hidden': rightOverflowNavButtonHidden
+			}"
+			(click)="handleOverflowNavClick(1)"
+			(mousedown)="handleOverflowNavMouseDown(1)"
+			(mouseup)="handleOverflowNavMouseUp()">
+			<svg
+				focusable="false"
+				preserveAspectRatio="xMidYMid meet"
+				xmlns="http://www.w3.org/2000/svg"
+				fill="currentColor"
+				width="16"
+				height="16"
+				viewBox="0 0 16 16"
+				aria-hidden="true">
+				<path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+			</svg>
+		</button>
 	</nav>
 	`
 })
-export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
+export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges, OnInit {
 	/**
 	 * Set to 'true' to have tabs automatically activated and have their content displayed when they receive focus.
 	 */
@@ -104,20 +128,47 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
 	 * ContentChildren of all the tabHeaders.
 	 */
 	@ContentChildren(TabHeader) tabHeaderQuery: QueryList<TabHeader>;
+	// @ts-ignore
+	@ViewChild("tabList", { static: true }) headerContainer;
+	// @ts-ignore
+	@ViewChild("rightOverflowNavButton", { static: true }) rightOverflowNavButton;
+	// @ts-ignore
+	@ViewChild("leftOverflowNavButton", { static: true }) leftOverflowNavButton;
 	/**
 	 * Keeps track of all the subscriptions to the tab header selection events.
 	 */
 	selectedSubscriptionTracker = new Subscription();
 
-	public tabListVisible = false;
 	/**
 	 * Controls the manual focusing done by tabbing through headings.
 	 */
 	public currentSelectedIndex = 0;
 
+	public get hasHorizontalOverflow() {
+		const tabList = this.headerContainer.nativeElement;
+		return tabList.scrollWidth > tabList.clientWidth;
+	}
+
+	public get leftOverflowNavButtonHidden() {
+		const tabList = this.headerContainer.nativeElement;
+		return !this.hasHorizontalOverflow || !tabList.scrollLeft;
+	}
+
+	public get rightOverflowNavButtonHidden() {
+		const tabList = this.headerContainer.nativeElement;
+		return !this.hasHorizontalOverflow ||
+			(tabList.scrollLeft + tabList.clientWidth) === tabList.scrollWidth;
+	}
+
+	// width of the overflow buttons
+	OVERFLOW_BUTTON_OFFSET = 40;
+
 	private _cacheActive = false;
 
-	constructor(protected elementRef: ElementRef) {}
+	private overflowNavInterval;
+	private windowResizeSubscription;
+
+	constructor(protected elementRef: ElementRef, protected changeDetectorRef: ChangeDetectorRef) { }
 
 	// keyboard accessibility
 	/**
@@ -191,18 +242,12 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
 		if ((event.key === " " || event.key === "Spacebar") && !this.followFocus) {
 			tabHeadersArray[this.currentSelectedIndex].selectTab();
 		}
-
-		// dropdown list handler
-		if (event.key === "Escape") {
-			this.tabListVisible = false;
-		}
 	}
 
-	@HostListener("focusout", ["$event"])
-	focusOut(event) {
-		if (this.tabListVisible && !this.elementRef.nativeElement.contains(event.relatedTarget)) {
-			this.tabListVisible = false;
-		}
+	ngOnInit() {
+		this.windowResizeSubscription = fromEvent(window, "resize", { passive: true })
+			.pipe(debounceTime(200))
+			.subscribe(() => this.handleScroll());
 	}
 
 	ngAfterContentInit() {
@@ -259,67 +304,62 @@ export class TabHeaderGroup implements AfterContentInit, OnDestroy, OnChanges {
 		};
 	}
 
-	public showTabList() {
-		this.tabListVisible = true;
-		const focusTarget = this.tabHeaderQuery.toArray().find(tab => {
-			const tabContainer = tab.tabItem.nativeElement.parentElement;
-			return !tabContainer.classList.contains("bx--tabs__nav-item--selected");
-		});
-		focusTarget.tabItem.nativeElement.focus();
+	public handleScroll() {
+		this.changeDetectorRef.markForCheck();
 	}
 
-	public onDropdownKeydown(event: KeyboardEvent) {
-		switch (event.key) {
-			case " ":
-			case "Spacebar":
-			case "Enter":
-				event.preventDefault();
-				this.showTabList();
-				break;
-			default:
-				break;
+	public handleOverflowNavClick(direction: number, multiplier = 15) {
+		const tabList = this.headerContainer.nativeElement;
+
+		const { clientWidth, scrollLeft, scrollWidth } = tabList;
+		if (direction === 1 && !scrollLeft) {
+			tabList.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;
 		}
-	}
 
-	public tabDropdownKeydown(event: KeyboardEvent) {
-		if (!this.tabListVisible) { return; }
+		tabList.scrollLeft += direction * multiplier;
 
-		const target = (event.target as HTMLElement).closest("a");
-
-		const headers = this.tabHeaderQuery.toArray().filter(tab =>
-			!tab.tabItem.nativeElement.parentElement.classList.contains("bx--tabs__nav-item--disabled") &&
-			!tab.tabItem.nativeElement.parentElement.classList.contains("bx--tabs__nav-item--selected"));
-
-		// unless focus can move, it should remain on the target
-		let next: HTMLElement = target;
-		let previous: HTMLElement = target;
-
-		for (let i = 0; i < headers.length; i++) {
-			if (headers[i].tabItem.nativeElement === target) {
-				if (i + 1 < headers.length) {
-					next = headers[i + 1].tabItem.nativeElement;
-				}
-				if (i - 1 >= 0) {
-					previous = headers[i - 1].tabItem.nativeElement;
-				}
+		const leftEdgeReached =
+			direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+		const rightEdgeReached =
+			direction === 1 &&
+			scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+		if (leftEdgeReached || rightEdgeReached) {
+			if (leftEdgeReached) {
+				this.rightOverflowNavButton.nativeElement.focus();
+			}
+			if (rightEdgeReached) {
+				this.leftOverflowNavButton.nativeElement.focus();
 			}
 		}
+	}
 
-		switch (event.key) {
-			case "ArrowDown":
-			case "Down": // IE11 specific value
-				next.focus();
-				break;
-			case "ArrowUp":
-			case "Up": // IE11 specific value
-				previous.focus();
-				break;
-			default:
-				break;
-		}
+	public handleOverflowNavMouseDown(direction: number) {
+		const tabList = this.headerContainer.nativeElement;
+
+		this.overflowNavInterval = setInterval(() => {
+			const { clientWidth, scrollLeft, scrollWidth } = tabList;
+
+			// clear interval if scroll reaches left or right edge
+			const leftEdgeReached = direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+			const rightEdgeReached =
+				direction === 1 &&
+				scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+
+			if (leftEdgeReached || rightEdgeReached) {
+				clearInterval(this.overflowNavInterval);
+			}
+
+			// account for overflow button appearing and causing tablist width change
+			this.handleOverflowNavClick(direction);
+		});
+	}
+
+	public handleOverflowNavMouseUp() {
+		clearInterval(this.overflowNavInterval);
 	}
 
 	ngOnDestroy() {
 		this.selectedSubscriptionTracker.unsubscribe();
+		this.windowResizeSubscription.unsubscribe();
 	}
 }

--- a/src/tabs/tab-header.component.ts
+++ b/src/tabs/tab-header.component.ts
@@ -15,23 +15,23 @@ import { EventEmitter } from "@angular/core";
 	template: `
 		<li
 			[ngClass]="{
-				'bx--tabs__nav-item--selected': active,
-				'bx--tabs__nav-item--disabled': disabled
+				'bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected': active,
+				'bx--tabs__nav-item--disabled bx--tabs--scrollable__nav-item--disabled': disabled
 			}"
-			class="bx--tabs__nav-item"
+			class="bx--tabs--scrollable__nav-item"
 			role="presentation"
 			(click)="selectTab()">
-			<a
+			<button
 				#tabItem
 				[attr.aria-selected]="active"
 				draggable="false"
-				class="bx--tabs__nav-link"
+				class="bx--tabs--scrollable__nav-link"
 				href="javascript:void(0)"
 				[title]="title"
 				[attr.tabindex]="(active? 0 : -1)"
 				role="tab">
 				<ng-content></ng-content>
-			</a>
+			</button>
 		</li>
 	`
 })

--- a/src/tabs/tab-headers.component.spec.ts
+++ b/src/tabs/tab-headers.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 
+import { UtilsModule } from "carbon-components-angular/utils";
 import { TabHeaders } from "./tab-headers.component";
 
 describe("TabHeadersComponent", () => {
@@ -9,7 +10,7 @@ describe("TabHeadersComponent", () => {
 	beforeEach(() => {
 		TestBed.configureTestingModule({
 			declarations: [TabHeaders],
-			imports: [],
+			imports: [UtilsModule],
 			providers: []
 		});
 

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -12,11 +12,9 @@ import {
 	OnChanges,
 	SimpleChanges,
 	OnInit,
-	OnDestroy,
 	ChangeDetectorRef
 } from "@angular/core";
-import { fromEvent } from "rxjs";
-import { debounceTime } from "rxjs/operators";
+import { EventService } from "carbon-components-angular/utils";
 
 import { Tab } from "./tab.component";
 
@@ -131,7 +129,7 @@ import { Tab } from "./tab.component";
 	`
 })
 
-export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnInit {
+export class TabHeaders implements AfterContentInit, OnChanges, OnInit {
 	/**
 	 * List of `Tab` components.
 	 */
@@ -215,9 +213,12 @@ export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnIni
 	OVERFLOW_BUTTON_OFFSET = 40;
 
 	private overflowNavInterval;
-	private windowResizeSubscription;
 
-	constructor(protected elementRef: ElementRef, protected changeDetectorRef: ChangeDetectorRef) { }
+	constructor(
+		protected elementRef: ElementRef,
+		protected changeDetectorRef: ChangeDetectorRef,
+		protected eventService: EventService
+	) { }
 
 	// keyboard accessibility
 	/**
@@ -284,9 +285,7 @@ export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnIni
 	}
 
 	ngOnInit() {
-		this.windowResizeSubscription = fromEvent(window, "resize", { passive: true })
-			.pipe(debounceTime(200))
-			.subscribe(() => this.handleScroll());
+		this.eventService.on(window as any, "resize", () => this.handleScroll());
 	}
 
 	ngAfterContentInit() {
@@ -306,12 +305,6 @@ export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnIni
 	ngOnChanges(changes: SimpleChanges) {
 		if (this.tabs && changes.cacheActive) {
 			this.tabs.forEach(tab => tab.cacheActive = this.cacheActive);
-		}
-	}
-
-	ngOnDestroy() {
-		if (this.windowResizeSubscription) {
-			this.windowResizeSubscription.unsubscribe();
 		}
 	}
 

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -10,11 +10,15 @@ import {
 	ElementRef,
 	TemplateRef,
 	OnChanges,
-	SimpleChanges
+	SimpleChanges,
+	OnInit,
+	OnDestroy,
+	ChangeDetectorRef
 } from "@angular/core";
+import { fromEvent } from "rxjs";
+import { debounceTime } from "rxjs/operators";
 
 import { Tab } from "./tab.component";
-
 
 /**
  * The `TabHeaders` component contains the `Tab` items and controls scroll functionality
@@ -24,58 +28,55 @@ import { Tab } from "./tab.component";
 	selector: "ibm-tab-headers",
 	template: `
 		<nav
-			class="bx--tabs"
+			class="bx--tabs--scrollable"
 			[ngClass]="{
 				'bx--skeleton': skeleton,
-				'bx--tabs--container': type === 'container'
+				'bx--tabs--container bx--tabs--scrollable--container': type === 'container'
 			}"
 			role="navigation"
 			[attr.aria-label]="ariaLabel"
 			[attr.aria-labelledby]="ariaLabelledby">
-			<div
-				class="bx--tabs-trigger"
-				tabindex="0"
-				(click)="showTabList()"
-				(keydown)="onDropdownKeydown($event)">
-				<a
-					href="#"
-					(click)="$event.preventDefault()"
-					class="bx--tabs-trigger-text"
-					tabindex="-1">
-					<ng-container *ngIf="!getSelectedTab().headingIsTemplate">
-						{{ getSelectedTab().heading }}
-					</ng-container>
-					<ng-template
-						*ngIf="getSelectedTab().headingIsTemplate"
-						[ngTemplateOutlet]="getSelectedTab().heading"
-						[ngTemplateOutletContext]="{$implicit: getSelectedTab().context}">
-					</ng-template>
-				</a>
-				<svg width="10" height="5" viewBox="0 0 10 5">
-					<path d="M0 0l5 4.998L10 0z" fill-rule="evenodd"></path>
+			<button
+				#leftOverflowNavButton
+				type="button"
+				[ngClass]="{
+					'bx--tab--overflow-nav-button': hasHorizontalOverflow,
+					'bx--tab--overflow-nav-button--hidden': leftOverflowNavButtonHidden
+				}"
+				(click)="handleOverflowNavClick(-1)"
+				(mousedown)="handleOverflowNavMouseDown(-1)"
+				(mouseup)="handleOverflowNavMouseUp()">
+				<svg
+					focusable="false"
+					preserveAspectRatio="xMidYMid meet"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="currentColor"
+					width="16"
+					height="16"
+					viewBox="0 0 16 16"
+					aria-hidden="true">
+					<path d="M5 8L10 3 10.7 3.7 6.4 8 10.7 12.3 10 13z"></path>
 				</svg>
-			</div>
+			</button>
+			<div *ngIf="!leftOverflowNavButtonHidden" class="bx--tabs__overflow-indicator--left"></div>
 			<ul
 				#tabList
-				[ngClass]="{
-					'bx--tabs__nav--hidden': !tabListVisible
-				}"
-				class="bx--tabs__nav"
-				role="tablist">
+				class="bx--tabs--scrollable__nav"
+				role="tablist"
+				(scroll)="handleScroll()">
 				<li role="presentation">
 					<ng-container *ngIf="contentBefore" [ngTemplateOutlet]="contentBefore"></ng-container>
 				</li>
 				<li
 					*ngFor="let tab of tabs; let i = index;"
 					[ngClass]="{
-						'bx--tabs__nav-item--selected': tab.active,
-						'bx--tabs__nav-item--disabled': tab.disabled
+						'bx--tabs__nav-item--selected bx--tabs--scrollable__nav-item--selected': tab.active,
+						'bx--tabs__nav-item--disabled bx--tabs--scrollable__nav-item--disabled': tab.disabled
 					}"
-					class="bx--tabs__nav-item"
+					class="bx--tabs--scrollable__nav-item"
 					role="presentation"
-					(click)="selectTab(tabItem, tab, i)"
-					(keydown)="tabDropdownKeydown($event)">
-					<a
+					(click)="selectTab(tabItem, tab, i)">
+					<button
 						#tabItem
 						[attr.aria-selected]="tab.active"
 						[attr.tabindex]="(tab.active?0:-1)"
@@ -85,7 +86,7 @@ import { Tab } from "./tab.component";
 						(click)="$event.preventDefault()"
 						draggable="false"
 						id="{{tab.id}}-header"
-						class="bx--tabs__nav-link"
+						class="bx--tabs--scrollable__nav-link"
 						[title]="tab.title ? tab.title : tab.heading"
 						href="#"
 						role="tab">
@@ -97,17 +98,40 @@ import { Tab } from "./tab.component";
 							[ngTemplateOutlet]="tab.heading"
 							[ngTemplateOutletContext]="{$implicit: tab.context}">
 						</ng-template>
-					</a>
+					</button>
 				</li>
 				<li role="presentation">
 					<ng-container *ngIf="contentAfter" [ngTemplateOutlet]="contentAfter"></ng-container>
 				</li>
 			</ul>
+			<div *ngIf="!rightOverflowNavButtonHidden" class="bx--tabs__overflow-indicator--right"></div>
+			<button
+				#rightOverflowNavButton
+				type="button"
+				[ngClass]="{
+					'bx--tab--overflow-nav-button': hasHorizontalOverflow,
+					'bx--tab--overflow-nav-button--hidden': rightOverflowNavButtonHidden
+				}"
+				(click)="handleOverflowNavClick(1)"
+				(mousedown)="handleOverflowNavMouseDown(1)"
+				(mouseup)="handleOverflowNavMouseUp()">
+				<svg
+					focusable="false"
+					preserveAspectRatio="xMidYMid meet"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="currentColor"
+					width="16"
+					height="16"
+					viewBox="0 0 16 16"
+					aria-hidden="true">
+					<path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+				</svg>
+			</button>
 		</nav>
 	`
 })
 
-export class TabHeaders implements AfterContentInit, OnChanges {
+export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnInit {
 	/**
 	 * List of `Tab` components.
 	 */
@@ -146,6 +170,10 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 	 */
 	// @ts-ignore
 	@ViewChild("tabList", { static: true }) headerContainer;
+	// @ts-ignore
+	@ViewChild("rightOverflowNavButton", { static: true }) rightOverflowNavButton;
+	// @ts-ignore
+	@ViewChild("leftOverflowNavButton", { static: true }) leftOverflowNavButton;
 	/**
 	 * ContentChild of all the n-tabs
 	 */
@@ -166,9 +194,30 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 	 * Controls the manual focusing done by tabbing through headings.
 	 */
 	public currentSelectedTab: number;
-	public tabListVisible = false;
 
-	constructor(protected elementRef: ElementRef) {}
+	public get hasHorizontalOverflow() {
+		const tabList = this.headerContainer.nativeElement;
+		return tabList.scrollWidth > tabList.clientWidth;
+	}
+
+	public get leftOverflowNavButtonHidden() {
+		const tabList = this.headerContainer.nativeElement;
+		return !this.hasHorizontalOverflow || !tabList.scrollLeft;
+	}
+
+	public get rightOverflowNavButtonHidden() {
+		const tabList = this.headerContainer.nativeElement;
+		return !this.hasHorizontalOverflow ||
+			(tabList.scrollLeft + tabList.clientWidth) === tabList.scrollWidth;
+	}
+
+	// width of the overflow buttons
+	OVERFLOW_BUTTON_OFFSET = 40;
+
+	private overflowNavInterval;
+	private windowResizeSubscription;
+
+	constructor(protected elementRef: ElementRef, protected changeDetectorRef: ChangeDetectorRef) { }
 
 	// keyboard accessibility
 	/**
@@ -232,18 +281,12 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 		if ((event.key === " " || event.key === "Spacebar") && !this.followFocus) {
 			this.selectTab(event.target, tabsArray[this.currentSelectedTab], this.currentSelectedTab);
 		}
-
-		// dropdown list handler
-		if (event.key === "Escape") {
-			this.hideTabList();
-		}
 	}
 
-	@HostListener("focusout", ["$event"])
-	focusOut(event) {
-		if (this.tabListVisible && !this.elementRef.nativeElement.contains(event.relatedTarget)) {
-			this.tabListVisible = false;
-		}
+	ngOnInit() {
+		this.windowResizeSubscription = fromEvent(window, "resize", { passive: true })
+			.pipe(debounceTime(200))
+			.subscribe(() => this.handleScroll());
 	}
 
 	ngAfterContentInit() {
@@ -266,11 +309,16 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 		}
 	}
 
+	ngOnDestroy() {
+		if (this.windowResizeSubscription) {
+			this.windowResizeSubscription.unsubscribe();
+		}
+	}
+
 	/**
 	 * Controls manually focusing tabs.
 	 */
 	public onTabFocus(ref: HTMLElement, index: number) {
-		if (this.tabListVisible) { return; }
 		this.currentSelectedTab = index;
 		// reset scroll left because we're already handling it
 		this.headerContainer.nativeElement.parentElement.scrollLeft = 0;
@@ -281,70 +329,7 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 		if (selected) {
 			return selected;
 		}
-		return {headingIsTemplate: false, heading: ""};
-	}
-
-	public showTabList() {
-		this.tabListVisible = true;
-		const focusTarget = this.allTabHeaders.find(tab => {
-			const tabContainer = tab.nativeElement.parentElement;
-			return !tabContainer.classList.contains("bx--tabs__nav-item--selected");
-		});
-		focusTarget.nativeElement.focus();
-	}
-
-	public hideTabList() {
-		this.tabListVisible = false;
-	}
-
-	public onDropdownKeydown(event: KeyboardEvent) {
-		switch (event.key) {
-			case " ":
-			case "Spacebar":
-			case "Enter":
-				event.preventDefault();
-				this.showTabList();
-				break;
-			default:
-				break;
-		}
-	}
-
-	public tabDropdownKeydown(event: KeyboardEvent) {
-		if (!this.tabListVisible) { return; }
-		const target = (event.target as HTMLElement).closest("a");
-
-		const headers = this.allTabHeaders.toArray().filter(tab =>
-			!tab.nativeElement.parentElement.classList.contains("bx--tabs__nav-item--disabled") &&
-			!tab.nativeElement.parentElement.classList.contains("bx--tabs__nav-item--selected"));
-
-		// unless the focus can move, it should remain on the target
-		let next: HTMLElement = target;
-		let previous: HTMLElement = target;
-
-		for (let i = 0; i < headers.length; i++) {
-			if (headers[i].nativeElement === target) {
-				if (i + 1 < headers.length) {
-					next = headers[i + 1].nativeElement;
-				}
-				if (i - 1 >= 0) {
-					previous = headers[i - 1].nativeElement;
-				}
-			}
-		}
-
-		switch (event.key) {
-			case "ArrowDown":
-			case "Down": // IE11 specific value
-				next.focus();
-				break;
-			case "ArrowUp":
-			case "Up": // IE11 specific value
-				previous.focus();
-				break;
-			default:
-				break;
-		}
+		return { headingIsTemplate: false, heading: "" };
 	}
 
 	/**
@@ -355,12 +340,64 @@ export class TabHeaders implements AfterContentInit, OnChanges {
 			return;
 		}
 
-		// hide the tablist on mobile
-		this.tabListVisible = false;
 		this.currentSelectedTab = tabIndex;
 		this.tabs.forEach(_tab => _tab.active = false);
 		tab.active = true;
 		tab.doSelect();
+	}
+
+	public handleScroll() {
+		this.changeDetectorRef.markForCheck();
+	}
+
+	public handleOverflowNavClick(direction: number, multiplier = 15) {
+		const tabList = this.headerContainer.nativeElement;
+
+		const { clientWidth, scrollLeft, scrollWidth } = tabList;
+		if (direction === 1 && !scrollLeft) {
+			tabList.scrollLeft += this.OVERFLOW_BUTTON_OFFSET;
+		}
+
+		tabList.scrollLeft += direction * multiplier;
+
+		const leftEdgeReached =
+			direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+		const rightEdgeReached =
+			direction === 1 &&
+			scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+		if (leftEdgeReached || rightEdgeReached) {
+			if (leftEdgeReached) {
+				this.rightOverflowNavButton.nativeElement.focus();
+			}
+			if (rightEdgeReached) {
+				this.leftOverflowNavButton.nativeElement.focus();
+			}
+		}
+	}
+
+	public handleOverflowNavMouseDown(direction: number) {
+		const tabList = this.headerContainer.nativeElement;
+
+		this.overflowNavInterval = setInterval(() => {
+			const { clientWidth, scrollLeft, scrollWidth } = tabList;
+
+			// clear interval if scroll reaches left or right edge
+			const leftEdgeReached = direction === -1 && scrollLeft < this.OVERFLOW_BUTTON_OFFSET;
+			const rightEdgeReached =
+				direction === 1 &&
+				scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
+
+			if (leftEdgeReached || rightEdgeReached) {
+				clearInterval(this.overflowNavInterval);
+			}
+
+			// account for overflow button appearing and causing tablist width change
+			this.handleOverflowNavClick(direction);
+		});
+	}
+
+	public handleOverflowNavMouseUp() {
+		clearInterval(this.overflowNavInterval);
 	}
 
 	/**

--- a/src/tabs/tab-headers.component.ts
+++ b/src/tabs/tab-headers.component.ts
@@ -365,13 +365,12 @@ export class TabHeaders implements AfterContentInit, OnChanges, OnDestroy, OnIni
 		const rightEdgeReached =
 			direction === 1 &&
 			scrollLeft + clientWidth >= scrollWidth - this.OVERFLOW_BUTTON_OFFSET;
-		if (leftEdgeReached || rightEdgeReached) {
-			if (leftEdgeReached) {
-				this.rightOverflowNavButton.nativeElement.focus();
-			}
-			if (rightEdgeReached) {
-				this.leftOverflowNavButton.nativeElement.focus();
-			}
+
+		if (leftEdgeReached) {
+			this.rightOverflowNavButton.nativeElement.focus();
+		}
+		if (rightEdgeReached) {
+			this.leftOverflowNavButton.nativeElement.focus();
 		}
 	}
 

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -63,8 +63,10 @@ let nextId = 0;
 			[attr.tabindex]="tabIndex"
 			role="tabpanel"
 			*ngIf="shouldRender()"
+			class="bx--tab-content"
 			[ngStyle]="{'display': active ? null : 'none'}"
-			[attr.aria-labelledby]="id + '-header'">
+			[attr.aria-labelledby]="id + '-header'"
+			aria-live="polite">
 			<ng-content></ng-content>
 		</div>
 	`

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -2,6 +2,7 @@ import { Component } from "@angular/core";
 import { TestBed } from "@angular/core/testing";
 import { By	 } from "@angular/platform-browser";
 
+import { UtilsModule } from "carbon-components-angular/utils";
 import { Tabs } from "./tabs.component";
 import { CommonModule } from "@angular/common";
 import { Tab } from "./tab.component";
@@ -41,7 +42,8 @@ describe("Sample", () => {
 				TabsTest
 			],
 			imports: [
-				CommonModule
+				CommonModule,
+				UtilsModule
 			]
 		});
 	});

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -64,13 +64,13 @@ describe("Sample", () => {
 
 	it("should emit the selected event on click and change selected tab on keydown", () => {
 		spyOn(wrapper, "onSelected");
-		const navItem = element.nativeElement.querySelector(".bx--tabs__nav-item");
+		const navItem = element.nativeElement.querySelector(".bx--tabs--scrollable__nav-item");
 		navItem.click();
 		expect(wrapper.onSelected).toHaveBeenCalled();
 	});
 
 	it("should increment currentSelectedTab on right arrow and decrement on left arrow", () => {
-		const navItem = element.nativeElement.querySelector(".bx--tabs__nav-item");
+		const navItem = element.nativeElement.querySelector(".bx--tabs--scrollable__nav-item");
 		const tabHeaders = fixture.debugElement.query(By.css("ibm-tab-headers"));
 
 		navItem.click();
@@ -87,7 +87,7 @@ describe("Sample", () => {
 	});
 
 	it("should set currentSelectedTab to the first tab on arrowRight when done on the last tab", () => {
-		const navItem = element.nativeElement.querySelector(".bx--tabs__nav-item");
+		const navItem = element.nativeElement.querySelector(".bx--tabs--scrollable__nav-item");
 		const tabHeaders = fixture.debugElement.query(By.css("ibm-tab-headers"));
 
 		navItem.click();
@@ -101,7 +101,7 @@ describe("Sample", () => {
 	});
 
 	it("should set currentSelectedTab to the last tab on left arrow when done on the first tab", () => {
-		const navItem = element.nativeElement.querySelector(".bx--tabs__nav-item");
+		const navItem = element.nativeElement.querySelector(".bx--tabs--scrollable__nav-item");
 		const tabHeaders = fixture.debugElement.query(By.css("ibm-tab-headers"));
 		navItem.click();
 		tabHeaders.nativeElement.dispatchEvent(arrowLeft);
@@ -124,14 +124,5 @@ describe("Sample", () => {
 		element.componentInstance.tabs.forEach(tab => {
 			expect(tab.tabIndex).toBe(0);
 		});
-	});
-
-	it("should set tabListVisible to true when tabs trigger is clicked", () => {
-		let tabHeaders = fixture.debugElement.query(By.css("ibm-tab-headers"));
-		fixture.detectChanges();
-		let tabsTrigger = tabHeaders.nativeElement.querySelector(".bx--tabs-trigger");
-		tabsTrigger.click();
-		fixture.detectChanges();
-		expect(tabHeaders.componentInstance.tabListVisible).toBe(true);
 	});
 });

--- a/src/tabs/tabs.module.ts
+++ b/src/tabs/tabs.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { UtilsModule } from "carbon-components-angular/utils";
 
 import { Tabs } from "./tabs.component";
 import { Tab } from "./tab.component";
@@ -23,7 +24,8 @@ import { TabHeaderGroup } from "./tab-header-group.component";
 		TabHeaderGroup
 	],
 	imports: [
-		CommonModule
+		CommonModule,
+		UtilsModule
 	]
 })
 export class TabsModule {}


### PR DESCRIPTION
Closes #1724 

Brings the tabs up to date with react implementation. It borrows some approaches and interfaces from react implementation to match the behavior as closely as possible.

Tabs could use a bit of refactoring. Because of differences between tab headers and tab header group, it might not be reasonable to have one extend the other. It might make sense to have a tab-headers-base that contains common functionality between the two, that both extend. Not in this PR though. If we agree on this approach, I'll open an issue with this info.