### PR TITLE
fix(dropdown) Incoming changes on a multi select now properly accept the "zero" case

### DIFF
--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -331,7 +331,16 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	protected onTouchedCallback: () => void = this._noop;
 
 	// primarily used to capture and propagate input to `writeValue` before the content is available
-	protected writtenValue: any = [];
+	protected _writtenValue: any = [];
+	protected get writtenValue() {
+		return this._writtenValue;
+	}
+	protected set writtenValue(val: any[]) {
+		if (val && val.length === 0) {
+			this.clearSelected();
+		}
+		this._writtenValue = val;
+	}
 
 	/**
 	 * Creates an instance of Dropdown.
@@ -592,7 +601,9 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	}
 
 	clearSelected() {
-		if (this.disabled) { return; }
+		if (this.disabled || this.getSelectedCount() === 0) {
+			return;
+		}
 		for (const item of this.view.getListItems()) {
 			item.selected = false;
 		}

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -331,7 +331,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	protected onTouchedCallback: () => void = this._noop;
 
 	// primarily used to capture and propagate input to `writeValue` before the content is available
-	protected _writtenValue: any = [];
+	private _writtenValue: any = [];
 	protected get writtenValue() {
 		return this._writtenValue;
 	}


### PR DESCRIPTION
For multi-select with ngModel, any external change that reduced the selection count to zero would be ignored.
This update solves that.

## How to reproduce
1. Open `dropdown.stories.ts`
2. Find `Multi-select with ngModel`
3. Duplicate the `<ibm-dropdown>` html, so there are *two* of them, one after the other
4. Make any change you want, and you'll see that they stay in sync -- _except_ when the change results in **no selections**.
5. For that case, the "other" dropdown ignores that update. This PR fixes this case.

> Note: This is also true for any external changes, including URL changes that might have an effect of the model, etc.

#### Changelog

**Changed**

- `_writtenValue` is now a set/get pair, where writes with length zero call `clearSelected()`
- `clearSelected()` checks for zero case to avoid and infinite loop
