### PR TITLE
fix(select): allow view to be updated through reactive forms and ngModel in prod

### DIFF
--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -190,7 +190,7 @@ export class Select implements ControlValueAccessor, AfterViewInit {
 	@Output() valueChange = new EventEmitter();
 
 	// @ts-ignore
-	@ViewChild("select", { static: true }) select: ElementRef;
+	@ViewChild("select", { static: false }) select: ElementRef;
 
 	@Input() set value(v) {
 		this._value = v;


### PR DESCRIPTION
Closes #1776
Closes #1798 

In the storybook `@ViewChild` got the right reference to the select element but in a production build it was `undefined` so the view couldn't be programmatically updated within the component.
