### PR TITLE
fix cannot read 'instance' of null when closing tooltip on weak devices

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -288,7 +288,9 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	close(meta: CloseMeta = { reason: CloseReasons.interaction }) {
 		if (this.dialogRef) {
 			setTimeout(() => {
-				this.dialogRef.instance.doClose(meta);
+				if (this.dialogRef) {
+					this.dialogRef.instance.doClose(meta);
+				}
 			});
 		}
 	}

--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -286,13 +286,11 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	 * Helper method to close the dialogRef.
 	 */
 	close(meta: CloseMeta = { reason: CloseReasons.interaction }) {
-		if (this.dialogRef) {
-			setTimeout(() => {
-				if (this.dialogRef) {
-					this.dialogRef.instance.doClose(meta);
-				}
-			});
-		}
+		setTimeout(() => {
+			if (this.dialogRef) {
+				this.dialogRef.instance.doClose(meta);
+			}
+		});
 	}
 
 	/**


### PR DESCRIPTION
No related issue

Fix error "TypeError: Cannot read property 'instance' of null", that appears when two or more close events occur on tooltip simultaniously and device handles them with significant delay.

#### Changelog

**Changed**

* fix error with tooltip close events