### PR TITLE
fix(inline notification): Update status icon size

### DIFF
--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -15,6 +15,7 @@ import CaretRight16 from "@carbon/icons/es/caret--right/16";
 import CaretUp16 from "@carbon/icons/es/caret--up/16";
 import Checkmark16 from "@carbon/icons/es/checkmark/16";
 import CheckmarkFilled16 from "@carbon/icons/es/checkmark--filled/16";
+import CheckmarkFilled20 from "@carbon/icons/es/checkmark--filled/20";
 import CheckmarkOutline16 from "@carbon/icons/es/checkmark--outline/16";
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16";
 import ChevronRight16 from "@carbon/icons/es/chevron--right/16";
@@ -24,7 +25,9 @@ import Copy16 from "@carbon/icons/es/copy/16";
 import Delete16 from "@carbon/icons/es/delete/16";
 import Download16 from "@carbon/icons/es/download/16";
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16";
+import ErrorFilled20 from "@carbon/icons/es/error--filled/20";
 import InformationFilled16 from "@carbon/icons/es/information--filled/16";
+import InformationFilled20 from "@carbon/icons/es/information--filled/20";
 import Menu16 from "@carbon/icons/es/menu/16";
 import Menu20 from "@carbon/icons/es/menu/20";
 import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16";
@@ -34,6 +37,7 @@ import Search16 from "@carbon/icons/es/search/16";
 import Settings16 from "@carbon/icons/es/settings/16";
 import Warning16 from "@carbon/icons/es/warning/16";
 import WarningFilled16 from "@carbon/icons/es/warning--filled/16";
+import WarningFilled20 from "@carbon/icons/es/warning--filled/20";
 import WarningAltFilled16 from "@carbon/icons/es/warning--alt--filled/16";
 
 // either provides a new instance of IconService, or returns the parent
@@ -73,6 +77,7 @@ export class IconModule {
 			CaretUp16,
 			Checkmark16,
 			CheckmarkFilled16,
+			CheckmarkFilled20,
 			CheckmarkOutline16,
 			ChevronDown16,
 			ChevronRight16,
@@ -82,7 +87,9 @@ export class IconModule {
 			Delete16,
 			Download16,
 			ErrorFilled16,
+			ErrorFilled20,
 			InformationFilled16,
+			InformationFilled20,
 			Menu16,
 			Menu20,
 			OverflowMenuVertical16,
@@ -92,6 +99,7 @@ export class IconModule {
 			Settings16,
 			Warning16,
 			WarningFilled16,
+			WarningFilled20,
 			WarningAltFilled16
 		]);
 	}

--- a/src/notification/notification.component.ts
+++ b/src/notification/notification.component.ts
@@ -26,25 +26,25 @@ import { of, isObservable, Subject } from "rxjs";
 		<div class="bx--inline-notification__details">
 			<svg
 				ibmIcon="error--filled"
-				size="16"
+				size="20"
 				*ngIf="notificationObj.type === 'error'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
 				ibmIcon="warning--filled"
-				size="16"
+				size="20"
 				*ngIf="notificationObj.type === 'warning'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
 				ibmIcon="checkmark--filled"
-				size="16"
+				size="20"
 				*ngIf="notificationObj.type === 'success'"
 				class="bx--inline-notification__icon">
 			</svg>
 			<svg
 				ibmIcon="information--filled"
-				size="16"
+				size="20"
 				*ngIf="notificationObj.type === 'info'"
 				class="bx--inline-notification__icon">
 			</svg>

--- a/src/notification/toast.component.ts
+++ b/src/notification/toast.component.ts
@@ -23,25 +23,25 @@ import { I18n } from "carbon-components-angular/i18n";
 	template: `
 		<svg
 			ibmIcon="error--filled"
-			size="16"
+			size="20"
 			*ngIf="notificationObj.type === 'error'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
 			ibmIcon="warning--filled"
-			size="16"
+			size="20"
 			*ngIf="notificationObj.type === 'warning'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
 			ibmIcon="checkmark--filled"
-			size="16"
+			size="20"
 			*ngIf="notificationObj.type === 'success'"
 			class="bx--toast-notification__icon">
 		</svg>
 		<svg
 			ibmIcon="information--filled"
-			size="16"
+			size="20"
 			*ngIf="notificationObj.type === 'info'"
 			class="bx--toast-notification__icon">
 		</svg>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1782

Inline notification icon incorrect size
Replaced 16x16 icon in inline-notification to 20x20 to align with the specs found here https://www.carbondesignsystem.com/components/notification/style 

Before
![image](https://user-images.githubusercontent.com/25778007/113880524-915c6f80-9789-11eb-9717-457043f167e9.png)

After
![image](https://user-images.githubusercontent.com/25778007/113880450-7db10900-9789-11eb-8f4d-fecf716bcb83.png)

