### PR TITLE
Add support for IME input in Safari

### DIFF
--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -181,9 +181,10 @@ export class Search implements ControlValueAccessor {
 	 * @param search The input text.
 	 */
 	onSearch(search: string) {
-		if (!this.isComposing) { // check for IME use
-			this.value = search;
+		if (this.isComposing) { // check for IME use
+			return;
 		}
+		this.value = search;
 		this.doValueChange();
 	}
 

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -252,6 +252,6 @@ export class Search implements ControlValueAccessor {
 	@HostListener("compositionend", ["$event"])
 	compositionEnd(event) {
 		this.isComposing = false;
-		this.onSearch(event.data);
+		this.onSearch(this.value + event.data);
 	}
 }

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -128,6 +128,12 @@ export class Search implements ControlValueAccessor {
 	// @ts-ignore
 	@ViewChild("input", { static: false }) inputRef: ElementRef;
 
+	/**
+	 * Sets `true` when composing text via IME.
+	 */
+	isComposing = false;
+
+
 	protected _size: "sm" | "md" | "xl" = "md";
 
 	/**
@@ -176,7 +182,9 @@ export class Search implements ControlValueAccessor {
 	 * @param search The input text.
 	 */
 	onSearch(search: string) {
-		this.value = search;
+		if (!this.isComposing) { // check for IME use
+			this.value = search;
+		}
 		this.doValueChange();
 	}
 
@@ -228,5 +236,22 @@ export class Search implements ControlValueAccessor {
 			this.active = false;
 			this.open.emit(this.active);
 		}
+	}
+
+	/**
+	 * Called when using IME composition.
+	 */
+	@HostListener("compositionstart", ["$event"])
+	compositionStart(event) {
+		this.isComposing = true;
+	}
+
+	/**
+	 * Called when IME composition finishes.
+	 */
+	@HostListener("compositionend", ["$event"])
+	compositionEnd(event) {
+		this.isComposing = false;
+		this.onSearch(event.data);
 	}
 }

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -131,8 +131,7 @@ export class Search implements ControlValueAccessor {
 	/**
 	 * Sets `true` when composing text via IME.
 	 */
-	isComposing = false;
-
+	protected isComposing = false;
 
 	protected _size: "sm" | "md" | "xl" = "md";
 


### PR DESCRIPTION
Observed an issue in Safari when using IME composition. First reported by Japanese input users and confirmed with Chinese input. Screenshots show IME input with traditional Chinese (zhuyin).

**Original on Storybook**
![2021-04-02 at 09 50 10 IME safari](https://user-images.githubusercontent.com/1717398/113421343-eb7bc000-9398-11eb-910b-3ab8e5c2f233.gif)

**Correct input**
![2021-04-02 at 09 52 02 IME safari fix](https://user-images.githubusercontent.com/1717398/113421498-37c70000-9399-11eb-82bf-8e71631e0877.gif)

Added a check for `isComposing` to prevent Safari from overwriting the search value with IME text, and verified with traditional Chinese in latest versions of Safari, Chrome, Edge, and Firefox.

#### Changelog

**New**

* Adds support for IME input in Safari.

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
