### PR TITLE
feat(context-menu): add a simple context menu component

### DIFF
--- a/src/context-menu/context-menu-divider.component.ts
+++ b/src/context-menu/context-menu-divider.component.ts
@@ -1,0 +1,16 @@
+import { Component, HostBinding } from "@angular/core";
+
+@Component({
+	selector: "ibm-context-menu-divider",
+	template: "",
+	styles: [`
+		:host {
+			display: list-item;
+			list-style: none;
+		}
+	`]
+})
+export class ContextMenuDividerComponent {
+	@HostBinding("class.bx--context-menu-divider") dividerClass = true;
+	@HostBinding("attr.role") role = "separator";
+}

--- a/src/context-menu/context-menu-group.component.ts
+++ b/src/context-menu/context-menu-group.component.ts
@@ -1,0 +1,65 @@
+import {
+	Component,
+	EventEmitter,
+	HostBinding,
+	Input,
+	OnChanges,
+	OnDestroy,
+	OnInit,
+	Output,
+	SimpleChanges
+} from "@angular/core";
+import { Subscription } from "rxjs";
+import { ContextMenuSelectionService } from "./context-menu-selection.service";
+
+@Component({
+	selector: "ibm-context-menu-group",
+	template: `
+		<ul role="group" [attr.aria-label]="label">
+			<ng-content></ng-content>
+		</ul>
+	`,
+	styles: [`
+		:host {
+			display: list-item;
+			list-style: none;
+		}
+	`],
+	providers: [ContextMenuSelectionService]
+})
+export class ContextMenuGroupComponent implements OnInit, OnChanges, OnDestroy {
+	@HostBinding("attr.role") role = "none";
+
+	@Input() label = null;
+	@Input() value: any[] = [];
+	@Input() type: null | "radio" | "checkbox" = null;
+	@Output() valueChange = new EventEmitter<any[]>();
+
+	private subscription = new Subscription();
+
+	constructor(protected contextMenuSelectionService: ContextMenuSelectionService) { }
+
+	ngOnInit() {
+		const { selectionObservable } = this.contextMenuSelectionService;
+		const subscription = selectionObservable.subscribe(value => {
+			this.valueChange.emit(value);
+		});
+		this.subscription.add(subscription);
+	}
+
+	ngOnChanges(changes: SimpleChanges) {
+		if (changes.value) {
+			if (this.type === "radio") {
+				this.contextMenuSelectionService.selectRadio(changes.value.currentValue);
+			}
+
+			if (this.type === "checkbox") {
+				this.contextMenuSelectionService.selectCheckboxes(changes.value.currentValue);
+			}
+		}
+	}
+
+	ngOnDestroy() {
+		this.subscription.unsubscribe();
+	}
+}

