### PR TITLE
fix(slider): Fix accessibility check "1.1.1 Non-text Content: ViolationForm control with "slider" role has no associated label

### DIFF
--- a/src/slider/slider.component.ts
+++ b/src/slider/slider.component.ts
@@ -54,7 +54,7 @@ import { EventService } from "carbon-components-angular/utils";
 	selector: "ibm-slider",
 	template: `
 		<ng-container *ngIf="!skeleton; else skeletonTemplate">
-			<label *ngIf="label" [for]="id" class="bx--label">
+			<label *ngIf="label" [for]="id" [id]="labelId" class="bx--label">
 				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 			</label>
@@ -70,6 +70,7 @@ import { EventService } from "carbon-components-angular/utils";
 							#thumbs
 							role="slider"
 							[id]="id"
+							[attr.aria-labelledby]="labelId"
 							class="bx--slider__thumb"
 							[ngStyle]="{left: getFractionComplete(value) * 100 + '%'}"
 							tabindex="0"
@@ -83,6 +84,7 @@ import { EventService } from "carbon-components-angular/utils";
 							*ngFor="let thumb of value; let i = index; trackBy: trackThumbsBy"
 							role="slider"
 							[id]="id + (i > 0 ? '-' + i : '')"
+							[attr.aria-labelledby]="labelId"
 							class="bx--slider__thumb"
 							[ngStyle]="{left: getFractionComplete(thumb) * 100 + '%'}"
 							tabindex="0"
@@ -267,6 +269,7 @@ export class Slider implements AfterViewInit, ControlValueAccessor {
 	// @ts-ignore
 	@ViewChild("range", { static: false }) range: ElementRef;
 
+	public labelId = `${this.id}-label`;
 	public bottomRangeId = `${this.id}-bottom-range`;
 	public topRangeId = `${this.id}-top-range`;
 	public fractionComplete = 0;


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1846

I think the `IBM Equal Access Accessibility Checker` might have some issues on its own and not detecting the already existing  `for` attribute on the main `<label>` element. This PR adds a safe-guard, which feels very much a redundant labeling, by adding an `aria-labeledby` attribute on the slider handle(s)

Slider:
![image](https://user-images.githubusercontent.com/1253469/122832857-fd933d80-d2b9-11eb-9138-794a76ab4c0f.png)

Range:
![image](https://user-images.githubusercontent.com/1253469/122832880-07b53c00-d2ba-11eb-8ea7-51759a45073b.png)
