### PR TITLE
feat(form controls): add warning state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,9 +3180,9 @@
       "integrity": "sha512-JtmCXV7iIc+N5RqQQy+MGT8T+5KcF7+BUKADvHnJKZ8o+ncF5gI4hmrP450dQD76mikI4fqQ0dQflaosesdSPw=="
     },
     "@carbon/icons": {
-      "version": "10.20.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
-      "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.27.0.tgz",
+      "integrity": "sha512-lxgmO3InfNnPqG/GGfVWAzQe3b1gK7QvglzshoYqeZLbbYj3IW4acII/ht+qf4eoCg9IOlYvsgYeUQNe7zqXbA=="
     },
     "@carbon/icons-angular": {
       "version": "11.0.1",
@@ -10180,9 +10180,9 @@
       "dev": true
     },
     "carbon-components": {
-      "version": "10.29.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.29.0.tgz",
-      "integrity": "sha512-y7BPEfwWxE1URTjrtHz4+rYQwB0u/e7WptlbTH2Lb/iqRYCe6T94u9EVZuq0ZZTpRUNRckbI1irt0AV3J/qlcA==",
+      "version": "10.31.0",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.31.0.tgz",
+      "integrity": "sha512-gUXRky9rUHavqFLJJQf+Lzouk8GHsXJUjxRgTOUQ6vdBfA0ks6ugwptG8fiFGwCJJht/CW9/YsKb5w8N9a39sg==",
       "dev": true,
       "requires": {
         "@carbon/telemetry": "0.0.0-alpha.6",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/jasmine": "2.8.2",
     "@types/node": "11.13.0",
     "babel-loader": "8.0.5",
-    "carbon-components": "10.29.0",
+    "carbon-components": "10.31.0",
     "chai": "4.2.0",
     "codelyzer": "5.0.0",
     "commitizen": "4.0.3",
@@ -134,7 +134,7 @@
   },
   "dependencies": {
     "@carbon/icon-helpers": "10.9.0",
-    "@carbon/icons": "10.20.0",
+    "@carbon/icons": "10.27.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
     "@carbon/utils-position": "1.1.3",
     "flatpickr": "4.6.1"

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -50,9 +50,10 @@ import { Observable } from "rxjs";
 				'bx--list-box--expanded': open,
 				'bx--list-box--sm': size === 'sm',
 				'bx--list-box--xl': size === 'xl',
-				'bx--list-box--disabled': disabled
+				'bx--list-box--disabled': disabled,
+				'bx--combo-box--warning bx--list-box--warning': warn
 			}"
-			class="bx--combo-box bx--list-box"
+			class="bx--list-box"
 			role="combobox"
 			[id]="id"
 			[attr.data-invalid]="(invalid ? true : null)">
@@ -106,10 +107,16 @@ import { Observable } from "rxjs";
 					[attr.aria-autocomplete]="autocomplete"
 					[placeholder]="placeholder"/>
 				<svg
-					*ngIf="invalid"
+					*ngIf="!warn && invalid"
 					ibmIcon="warning--filled"
 					size="16"
 					class="bx--list-box__invalid-icon">
+				</svg>
+				<svg
+					*ngIf="!invalid && warn"
+					ibmIcon="warning--alt--filled"
+					size="16"
+					class="bx--list-box__invalid-icon bx--list-box__invalid-icon--warning">
 				</svg>
 				<div
 					*ngIf="showClearButton"
@@ -137,15 +144,19 @@ import { Observable } from "rxjs";
 			</div>
 		</div>
 		<div
-			*ngIf="helperText && !invalid"
+			*ngIf="helperText && !invalid && !warn"
 			class="bx--form__helper-text"
 			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
 			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 		</div>
-		<div *ngIf="invalid" class="bx--form-requirement">
+		<div *ngIf="!warn && invalid" class="bx--form-requirement">
 			<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>
 			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+		</div>
+		<div *ngIf="!invalid && warn" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 		</div>
 	`,
 	providers: [
@@ -283,13 +294,21 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	 */
 	@Input() appendInline: boolean = null;
 	/**
-	 * Set to `true` for invalid state.
+	 * Set to `true` to show the invalid state.
 	 */
 	@Input() invalid = false;
 	/**
-	 * Value displayed if dropdown is in invalid state.
+	 * Value displayed if combobox is in an invalid state.
 	 */
 	@Input() invalidText: string | TemplateRef<any>;
+	/**
+ 	* Set to `true` to show a warning (contents set by warningText)
+ 	*/
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 	/**
 	 * Max length value to limit input characters
 	 */

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -302,7 +302,7 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	 */
 	@Input() invalidText: string | TemplateRef<any>;
 	/**
- 	* Set to `true` to show a warning (contents set by warningText)
+ 	* Set to `true` to show a warning (contents set by warnText)
  	*/
 	@Input() warn = false;
 	/**

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -25,6 +25,8 @@ const getOptions = (override = {}) => {
 		disabled: boolean("disabled", false),
 		invalid: boolean("Invalid", false),
 		invalidText: text("Invalid text", "A valid value is required"),
+		warn: boolean("Show the warning state", false),
+		warnText: text("Text for the warning", "This is a warning"),
 		label: text("Label", "ComboBox label"),
 		helperText: text("Helper text", "Optional helper text."),
 		items: [
@@ -223,6 +225,8 @@ storiesOf("Components|Combobox", module)
 					[size]="size"
 					[appendInline]="false"
 					[invalidText]="invalidText"
+					[warn]="warn"
+					[warnText]="warnText"
 					[label]="label"
 					[helperText]="helperText"
 					[items]="items"

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -119,7 +119,7 @@ export class DatePickerInput {
 	 */
 	@Input() invalidText: string | TemplateRef<any>;
 	/**
-	  * Set to `true` to show a warning (contents set by warningText)
+	  * Set to `true` to show a warning (contents set by warnText)
 	  */
 	@Input() warn = false;
 	/**

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -28,7 +28,8 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				</label>
 				<div class="bx--date-picker-input__wrapper"
 					[ngClass]="{
-						'bx--date-picker-input__wrapper--invalid': invalid
+						'bx--date-picker-input__wrapper--invalid': invalid,
+						'bx--date-picker-input__wrapper--warn': warn
 					}">
 					<input
 						#input
@@ -47,11 +48,32 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						[id]= "id"
 						[disabled]="disabled"
 						(change)="onChange($event)"/>
-						<svg *ngIf="type !== 'simple'" ibmIcon="calendar" size="16" class="bx--date-picker__icon"></svg>
+						<svg
+							*ngIf="type !== 'simple' && !warn && !invalid"
+							ibmIcon="calendar"
+							size="16"
+							class="bx--date-picker__icon">
+						</svg>
+						<svg
+							*ngIf="!warn && invalid"
+							class="bx--date-picker__icon bx--date-picker__icon--invalid"
+							ibmIcon="warning--filled"
+							size="16">
+						</svg>
+						<svg
+							*ngIf="!invalid && warn"
+							ibmIcon="warning--alt--filled"
+							size="16"
+							class="bx--date-picker__icon bx--date-picker__icon--warn">
+						</svg>
 				</div>
-				<div *ngIf="invalid" class="bx--form-requirement">
-					<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
+				<div *ngIf="!warn && invalid" class="bx--form-requirement">
+					<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>
 					<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+				</div>
+				<div *ngIf="!invalid && warn" class="bx--form-requirement">
+					<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+					<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 				</div>
 			</div>
 		</div>
@@ -88,10 +110,22 @@ export class DatePickerInput {
 	@Input() theme: "light" | "dark" = "dark";
 
 	@Input() disabled = false;
-
+	/**
+	 * Set to `true` for invalid state.
+	 */
 	@Input() invalid = false;
-
+	/**
+	 * Value displayed if dropdown is in invalid state.
+	 */
 	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 
 	@Input() skeleton = false;
 

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -57,6 +57,8 @@ import { I18n } from "carbon-components-angular/i18n";
 					[disabled]="disabled"
 					[invalid]="invalid"
 					[invalidText]="invalidText"
+					[warn]="warn"
+					[warnText]="warnText"
 					[skeleton]="skeleton"
 					(valueChange)="onValueChange($event)"
 					(click)="openCalendar(input)">
@@ -76,6 +78,8 @@ import { I18n } from "carbon-components-angular/i18n";
 					[disabled]="disabled"
 					[invalid]="rangeInvalid"
 					[invalidText]="rangeInvalidText"
+					[warn]="rangeWarn"
+					[warnText]="rangeWarnText"
 					[skeleton]="skeleton"
 					(valueChange)="onRangeValueChange($event)"
 					(click)="openCalendar(rangeInput)">
@@ -166,16 +170,40 @@ export class DatePicker implements
 	@Input() theme: "light" | "dark" = "dark";
 
 	@Input() disabled = false;
-
+	/**
+	 * Set to `true` to display the invalid state.
+	 */
 	@Input() invalid = false;
-
+	/**
+	 * Value displayed if datepicker is in an invalid state.
+	 */
 	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 
 	@Input() size: "sm" | "md" | "xl" = "md";
-
+	/**
+	 * Set to `true` to display the invalid state for the second datepicker input.
+	 */
 	@Input() rangeInvalid = false;
-
+	/**
+	 * Value displayed if the second datepicker input is in an invalid state.
+	 */
 	@Input() rangeInvalidText: string | TemplateRef<any>;
+	/**
+	  * Set to `true` to show a warning in the second datepicker input (contents set by rangeWarningText)
+	  */
+	@Input() rangeWarn = false;
+	/**
+	 * Sets the warning text for the second datepicker input
+	 */
+	@Input() rangeWarnText: string | TemplateRef<any>;
 
 	@Input() skeleton = false;
 

--- a/src/datepicker/datepicker.stories.ts
+++ b/src/datepicker/datepicker.stories.ts
@@ -149,6 +149,8 @@ storiesOf("Components|Date Picker", module)
 			[size]="size"
 			[invalid]="invalid"
 			[invalidText]="invalidText"
+			[warn]="warn"
+			[warnText]="warnText"
 			(valueChange)="valueChange($event)">
 		</ibm-date-picker-input>
 		`,
@@ -158,6 +160,8 @@ storiesOf("Components|Date Picker", module)
 			placeholder: text("Placeholder text", "mm/dd/yyyy"),
 			invalidText: text("Form validation content", "Invalid date format"),
 			invalid: boolean("Show form validation", false),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			size: select("Size", ["sm", "md", "xl"], "md"),
 			disabled: boolean("Disabled", false),
 			valueChange: action("Date change fired!")
@@ -177,6 +181,8 @@ storiesOf("Components|Date Picker", module)
 				[disabled]="disabled"
 				[invalid]="invalid"
 				[invalidText]="invalidText"
+				[warn]="warn"
+				[warnText]="warnText"
 				[dateFormat]="dateFormat"
 				(valueChange)="valueChange($event)">
 			</ibm-date-picker>
@@ -190,6 +196,8 @@ storiesOf("Components|Date Picker", module)
 				[disabled]="disabled"
 				[invalid]="invalid"
 				[invalidText]="invalidText"
+				[warn]="warn"
+				[warnText]="warnText"
 				[dateFormat]="dateFormat"
 				(valueChange)="valueChange($event)">
 			</ibm-date-picker>
@@ -202,6 +210,8 @@ storiesOf("Components|Date Picker", module)
 			label: text("Label text", "Date Picker Label"),
 			placeholder: text("Placeholder text", "mm/dd/yyyy"),
 			invalidText: text("Form validation content", "Invalid date format"),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			invalid: boolean("Show form validation", false),
 			disabled: boolean("Disabled", false),
 			dateFormat: text("Date format", "m/d/Y"),
@@ -223,6 +233,8 @@ storiesOf("Components|Date Picker", module)
 			[disabled]="disabled"
 			[invalid]="invalid"
 			[invalidText]="invalidText"
+			[warn]="warn"
+			[warnText]="warnText"
 			[rangeInvalid]="invalid"
 			[rangeInvalidText]="invalidText"
 			[dateFormat]="dateFormat"
@@ -241,6 +253,10 @@ storiesOf("Components|Date Picker", module)
 			[disabled]="disabled"
 			[invalid]="invalid"
 			[invalidText]="invalidText"
+			[warn]="warn"
+			[warnText]="warnText"
+			[rangeWarn]="warn"
+			[rangeWarnText]="warnText"
 			[dateFormat]="dateFormat"
 			(valueChange)="valueChange($event)">
 		</ibm-date-picker>
@@ -253,6 +269,8 @@ storiesOf("Components|Date Picker", module)
 			label: text("Label text", "Date Picker Label"),
 			placeholder: text("Placeholder text", "mm/dd/yyyy"),
 			invalidText: text("Form validation content", "Invalid date format"),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			invalid: boolean("Show form validation", false),
 			disabled: boolean("Disabled", false),
 			dateFormat: text("Date format", "m/d/Y"),

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -68,6 +68,7 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			'bx--skeleton': skeleton,
 			'bx--dropdown--disabled bx--list-box--disabled': disabled,
 			'bx--dropdown--invalid': invalid,
+			'bx--dropdown--warning bx--list-box--warning': warn,
 			'bx--dropdown--xl bx--list-box--xl': size === 'xl',
 			'bx--dropdown--sm bx--list-box--sm': size === 'sm',
 			'bx--list-box--expanded': !menuIsClosed
@@ -112,10 +113,16 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 				[ngTemplateOutlet]="displayValue">
 			</ng-template>
 			<svg
-				*ngIf="invalid"
+				*ngIf="!warn && invalid"
 				class="bx--dropdown__invalid-icon"
 				ibmIcon="warning--filled"
 				size="16">
+			</svg>
+			<svg
+				*ngIf="!invalid && warn"
+				ibmIcon="warning--alt--filled"
+				size="16"
+				class="bx--list-box__invalid-icon bx--list-box__invalid-icon--warning">
 			</svg>
 			<svg
 				*ngIf="!skeleton"
@@ -134,13 +141,17 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			<ng-content *ngIf="!menuIsClosed"></ng-content>
 		</div>
 	</div>
-	<div *ngIf="helperText && !invalid" class="bx--form__helper-text">
+	<div *ngIf="helperText && !invalid && !warn" class="bx--form__helper-text">
 		<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 		<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 	</div>
-	<div *ngIf="invalid" class="bx--form-requirement">
+	<div *ngIf="!warn && invalid" class="bx--form-requirement">
 		<ng-container *ngIf="!isTemplate(invalidText)">{{ invalidText }}</ng-container>
 		<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+	</div>
+	<div *ngIf="!invalid && warn" class="bx--form-requirement">
+		<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+		<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 	</div>
 	`,
 	providers: [
@@ -213,6 +224,14 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 * Value displayed if dropdown is in invalid state.
 	 */
 	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 	/**
 	 * set to `true` to place the dropdown view inline with the component
 	 */

--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -54,6 +54,8 @@ const getProps = (overrides = {}) => Object.assign({}, {
 	invalid: boolean("Invalid", false),
 	size: select("Size", ["sm", "md", "xl"], "md"),
 	invalidText: "This is not a validation text",
+	warn: boolean("Show the warning state", false),
+	warnText: text("Text for the warning", "This is a warning"),
 	disabled: boolean("disabled", false),
 	label: text("Label", "Dropdown label"),
 	helperText: text("Helper text", "Optional helper text."),
@@ -177,6 +179,8 @@ storiesOf("Components|Dropdown", module)
 				[dropUp]="dropUp"
 				[invalid]="invalid"
 				[invalidText]="invalidText"
+				[warn]="warn"
+				[warnText]="warnText"
 				[theme]="theme"
 				placeholder="Select"
 				[disabled]="disabled"

--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -34,6 +34,7 @@ import Search16 from "@carbon/icons/es/search/16";
 import Settings16 from "@carbon/icons/es/settings/16";
 import Warning16 from "@carbon/icons/es/warning/16";
 import WarningFilled16 from "@carbon/icons/es/warning--filled/16";
+import WarningAltFilled16 from "@carbon/icons/es/warning--alt--filled/16";
 
 // either provides a new instance of IconService, or returns the parent
 export function ICON_SERVICE_PROVIDER_FACTORY(parentService: IconService) {
@@ -90,7 +91,8 @@ export class IconModule {
 			Search16,
 			Settings16,
 			Warning16,
-			WarningFilled16
+			WarningFilled16,
+			WarningAltFilled16
 		]);
 	}
 }

--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -33,6 +33,7 @@ export class TextInput {
 		return this.size === "sm";
 	}
 	@HostBinding("class.bx--text-input--invalid") @Input() invalid = false;
+	@HostBinding("class.bx--text-input__field-wrapper--warning") @Input() warn = false;
 	@HostBinding("class.bx--skeleton") @Input() skeleton = false;
 	@HostBinding("class.bx--text-input--light") get isLightTheme() {
 		return this.theme === "light";

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -22,12 +22,15 @@ storiesOf("Components|Input", module).addDecorator(
 		<ibm-label
 			[helperText]="helperText"
 			[invalid]="invalid"
-			[invalidText]="invalidText">
+			[invalidText]="invalidText"
+			[warn]="warn"
+			[warnText]="warnText">
 			{{label}}
 			<input
 				ibmText
 				[size]="size"
 				[invalid]="invalid"
+				[warn]="warn"
 				[disabled]="disabled"
 				[theme]="theme"
 				[placeholder]="placeholder"
@@ -40,6 +43,8 @@ storiesOf("Components|Input", module).addDecorator(
 			disabled: boolean("Disabled", false),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Validation message here"),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			label: text("Label", "Text Input label"),
 			helperText: text("Helper text", "Optional helper text."),
 			placeholder: text("Placeholder text", "Placeholder text"),

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -46,22 +46,38 @@ import { TextArea } from "./text-area.directive";
 			}">
 			<ng-content></ng-content>
 		</label>
-		<div [class]="wrapperClass" [attr.data-invalid]="(invalid ? true : null)" #wrapper>
+		<div
+			[class]="wrapperClass"
+			[ngClass]="{
+				'bx--text-input__field-wrapper--warning': warn
+			}"
+			[attr.data-invalid]="(invalid ? true : null)"
+			#wrapper>
 			<svg
-				*ngIf="invalid"
+				*ngIf="!warn && invalid"
 				ibmIcon="warning--filled"
 				size="16"
 				class="bx--text-input__invalid-icon bx--text-area__invalid-icon">
 			</svg>
+			<svg
+				*ngIf="!invalid && warn"
+				ibmIcon="warning--alt--filled"
+				size="16"
+				class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
+			</svg>
 			<ng-content select="input,textarea,div"></ng-content>
 		</div>
-		<div *ngIf="!skeleton && helperText && !invalid" class="bx--form__helper-text">
+		<div *ngIf="!skeleton && helperText && !invalid && !warn" class="bx--form__helper-text">
 			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 		</div>
-		<div *ngIf="invalid" class="bx--form-requirement">
+		<div *ngIf="!warn && invalid" class="bx--form-requirement">
 			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+		</div>
+		<div *ngIf="!invalid && warn" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 		</div>
 	`
 })