--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -1,0 +1,207 @@
+import {
+	Component,
+	HostBinding,
+	Input, Output,
+	EventEmitter,
+	ElementRef,
+	HostListener,
+	ContentChild,
+	Optional,
+	OnInit,
+	AfterContentInit,
+	OnDestroy
+} from "@angular/core";
+import { Subscription } from "rxjs";
+import { ContextMenuSelectionService } from "./context-menu-selection.service";
+import { ContextMenuComponent } from "./context-menu.component";
+
+@Component({
+	selector: "ibm-context-menu-item",
+	template: `
+		<div class="bx--context-menu-option__content">
+			<div class="bx--context-menu-option__icon">
+				<svg *ngIf="selectable && checked" ibmIcon="checkmark" size="16"></svg>
+				<svg *ngIf="!selectable && icon" [ibmIcon]="icon" size="16"></svg>
+			</div>
+			<span class="bx--context-menu-option__label" [title]="label">{{label}}</span>
+			<div class="bx--context-menu-option__info">
+				{{info}}
+				<svg *ngIf="hasChildren" ibmIcon="caret--right" size="16"></svg>
+			</div>
+		</div>
+		<ng-content></ng-content>
+	`,
+	styles: [`
+		:host {
+			display: list-item;
+			list-style: none;
+		}
+	`]
+})
+export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDestroy {
+	@HostBinding("class.bx--context-menu-option") optionClass = true;
+	@HostBinding("attr.role") role = "menuitem";
+	@HostBinding("attr.tabindex") tabindex = -1;
+	@HostBinding("attr.aria-haspopup") ariaHasPopup = null;
+	@HostBinding("attr.aria-expanded") ariaExpanded = null;
+
+	@Input() label = "";
+	@Input() info = "";
+	@Input() type: null | "checkbox" | "radio" = null;
+	@Input() checked = false;
+	@Input() icon = "";
+	@Input() value = "";
+	@Output() checkedChange = new EventEmitter<boolean>();
+
+	hasChildren = false;
+	selectable = false;
+
+	// @ts-ignore
+	@ContentChild(ContextMenuComponent, { static: true }) childContextMenu: ContextMenuComponent;
+	private subscriptions = new Subscription();
+
+	constructor(
+		protected elementRef: ElementRef,
+		@Optional() protected contextMenuSelectionService: ContextMenuSelectionService
+	) { }
+
+	ngOnInit() {
+		switch (this.type) {
+			case "checkbox": {
+				this.role = "menuitemcheckbox";
+				this.selectable = true;
+				break;
+			}
+			case "radio": {
+				this.role = "menuitemradio";
+				this.selectable = true;
+				break;
+			}
+			default: {
+				this.role = "menuitem";
+			}
+		}
+
+		if (this.type && this.contextMenuSelectionService && this.value) {
+			const { selectionObservable } = this.contextMenuSelectionService;
+			const subscription = selectionObservable.subscribe((value) => {
+				if (this.type === "radio") {
+					this.handleSelection(value === this.value);
+				}
+
+				if (this.type === "checkbox") {
+					this.handleSelection(value.includes(this.value));
+				}
+			});
+			this.subscriptions.add(subscription);
+		}
+	}
+
+	ngAfterContentInit() {
+		if (this.childContextMenu) {
+			this.hasChildren = true;
+			this.ariaHasPopup = true;
+			this.ariaExpanded = false;
+		}
+	}
+
+	@HostListener("keydown.enter", ["$event"])
+	@HostListener("keydown.space", ["$event"])
+	@HostListener("click", ["$event"])
+	handleClick(event: MouseEvent & KeyboardEvent) {
+		event.stopPropagation();
+		if (this.hasChildren && (event.key === " " || event.key === "Enter")) {
+			this.openSubMenu();
+			this.childContextMenu.focusMenu();
+		}
+
+		if (this.type) {
+			this.handleSelection(!this.checked);
+		}
+
+		if (this.contextMenuSelectionService) {
+			if (this.type === "radio") {
+				this.contextMenuSelectionService.selectRadio(this.value);
+			}
+
+			if (this.type === "checkbox") {
+				this.contextMenuSelectionService.selectCheckbox(this.value);
+			}
+		}
+	}
+
+	handleSelection(selected: boolean) {
+		this.checked = selected;
+		this.checkedChange.emit(this.checked);
+	}
+
+	openSubMenu() {
+		if (this.childContextMenu) {
+			this.childContextMenu.open = true;
+			this.ariaExpanded = true;
+			const dimensions = this.getDimensions();
+			this.childContextMenu.position.left = dimensions.left + dimensions.width;
+			// subtract 4px to account for margins
+			this.childContextMenu.position.top = dimensions.top - 4;
+		}
+	}
+
+	closeSubMenu() {
+		if (this.childContextMenu) {
+			this.childContextMenu.open = false;
+			this.ariaExpanded = false;
+		}
+	}
+
+	@HostListener("mouseover")
+	handleMouseOver() {
+		this.openSubMenu();
+	}
+
+	@HostListener("mouseout")
+	handleMouseOut() {
+		this.closeSubMenu();
+	}
+
+	@HostListener("focus")
+	handleFocus() {
+		this.tabindex = 0;
+	}
+
+	@HostListener("blur")
+	handleBlur() {
+		this.tabindex = -1;
+	}
+
+	focusItem() {
+		this.elementRef.nativeElement.focus();
+	}
+
+	// @HostListener('keydown', ['$event'])
+	// handleNavigation(event: KeyboardEvent) {
+	// 	const element: HTMLElement = this.elementRef.nativeElement;
+	// 	if (event.key === 'ArrowDown') {
+	// 		console.log('item down');
+	// 		let nextElement = element.nextElementSibling as HTMLElement;
+	// 		nextElement.focus();
+	// 		if (nextElement.classList.contains('bx--context-menu-divider')) {
+	// 			nextElement = nextElement.nextElementSibling as HTMLElement;
+	// 		}
+	// 		nextElement.focus();
+	// 	}
+
+	// 	if (event.key === 'ArrowUp') {
+	// 		console.log('item up');
+	// 		(element.previousElementSibling as HTMLElement).focus();
+	// 	}
+	// }
+
+	getDimensions() {
+		const element: HTMLElement = this.elementRef.nativeElement.querySelector(".bx--context-menu-option__content");
+		return element.getBoundingClientRect();
+	}
+
+	ngOnDestroy() {
+		this.subscriptions.unsubscribe();
+	}
+}

