### PR TITLE
fix(select): fix reactive form functionality and allow selected to be initialized through value and options tags

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -207,12 +207,12 @@ export class Select implements ControlValueAccessor, AfterViewInit {
 
 	ngAfterViewInit() {
 		if (
-			this._value !== undefined &&
+			this.value !== undefined &&
 			this.value !== null &&
 			this.select &&
-			this.select.nativeElement.value !== this._value
+			this.select.nativeElement.value !== this.value
 		) {
-			this.select.nativeElement.value = this._value;
+			this.select.nativeElement.value = this.value;
 		}
 	}
 

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -206,7 +206,12 @@ export class Select implements ControlValueAccessor, AfterViewInit {
 	protected _value;
 
 	ngAfterViewInit() {
-		if (this._value !== undefined && this.value !== null && this.select) {
+		if (
+			this._value !== undefined &&
+			this.value !== null &&
+			this.select &&
+			this.select.nativeElement.value !== this._value
+		) {
 			this.select.nativeElement.value = this._value;
 		}
 	}

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -1,10 +1,13 @@
 import {
+	AfterViewInit,
 	Component,
+	ElementRef,
 	Input,
 	Output,
 	HostListener,
 	EventEmitter,
-	TemplateRef
+	TemplateRef,
+	ViewChild
 } from "@angular/core";
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 
@@ -62,8 +65,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 		<ng-template #noInline>
 			<div class="bx--select-input__wrapper" [attr.data-invalid]="(invalid ? true : null)">
 				<select
+					#select
 					[attr.id]="id"
-					[attr.value]="value"
 					[attr.aria-label]="ariaLabel"
 					[disabled]="disabled"
 					(change)="onChange($event)"
@@ -127,7 +130,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 		}
 	]
 })
-export class Select implements ControlValueAccessor {
+export class Select implements ControlValueAccessor, AfterViewInit {
 	/**
 	 * Tracks the total number of selects instantiated. Used to generate unique IDs
 	 */
@@ -186,15 +189,27 @@ export class Select implements ControlValueAccessor {
 
 	@Output() valueChange = new EventEmitter();
 
+	// @ts-ignore
+	@ViewChild("select", { static: true }) select: ElementRef;
+
+	@Input() set value(v) {
+		this._value = v;
+		if (this.select) {
+			this.select.nativeElement.value = this._value;
+		}
+	}
+
 	get value() {
 		return this._value;
 	}
 
-	set value(v) {
-		this._value = v;
-	}
-
 	protected _value;
+
+	ngAfterViewInit() {
+		if (this._value !== undefined && this.value !== null && this.select) {
+			this.select.nativeElement.value = this._value;
+		}
+	}
 
 	/**
 	 * Receives a value from the model.

--- a/src/select/select.stories.ts
+++ b/src/select/select.stories.ts
@@ -28,8 +28,13 @@ import {
 				<option value="option3">Option 3</option>
 			</ibm-select>
 		</form>
-
-		<button (click)="clearSelection()">Clear selection</button>
+		<div style="display: flex; flex-direction: column;">
+			selectedValue: {{ formGroup.get("selecterino").value }}
+			<div>
+				<button (click)="clearSelection()">Clear selection</button>
+				<button (click)="selectRandom()">Select random</button>
+			</div>
+		</div>
 	`
 })
 class ReactiveFormsSelect implements OnInit {
@@ -39,6 +44,15 @@ class ReactiveFormsSelect implements OnInit {
 
 	clearSelection() {
 		this.formGroup.get("selecterino").setValue("default");
+	}
+
+	selectRandom() {
+		this.formGroup.get("selecterino").setValue([
+			"default",
+			"option1",
+			"option2",
+			"option3"
+		][Math.floor(Math.random() * 4)]);
 	}
 
 	ngOnInit() {
@@ -112,16 +126,79 @@ storiesOf("Components|Select", module).addDecorator(
 					<option value="option3">Option 3</option>
 				</ibm-select>
 				<br>
-				<span>Selected: {{ model }}</span>
+				<div>
+					<span>Selected: {{ model }}</span>
+					<button (click)="selectRandom()">Select random</button>
+				</div>
 			</div>
 		`,
 		props: {
 			size: select("Size", ["sm", "md", "xl"], "md"),
-			model: "default"
+			model: "option2",
+			selectRandom: function() {
+				this.model = [
+					"default",
+					"option1",
+					"option2",
+					"option3"
+				][Math.floor(Math.random() * 4)];
+			}
 		}
 	}))
 	.add("With reactive forms", () => ({
 		template: `<app-reactive-form></app-reactive-form>`
+	}))
+	.add("Changing selected through option selected property", () => ({
+		template: `
+			<ibm-select label="Type">
+				<option
+					value="on-hand"
+					[selected]="selected === 'on-hand'">
+					On hand
+				</option>
+				<option
+					value="in-transit-inbound"
+					[selected]="selected === 'in-transit-inbound'">
+					Inbound in-transit
+				</option>
+				<option
+					value="in-transit-outbound"
+					[selected]="selected === 'in-transit-outbound'">
+					Outbound in-transit
+				</option>
+			</ibm-select>
+			<button (click)="selectRandom()">Select random</button>
+		`,
+		props: {
+			selected: "in-transit-inbound",
+			selectRandom: function() {
+				this.selected = [
+					"on-hand",
+					"in-transit-inbound",
+					"in-transit-outbound"
+				][Math.floor(Math.random() * 3)];
+			}
+		}
+	}))
+	.add("Changing selected through value property", () => ({
+		template: `
+			<ibm-select label="Type" [value]="selected">
+				<option value="on-hand">On hand</option>
+				<option value="in-transit-inbound">Inbound in-transit</option>
+				<option value="in-transit-outbound">Outbound in-transit</option>
+			</ibm-select>
+			<button (click)="selectRandom()">Select random</button>
+		`,
+		props: {
+			selected: "in-transit-outbound",
+			selectRandom: function() {
+				this.selected = [
+					"on-hand",
+					"in-transit-inbound",
+					"in-transit-outbound"
+				][Math.floor(Math.random() * 3)];
+			}
+		}
 	}))
 	.add("Skeleton", () => ({
 		template: `


### PR DESCRIPTION
Closes #1776

We cannot use the `value` property on select since default selected values through options tags would be ignored if a `value` is not set by the caller. #1754 addresses this but using an `attribute` means that the `attribute value` cannot change after initialization, which makes setting values through reactive forms not possible.