### PR TITLE
fix(overflow-menu-pane): include floating menu direction data attribute

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -11,6 +11,7 @@ import { Dialog } from "../dialog.component";
 	template: `
 		<div
 			[attr.aria-label]="dialogConfig.menuLabel"
+			[attr.data-floating-menu-direction]="placement ? placement : null"
 			[ngClass]="{'bx--overflow-menu--flip': dialogConfig.flip}"
 			class="bx--overflow-menu-options bx--overflow-menu-options--open"
 			role="menu"

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -24,6 +24,7 @@ import { closestAttr } from "carbon-components-angular/utils";
 	template: `
 		<ul
 			[attr.aria-label]="dialogConfig.menuLabel"
+			[attr.data-floating-menu-direction]="placement ? placement : null"
 			[ngClass]="{'bx--overflow-menu--flip': dialogConfig.flip}"
 			role="menu"
 			#dialog


### PR DESCRIPTION
Adds missing data attribute so that Carbon styles apply on the menu pane and cover the gap between the trigger and the pane itself.

![Jun-23-2021 13-05-55](https://user-images.githubusercontent.com/3933866/123087255-a1006180-d424-11eb-8769-a5f78eac10bc.gif)