--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -103,6 +103,7 @@ export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDes
 			this.hasChildren = true;
 			this.ariaHasPopup = true;
 			this.ariaExpanded = false;
+			this.childContextMenu.root = false;
 		}
 	}
 

--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -111,7 +111,7 @@ export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDes
 	@HostListener("click", ["$event"])
 	handleClick(event: MouseEvent & KeyboardEvent) {
 		event.stopPropagation();
-		if (this.hasChildren && (event.key === " " || event.key === "Enter")) {
+		if (this.hasChildren) {
 			this.openSubMenu();
 			this.childContextMenu.focusMenu();
 		}
@@ -167,6 +167,9 @@ export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDes
 	@HostListener("focus")
 	handleFocus() {
 		this.tabindex = 0;
+		if (this.hasChildren && this.ariaExpanded) {
+			this.closeSubMenu();
+		}
 	}
 
 	@HostListener("blur")

--- a/src/context-menu/context-menu-selection.service.ts
+++ b/src/context-menu/context-menu-selection.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from "@angular/core";
+import { Observable, ReplaySubject } from "rxjs";
+
+@Injectable()
+export class ContextMenuSelectionService {
+	public selectionObservable: Observable<any | any[]>;
+	private selectionSubject = new ReplaySubject<any | any[]>(1);
+	private value: any[] = [];
+
+	constructor() {
+		this.selectionObservable = this.selectionSubject.asObservable();
+	}
+
+	selectRadio(value: any) {
+		if (!value) {
+			return;
+		}
+		this.selectionSubject.next(value);
+		this.value = [value];
+	}
+
+	selectCheckbox(value: any) {
+		if (!value) {
+			return;
+		}
+		if (this.value.includes(value)) {
+			this.value = this.value.filter(v => v !== value);
+		} else {
+			this.value.push(value);
+		}
+		this.selectionSubject.next(this.value);
+	}
+
+	selectCheckboxes(value: any[]) {
+		this.value = value;
+		this.selectionSubject.next(value);
+	}
+}

--- a/src/context-menu/context-menu-selection.service.ts
+++ b/src/context-menu/context-menu-selection.service.ts
@@ -32,6 +32,9 @@ export class ContextMenuSelectionService {
 	}
 
 	selectCheckboxes(value: any[]) {
+		if (!value) {
+			return;
+		}
 		this.value = value;
 		this.selectionSubject.next(value);
 	}

--- a/src/context-menu/context-menu.component.ts
+++ b/src/context-menu/context-menu.component.ts
@@ -87,7 +87,6 @@ export class ContextMenuComponent implements OnChanges {
 				break;
 			}
 			case "ArrowRight": {
-
 				if (currentIndex !== -1 && subMenus.some(subMenu => currentMenuItem.contains(subMenu))) {
 					currentMenuItem.click();
 				}

--- a/src/context-menu/context-menu.component.ts
+++ b/src/context-menu/context-menu.component.ts
@@ -1,0 +1,140 @@
+import {
+	Component,
+	ContentChildren,
+	ElementRef,
+	HostListener,
+	Input,
+	OnInit,
+	Optional,
+	SimpleChanges,
+	SkipSelf,
+	QueryList,
+	forwardRef,
+	OnChanges
+} from "@angular/core";
+import { ContextMenuItemComponent } from "./context-menu-item.component";
+
+@Component({
+	selector: "ibm-context-menu",
+	template: `
+		<ul
+			class="bx--context-menu"
+			[ngClass]="{
+				'bx--context-menu--root': root,
+				'bx--context-menu--open': open
+			}"
+			role="menu"
+			[attr.data-level]="level"
+			tabindex="-1"
+			[ngStyle]="{
+				'left.px': position.left,
+				'top.px': position.top
+			}">
+			<ng-content></ng-content>
+		</ul>
+	`
+})
+export class ContextMenuComponent implements OnInit, OnChanges {
+	@Input() root = true;
+	@Input() open = false;
+	@Input() position = {
+		left: 0,
+		top: 0
+	};
+
+	public level = 0;
+
+	// tslint:disable-next-line
+	@ContentChildren(forwardRef(() => ContextMenuItemComponent), { descendants: true }) menuItems: QueryList<ContextMenuItemComponent>;
+	// tslint:disable-next-line
+	@ContentChildren(forwardRef(() => ContextMenuComponent), { descendants: true }) subMenus: QueryList<ContextMenuComponent>;
+
+	constructor(
+		@SkipSelf() @Optional() protected parentContextMenu: ContextMenuComponent,
+		protected elementRef: ElementRef
+	) { }
+
+	ngOnChanges(changes: SimpleChanges) {
+		if (changes.open) {
+			if (changes.open.currentValue) {
+				this.focusMenu();
+			}
+		}
+	}
+
+	ngOnInit() {
+		if (this.parentContextMenu && this.parentContextMenu.root) {
+			this.root = false;
+			this.open = false;
+			this.level = this.parentContextMenu.level + 1;
+		}
+	}
+
+	focusMenu() {
+		// wait until the next tick to let the DOM settle before changing the focus
+		setTimeout(() => {
+			if (this.root) {
+				this.elementRef.nativeElement.querySelector("ul").focus();
+			} else {
+				this.menuItems.first.focusItem();
+			}
+		});
+	}
+
+	@HostListener("keydown", ["$event"])
+	handleNavigation(event: KeyboardEvent) {
+		const subMenus = this.subMenus.toArray().filter(subMenu => subMenu !== this);
+		const menuItems = this.menuItems.toArray().filter(menuItem => {
+			// if the menu item is contained within any submenu then remove it from the array
+			return !subMenus.some(subMenu => {
+				// check if the menu item is contained within a submenu
+				return subMenu.menuItems.some(subMenuItem => {
+					return menuItem === subMenuItem;
+				});
+			});
+		});
+		const currentIndex = menuItems.findIndex(menuItem => menuItem.tabindex === 0);
+		const list: HTMLElement = this.elementRef.nativeElement.querySelector("ul");
+
+		if (event.key === "ArrowDown") {
+			if (document.activeElement === list) {
+				menuItems[0].focusItem();
+			} else {
+				if (currentIndex !== -1 && currentIndex < menuItems.length - 1) {
+					menuItems[currentIndex + 1].focusItem();
+				}
+			}
+		}
+
+		if (event.key === "ArrowUp") {
+			if (document.activeElement === list) {
+				menuItems[menuItems.length - 1].focusItem();
+			} else {
+				if (currentIndex !== -1 && currentIndex > 0) {
+					menuItems[currentIndex - 1].focusItem();
+				}
+			}
+		}
+
+		if (event.key === "ArrowRight") {
+			if (currentIndex !== -1 && menuItems[currentIndex].childContextMenu) {
+				menuItems[currentIndex].openSubMenu();
+				menuItems[currentIndex].childContextMenu.focusMenu();
+			}
+		}
+
+		if (event.key === "ArrowLeft") {
+			if (this.parentContextMenu) {
+				const parentItem = this.parentContextMenu.menuItems.find(item => item.childContextMenu === this);
+				parentItem.focusItem();
+				parentItem.closeSubMenu();
+
+			}
+		}
+	}
+
+	getDimensions() {
+		const element: HTMLElement = this.elementRef.nativeElement.querySelector("ul");
+		return element.getBoundingClientRect();
+	}
+}

--- a/src/context-menu/context-menu.component.ts
+++ b/src/context-menu/context-menu.component.ts
@@ -96,39 +96,42 @@ export class ContextMenuComponent implements OnInit, OnChanges {
 		const currentIndex = menuItems.findIndex(menuItem => menuItem.tabindex === 0);
 		const list: HTMLElement = this.elementRef.nativeElement.querySelector("ul");
 
-		if (event.key === "ArrowDown") {
-			if (document.activeElement === list) {
-				menuItems[0].focusItem();
-			} else {
-				if (currentIndex !== -1 && currentIndex < menuItems.length - 1) {
-					menuItems[currentIndex + 1].focusItem();
+		switch (event.key) {
+			case "ArrowDown": {
+				if (document.activeElement === list) {
+					menuItems[0].focusItem();
+				} else {
+					if (currentIndex !== -1 && currentIndex < menuItems.length - 1) {
+						menuItems[currentIndex + 1].focusItem();
+					}
 				}
+				break;
 			}
-		}
-
-		if (event.key === "ArrowUp") {
-			if (document.activeElement === list) {
-				menuItems[menuItems.length - 1].focusItem();
-			} else {
-				if (currentIndex !== -1 && currentIndex > 0) {
-					menuItems[currentIndex - 1].focusItem();
+			case "ArrowUp": {
+				if (document.activeElement === list) {
+					menuItems[menuItems.length - 1].focusItem();
+				} else {
+					if (currentIndex !== -1 && currentIndex > 0) {
+						menuItems[currentIndex - 1].focusItem();
+					}
 				}
+				break;
 			}
-		}
-
-		if (event.key === "ArrowRight") {
-			if (currentIndex !== -1 && menuItems[currentIndex].childContextMenu) {
-				menuItems[currentIndex].openSubMenu();
-				menuItems[currentIndex].childContextMenu.focusMenu();
+			case "ArrowRight": {
+				if (currentIndex !== -1 && menuItems[currentIndex].childContextMenu) {
+					menuItems[currentIndex].openSubMenu();
+					menuItems[currentIndex].childContextMenu.focusMenu();
+				}
+				break;
 			}
-		}
+			case "ArrowLeft": {
+				if (this.parentContextMenu) {
+					const parentItem = this.parentContextMenu.menuItems.find(item => item.childContextMenu === this);
+					parentItem.focusItem();
+					parentItem.closeSubMenu();
 
-		if (event.key === "ArrowLeft") {
-			if (this.parentContextMenu) {
-				const parentItem = this.parentContextMenu.menuItems.find(item => item.childContextMenu === this);
-				parentItem.focusItem();
-				parentItem.closeSubMenu();
-
+				}
+				break;
 			}
 		}
 	}

--- a/src/context-menu/context-menu.component.ts
+++ b/src/context-menu/context-menu.component.ts
@@ -1,18 +1,11 @@
 import {
 	Component,
-	ContentChildren,
 	ElementRef,
 	HostListener,
 	Input,
-	OnInit,
-	Optional,
 	SimpleChanges,
-	SkipSelf,
-	QueryList,
-	forwardRef,
 	OnChanges
 } from "@angular/core";
-import { ContextMenuItemComponent } from "./context-menu-item.component";
 
 @Component({
 	selector: "ibm-context-menu",
@@ -24,7 +17,6 @@ import { ContextMenuItemComponent } from "./context-menu-item.component";
 				'bx--context-menu--open': open
 			}"
 			role="menu"
-			[attr.data-level]="level"
 			tabindex="-1"
 			[ngStyle]="{
 				'left.px': position.left,
@@ -34,7 +26,7 @@ import { ContextMenuItemComponent } from "./context-menu-item.component";
 		</ul>
 	`
 })
-export class ContextMenuComponent implements OnInit, OnChanges {
+export class ContextMenuComponent implements OnChanges {
 	@Input() root = true;
 	@Input() open = false;
 	@Input() position = {
@@ -42,27 +34,11 @@ export class ContextMenuComponent implements OnInit, OnChanges {
 		top: 0
 	};
 
-	public level = 0;
-
-	// tslint:disable-next-line
-	@ContentChildren(forwardRef(() => ContextMenuItemComponent), { descendants: true }) menuItems: QueryList<ContextMenuItemComponent>;
-
-	constructor(
-		@SkipSelf() @Optional() protected parentContextMenu: ContextMenuComponent,
-		protected elementRef: ElementRef
-	) { }
+	constructor(protected elementRef: ElementRef) { }
 
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.open && changes.open.currentValue) {
 			this.focusMenu();
-		}
-	}
-
-	ngOnInit() {
-		if (this.parentContextMenu && this.parentContextMenu.root) {
-			this.root = false;
-			this.open = false;
-			this.level = this.parentContextMenu.level + 1;
 		}
 	}
 
@@ -118,8 +94,8 @@ export class ContextMenuComponent implements OnInit, OnChanges {
 				break;
 			}
 			case "ArrowLeft": {
-				if (this.parentContextMenu) {
-					const parent = currentMenuItem.parentElement.closest(".bx--context-menu-option") as HTMLElement;
+				const parent = currentMenuItem.parentElement.closest(".bx--context-menu-option") as HTMLElement;
+				if (parent) {
 					parent.focus();
 				}
 				break;

--- a/src/context-menu/context-menu.module.ts
+++ b/src/context-menu/context-menu.module.ts
@@ -1,0 +1,25 @@
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+import { IconModule } from "carbon-components-angular/icon";
+
+import { ContextMenuDividerComponent } from "./context-menu-divider.component";
+import { ContextMenuGroupComponent } from "./context-menu-group.component";
+import { ContextMenuItemComponent } from "./context-menu-item.component";
+import { ContextMenuComponent } from "./context-menu.component";
+
+@NgModule({
+	declarations: [
+		ContextMenuDividerComponent,
+		ContextMenuGroupComponent,
+		ContextMenuItemComponent,
+		ContextMenuComponent
+	],
+	exports: [
+		ContextMenuDividerComponent,
+		ContextMenuGroupComponent,
+		ContextMenuItemComponent,
+		ContextMenuComponent
+	],
+	imports: [CommonModule, IconModule]
+})
+export class ContextMenuModule { }

--- a/src/context-menu/context-menu.stories.ts
+++ b/src/context-menu/context-menu.stories.ts
@@ -1,0 +1,67 @@
+import { storiesOf, moduleMetadata } from "@storybook/angular";
+import { withKnobs, array, text, object, boolean } from "@storybook/addon-knobs";
+import { action } from "@storybook/addon-actions";
+
+import { ContextMenuModule } from "./context-menu.module";
+
+storiesOf("Components|Context Menu", module)
+	.addDecorator(
+		moduleMetadata({
+			imports: [
+				ContextMenuModule
+			]
+		})
+	)
+	.addDecorator(withKnobs)
+	.add("Basic", () => ({
+		template: `
+			<ibm-context-menu [open]="open" [position]="position">
+				<ibm-context-menu-item label="Cut" info="⌘X"></ibm-context-menu-item>
+				<ibm-context-menu-item label="Option with icon" icon="calendar"></ibm-context-menu-item>
+				<ibm-context-menu-divider></ibm-context-menu-divider>
+				<ibm-context-menu-item type="checkbox" label="Enable magic"></ibm-context-menu-item>
+				<ibm-context-menu-divider></ibm-context-menu-divider>
+				<ibm-context-menu-group label="Selection group">
+					<ibm-context-menu-item type="checkbox" label="Blue"></ibm-context-menu-item>
+					<ibm-context-menu-item type="checkbox" label="Red" [checked]="true"></ibm-context-menu-item>
+					<ibm-context-menu-item type="checkbox" label="Black"></ibm-context-menu-item>
+					<ibm-context-menu-item type="checkbox" label="Green"></ibm-context-menu-item>
+				</ibm-context-menu-group>
+				<ibm-context-menu-divider></ibm-context-menu-divider>
+				<ibm-context-menu-item label="Radio flyout">
+					<ibm-context-menu>
+						<ibm-context-menu-group
+							type="radio"
+							[value]="radioGroupValue"
+							(valueChange)="onRadioChange($event)">
+							<ibm-context-menu-item type="radio" label="Radio one" value="one"></ibm-context-menu-item>
+							<ibm-context-menu-item type="radio" label="Radio two" value="two"></ibm-context-menu-item>
+							<ibm-context-menu-item type="radio" label="Radio three" value="three"></ibm-context-menu-item>
+							<ibm-context-menu-item type="radio" label="Radio four" value="four"></ibm-context-menu-item>
+						</ibm-context-menu-group>
+					</ibm-context-menu>
+				</ibm-context-menu-item>
+				<ibm-context-menu-item label="Checkbox flyout">
+					<ibm-context-menu>
+						<ibm-context-menu-group
+							type="checkbox"
+							[value]="checkboxGroupValue"
+							(valueChange)="onCheckboxChange($event)">
+							<ibm-context-menu-item type="checkbox" label="Selectable item a" value="a"></ibm-context-menu-item>
+							<ibm-context-menu-item type="checkbox" label="Selectable item b" value="b"></ibm-context-menu-item>
+							<ibm-context-menu-item type="checkbox" label="Selectable item c" value="c"></ibm-context-menu-item>
+							<ibm-context-menu-item type="checkbox" label="Selectable item d" value="d"></ibm-context-menu-item>
+						</ibm-context-menu-group>
+					</ibm-context-menu>
+				</ibm-context-menu-item>
+			</ibm-context-menu>
+		`,
+		props: {
+			onRadioChange: action("Radio menu change"),
+			onCheckboxChange: action("Checkbox menu change"),
+			checkboxGroupValue: array("checkbox group value", ["a", "d"]),
+			radioGroupValue: text("radio group value", "one"),
+			position: object("Context menu position", { top: 0, left: 0 }),
+			open: boolean("Is the context menu open", true)
+		}
+	}));

--- a/src/context-menu/index.ts
+++ b/src/context-menu/index.ts
@@ -1,0 +1,5 @@
+export { ContextMenuModule } from "./context-menu.module";
+export { ContextMenuDividerComponent } from "./context-menu-divider.component";
+export { ContextMenuGroupComponent } from "./context-menu-group.component";
+export { ContextMenuItemComponent } from "./context-menu-item.component";
+export { ContextMenuComponent } from "./context-menu.component";

--- a/src/context-menu/package.json
+++ b/src/context-menu/package.json
@@ -1,0 +1,7 @@
+{
+	"ngPackage": {
+		"lib": {
+			"entryFile": "index.ts"
+		}
+	}
+}


### PR DESCRIPTION
Adds a simple context-menu implementation. [See here](https://react.carbondesignsystem.com/?path=/story/experimental-unstable-contextmenu--context-menu) for the existing react implementation this is based on. We deviate in a few ways, and add some component level styles to make things behave, but all the functionality should be the same.

This doesn't handle displaying on right click - We can add a service later to deal with that (I'm thinking something that could serve as a proper foundation for the dialog service ... Maybe we can address some of the positioning bugs at the same time).