### PR TITLE
fix(checkbox): Avoid double checkbox classes

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -217,13 +217,6 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 		return this._checked;
 	}
 
-	@HostBinding("class.bx--checkbox-wrapper") get checkboxWrapperClass() {
-		return !this.inline;
-	}
-	@HostBinding("class.bx--form-item") get formItemClass() {
-		return !this.inline;
-	}
-
 	/**
 	 * Emits click event.
 	 */


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

PR https://github.com/IBM/carbon-components-angular/pull/1337 added `<div class="bx--form-item bx--checkbox-wrapper">` container. However, it didn't remove the checkbox classes added on the host element. Therefore, we ended up with double checkbox classes:

![image](https://user-images.githubusercontent.com/34791554/111652341-6495e780-87dd-11eb-8c29-cb178ec12dfb.png)

This PR removes the checkbox classes on the host element:

![image](https://user-images.githubusercontent.com/34791554/111652464-76778a80-87dd-11eb-9920-057a59271a6d.png)

Note with this fix, the `inline` input property is no longer being used anymore. Maybe we should mark that as obsoleted?

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
