### PR TITLE
fix(select): Only pass value if it's set by caller

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -62,7 +62,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 			<div class="bx--select-input__wrapper" [attr.data-invalid]="(invalid ? true : null)">
 				<select
 					[attr.id]="id"
-					[value]="value"
+					[attr.value]="value"
 					[attr.aria-label]="ariaLabel"
 					[disabled]="disabled"
 					(change)="onChange($event)"
@@ -175,7 +175,7 @@ export class Select implements ControlValueAccessor {
 		this._value = v;
 	}
 
-	protected _value = "";
+	protected _value;
 
 	/**
 	 * Receives a value from the model.


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Currently, the `select` component will always pass `value` attribute to the HTML `select`, using `""` as the default if not set by caller. This doesn't work if `""` is not the intended value. For example, consider below code:

```html
<ibm-select label="Type">
  <option value="on-hand" selected="true">On hand</option>
  <option value="in-transit-inbound">Inbound in-transit</option>
  <option value="in-transit-outbound">Outbound in-transit</option>
</ibm-select>
```

This will be rendered as:

![image](https://user-images.githubusercontent.com/34791554/111076995-276fe380-84c5-11eb-8f96-07b68cd026b9.png)

This happens because `""` doesn't match any option. The `select` component should only pass `value` attribute if it's set by caller.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
