### PR TITLE
fix(modal): scroll auto detection

### DIFF
--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -217,7 +217,8 @@ export class Modal implements AfterViewInit, OnChanges {
 	get shouldShowScrollbar() {
 		const modalContent = this.modal ? this.modal.nativeElement.querySelector(".bx--modal-content") : null;
 		if (modalContent) {
-			const modalContentHeight = Math.round(modalContent.getBoundingClientRect().height); // get rounded value from height to match integer returned from scrollHeight
+			// get rounded value from height to match integer returned from scrollHeight
+			const modalContentHeight = Math.round(modalContent.getBoundingClientRect().height);
 			const modalContentScrollHeight = modalContent.scrollHeight;
 			return modalContentScrollHeight > modalContentHeight;
 		} else {

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -217,7 +217,7 @@ export class Modal implements AfterViewInit, OnChanges {
 	get shouldShowScrollbar() {
 		const modalContent = this.modal ? this.modal.nativeElement.querySelector(".bx--modal-content") : null;
 		if (modalContent) {
-			const modalContentHeight = modalContent.getBoundingClientRect().height;
+			const modalContentHeight = Math.round(modalContent.getBoundingClientRect().height); // get rounded value from height to match integer returned from scrollHeight
 			const modalContentScrollHeight = modalContent.scrollHeight;
 			return modalContentScrollHeight > modalContentHeight;
 		} else {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

there is a bug in modals where the .bx--modal-content--overflow-indicator appears when there is no scroll on the element due to a float returned by getBoundingClientRect().height that gets rounded when clicking on the text.

<img width="1200" alt="Screen Shot 2021-03-16 at 1 53 05 PM" src="https://user-images.githubusercontent.com/28939589/111356693-fe835600-865e-11eb-944c-99b2e81aceae.png">
<img width="1204" alt="Screen Shot 2021-03-16 at 1 53 14 PM" src="https://user-images.githubusercontent.com/28939589/111356712-017e4680-865f-11eb-867f-1d021948368a.png">




#### Changelog

**New**

since getBoundingClientRect().height returns a float, this can cause a bug when it is technically < modalContent.scrollHeight but the difference does not cause a scroll bar to appear. 

added Math.round() to the value returned by the modalContent.getBoundingClientRect().height to prevent the error when comparing against scrollHeight which returns an integer.