@@ -100,6 +116,14 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * Set to `true` for an invalid label component.
 	 */
 	@Input() invalid = false;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 	/**
 	 * Set the arialabel for label
 	 */

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -51,7 +51,11 @@ export class NumberChange {
 				'bx--number--sm': size === 'sm',
 				'bx--number--xl': size === 'xl'
 			}">
-			<div class="bx--number__input-wrapper">
+			<div
+				class="bx--number__input-wrapper"
+				[ngClass]="{
+					'bx--number__input-wrapper--warning': warn
+				}">
 				<input
 					type="number"
 					[id]="id"
@@ -63,10 +67,16 @@ export class NumberChange {
 					[required]="required"
 					(input)="onNumberInputChange($event)"/>
 				<svg
-					*ngIf="!skeleton && invalid"
+					*ngIf="!skeleton && !warn && invalid"
 					ibmIcon="warning--filled"
 					size="16"
 					class="bx--number__invalid">
+				</svg>
+				<svg
+					*ngIf="!skeleton && !invalid && warn"
+					ibmIcon="warning--alt--filled"
+					size="16"
+					class="bx--number__invalid bx--number__invalid--warning">
 				</svg>
 				<div *ngIf="!skeleton" class="bx--number__controls">
 					<button
@@ -89,13 +99,17 @@ export class NumberChange {
 					</button>
 				</div>
 			</div>
-			<div *ngIf="helperText && !invalid" class="bx--form__helper-text">
+			<div *ngIf="helperText && !invalid && !warn" class="bx--form__helper-text">
 				<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 				<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 			</div>
-			<div *ngIf="invalid" class="bx--form-requirement">
+			<div *ngIf="!warn && invalid" class="bx--form-requirement">
 				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+			</div>
+			<div *ngIf="!invalid && warn" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+				<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 			</div>
 		</div>
 	`,
@@ -185,6 +199,14 @@ export class NumberComponent implements ControlValueAccessor {
 	 * If `step` is a decimal, we may want precision to be set to go around floating point precision.
 	 */
 	@Input() precision: number;
+	/**
+	 * Set to `true` to show a warning (contents set by warningText)
+	 */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 	/**
 	 * Emits event notifying other classes when a change in state occurs in the input.
 	 */

--- a/src/number-input/number.stories.ts
+++ b/src/number-input/number.stories.ts
@@ -22,6 +22,8 @@ storiesOf("Components|Number", module).addDecorator(
 				[precision]="precision"
 				[invalid]="invalid"
 				[invalidText]="invalidText"
+				[warn]="warn"
+				[warnText]="warnText"
 				[size]="size"
 				[disabled]="disabled">
 			</ibm-number>
@@ -31,6 +33,8 @@ storiesOf("Components|Number", module).addDecorator(
 			size: select("Size", ["sm", "md", "xl"], "md"),
 			helperText: text("helper text", "Optional helper text."),
 			invalidText: text("Form validation content", "Invalid number"),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			theme: select("theme", ["dark", "light"], "dark"),
 			min: number("min", 0),
 			max: number("max", 100),

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -41,6 +41,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					'bx--select--inline': display === 'inline',
 					'bx--select--light': theme === 'light',
 					'bx--select--invalid': invalid,
+					'bx--select--warning': warn,
 					'bx--select--disabled': disabled
 				}">
 				<label *ngIf="label" [for]="id" class="bx--label">
@@ -87,15 +88,25 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					<path d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"></path>
 				</svg>
 				<svg
-					*ngIf="invalid"
+					*ngIf="!warn && invalid"
 					ibmIcon="warning--filled"
 					size="16"
 					class="bx--select__invalid-icon">
 				</svg>
+				<svg
+					*ngIf="!invalid && warn"
+					ibmIcon="warning--alt--filled"
+					size="16"
+					class="bx--select__invalid-icon bx--select__invalid-icon--warning">
+				</svg>
 			</div>
-			<div *ngIf="invalid && invalidText" role="alert" class="bx--form-requirement" aria-live="polite">
+			<div *ngIf="invalid && invalidText && !warn" role="alert" class="bx--form-requirement" aria-live="polite">
 				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+			</div>
+			<div *ngIf="!invalid && warn" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+				<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
 			</div>
 		</ng-template>
 	`,
@@ -138,6 +149,14 @@ export class Select implements ControlValueAccessor {
 	 * Sets the invalid text.
 	 */
 	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
 	/**
 	 * Sets the unique ID. Defaults to `select-${total count of selects instantiated}`
 	 */

--- a/src/select/select.stories.ts
+++ b/src/select/select.stories.ts
@@ -68,6 +68,8 @@ storiesOf("Components|Select", module).addDecorator(
 				[size]="size"
 				[invalid]="invalid"
 				[invalidText]="invalidText"
+				[warn]="warn"
+				[warnText]="warnText"
 				[label]="label"
 				[helperText]="helperText"
 				[theme]="theme"
@@ -89,6 +91,8 @@ storiesOf("Components|Select", module).addDecorator(
 			size: select("Size", ["sm", "md", "xl"], "md"),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Please select an option."),
+			warn: boolean("Show the warning state", false),
+			warnText: text("Text for the warning", "This is a warning"),
 			label: text("Label text", "Select Label"),
 			helperText: text("Helper text", ""),
 			theme: select("Theme", ["dark", "light"], "dark"),


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1750

Adds `warn` and `warnText` to all the form components mentioned in #1750.