### PR TITLE
Remove @carbon/icons-angular completely from this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 Assuming we're starting with a new @angular/cli project:
 
 ```shell
-$ npx @angular/cli@v11-lts new my-project --style=scss
+$ npx @angular/cli new my-project --style=scss
 $ cd my-project
-$ npm i --save carbon-components-angular carbon-components @carbon/icons-angular
+$ npm i --save carbon-components-angular carbon-components
 ```
 
 Then we need to include carbon-components in `src/styles.scss`:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 Assuming we're starting with a new @angular/cli project:
 
 ```shell
-$ npx @angular/cli new my-project --style=scss
+$ npx @angular/cli@v11-lts new my-project --style=scss
 $ cd my-project
 $ npm i --save carbon-components-angular carbon-components @carbon/icons-angular
 ```

--- a/integration/ng10/package-lock.json
+++ b/integration/ng10/package-lock.json
@@ -1630,14 +1630,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
       "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.2.1.tgz",
-      "integrity": "sha512-mZ/lREdEH+iqVTYMLwDidRlqCTpJ2chaq4c3vQaUMwg56p/e6aqz73bvi1qMgxx0BJArTHQp044VTykwcZv39A==",
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      }
-    },
     "@carbon/telemetry": {
       "version": "0.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.5.tgz",

--- a/integration/ng10/package.json
+++ b/integration/ng10/package.json
@@ -23,7 +23,6 @@
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2",
     "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.2.1",
     "carbon-components-angular": "latest"
   },
   "devDependencies": {

--- a/integration/ng11/package-lock.json
+++ b/integration/ng11/package-lock.json
@@ -1424,14 +1424,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
       "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.2.1.tgz",
-      "integrity": "sha512-mZ/lREdEH+iqVTYMLwDidRlqCTpJ2chaq4c3vQaUMwg56p/e6aqz73bvi1qMgxx0BJArTHQp044VTykwcZv39A==",
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      }
-    },
     "@carbon/telemetry": {
       "version": "0.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.5.tgz",

--- a/integration/ng11/package.json
+++ b/integration/ng11/package.json
@@ -23,7 +23,6 @@
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2",
     "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.2.1",
     "carbon-components-angular": "latest"
   },
   "devDependencies": {

--- a/integration/ng7/package-lock.json
+++ b/integration/ng7/package-lock.json
@@ -740,14 +740,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
       "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.2.1.tgz",
-      "integrity": "sha512-mZ/lREdEH+iqVTYMLwDidRlqCTpJ2chaq4c3vQaUMwg56p/e6aqz73bvi1qMgxx0BJArTHQp044VTykwcZv39A==",
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      }
-    },
     "@carbon/telemetry": {
       "version": "0.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.5.tgz",

--- a/integration/ng7/package.json
+++ b/integration/ng7/package.json
@@ -24,7 +24,6 @@
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26",
     "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.2.1",
     "carbon-components-angular": "latest"
   },
   "devDependencies": {

--- a/integration/ng8/package-lock.json
+++ b/integration/ng8/package-lock.json
@@ -1622,14 +1622,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
       "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.2.1.tgz",
-      "integrity": "sha512-mZ/lREdEH+iqVTYMLwDidRlqCTpJ2chaq4c3vQaUMwg56p/e6aqz73bvi1qMgxx0BJArTHQp044VTykwcZv39A==",
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      }
-    },
     "@carbon/telemetry": {
       "version": "0.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.5.tgz",

--- a/integration/ng8/package.json
+++ b/integration/ng8/package.json
@@ -23,7 +23,6 @@
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1",
     "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.2.1",
     "carbon-components-angular": "latest"
   },
   "devDependencies": {

--- a/integration/ng9/package-lock.json
+++ b/integration/ng9/package-lock.json
@@ -1449,14 +1449,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.20.0.tgz",
       "integrity": "sha512-5phm6FswP6dDkFAeHDPPg9fpuan8i7/vh7idI01mDHxAaSzswdnf3iTW3+M5PaIvcJbXUHMcJLPpTgByPdnuKQ=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.2.1.tgz",
-      "integrity": "sha512-mZ/lREdEH+iqVTYMLwDidRlqCTpJ2chaq4c3vQaUMwg56p/e6aqz73bvi1qMgxx0BJArTHQp044VTykwcZv39A==",
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      }
-    },
     "@carbon/telemetry": {
       "version": "0.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@carbon/telemetry/-/telemetry-0.0.0-alpha.5.tgz",

--- a/integration/ng9/package.json
+++ b/integration/ng9/package.json
@@ -23,7 +23,6 @@
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2",
     "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.2.1",
     "carbon-components-angular": "latest"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3204,23 +3204,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-10.27.0.tgz",
       "integrity": "sha512-lxgmO3InfNnPqG/GGfVWAzQe3b1gK7QvglzshoYqeZLbbYj3IW4acII/ht+qf4eoCg9IOlYvsgYeUQNe7zqXbA=="
     },
-    "@carbon/icons-angular": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-angular/-/icons-angular-11.0.1.tgz",
-      "integrity": "sha512-FJ5pCorN1y0wvkyU/Xb1GKQuNSafzdq9CFHEP+oVTeycxPG7f3sNYAvd0CD97uuF3ATj9fdgP6q45PWkaSFu/Q==",
-      "dev": true,
-      "requires": {
-        "@carbon/icon-helpers": "10.6.0"
-      },
-      "dependencies": {
-        "@carbon/icon-helpers": {
-          "version": "10.6.0",
-          "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.6.0.tgz",
-          "integrity": "sha512-4Nh6l+B8SRNyw1RpgNT4Z83Aa5UwRFmKJ2mx5m7mE5TqxPkfIZjyyLHyv5gl3gPtaVwq78ZGz80wG0NRQzRM7g==",
-          "dev": true
-        }
-      }
-    },
     "@carbon/import-once": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@carbon/import-once/-/import-once-10.3.0.tgz",
@@ -7593,7 +7576,7 @@
     },
     "@types/fs-extra": {
       "version": "5.1.0",
-      "resolved": "http://localhost:4873/@types%2ffs-extra/-/fs-extra-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2ffs-extra/-/fs-extra-5.1.0.tgz",
       "integrity": "sha512-AInn5+UBFIK9FK5xc9yP5e3TQSPNNgjHByqYcj9g5elVBnDQcQL7PlO1CIRy2gWlbwK7UPYqi7vRvFA44dCmYQ==",
       "dev": true,
       "requires": {
@@ -7602,7 +7585,7 @@
     },
     "@types/glob": {
       "version": "7.1.3",
-      "resolved": "http://localhost:4873/@types%2fglob/-/glob-7.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fglob/-/glob-7.1.3.tgz",
       "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
       "dev": true,
       "requires": {
@@ -7612,7 +7595,7 @@
     },
     "@types/handlebars": {
       "version": "4.1.0",
-      "resolved": "http://localhost:4873/@types%2fhandlebars/-/handlebars-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fhandlebars/-/handlebars-4.1.0.tgz",
       "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
       "dev": true,
       "requires": {
@@ -7621,7 +7604,7 @@
     },
     "@types/highlight.js": {
       "version": "9.12.4",
-      "resolved": "http://localhost:4873/@types%2fhighlight.js/-/highlight.js-9.12.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fhighlight.js/-/highlight.js-9.12.4.tgz",
       "integrity": "sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==",
       "dev": true
     },
@@ -7676,19 +7659,19 @@
     },
     "@types/lodash": {
       "version": "4.14.161",
-      "resolved": "http://localhost:4873/@types%2flodash/-/lodash-4.14.161.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2flodash/-/lodash-4.14.161.tgz",
       "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
       "dev": true
     },
     "@types/marked": {
       "version": "0.4.2",
-      "resolved": "http://localhost:4873/@types%2fmarked/-/marked-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fmarked/-/marked-0.4.2.tgz",
       "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
       "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "http://localhost:4873/@types%2fminimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fminimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
@@ -7809,7 +7792,7 @@
     },
     "@types/shelljs": {
       "version": "0.8.8",
-      "resolved": "http://localhost:4873/@types%2fshelljs/-/shelljs-0.8.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types%2fshelljs/-/shelljs-0.8.8.tgz",
       "integrity": "sha512-lD3LWdg6j8r0VRBFahJVaxoW0SIcswxKaFUrmKl33RJVeeoNYQAz4uqCJ5Z6v4oIBOsC5GozX+I5SorIKiTcQA==",
       "dev": true,
       "requires": {
@@ -29686,7 +29669,7 @@
     },
     "typedoc": {
       "version": "0.14.2",
-      "resolved": "http://localhost:4873/typedoc/-/typedoc-0.14.2.tgz",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
       "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
       "dev": true,
       "requires": {
@@ -29711,13 +29694,13 @@
     },
     "typedoc-default-themes": {
       "version": "0.5.0",
-      "resolved": "http://localhost:4873/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
       "dev": true
     },
     "typedoc-plugin-external-module-name": {
       "version": "4.0.3",
-      "resolved": "http://localhost:4873/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-4.0.3.tgz",
       "integrity": "sha512-2PjEN9kdmkB7NxN3DEax6yDIPjq7HV8qELQhkSRJGxJs/8G/ZwPPvXT0z6hUqtWVr6MeCjpAoYJFzHo04C14Aw==",
       "dev": true,
       "requires": {
@@ -29727,7 +29710,7 @@
       "dependencies": {
         "semver": {
           "version": "7.3.2",
-          "resolved": "http://localhost:4873/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@angular/platform-browser-dynamic": "7.2.16",
     "@angular/router": "7.2.16",
     "@babel/core": "7.4.3",
-    "@carbon/icons-angular": "11.0.1",
     "@carbon/themes": "10.15.0",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -7,8 +7,6 @@ import {
 	EventEmitter
 } from "@angular/core";
 
-import { IconModule } from "../icon/icon.module";
-
 @Component({
 	selector: "ibm-accordion-item",
 	template: `

--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -7,6 +7,8 @@ import {
 	EventEmitter
 } from "@angular/core";
 
+import { IconModule } from "../icon/icon.module";
+
 @Component({
 	selector: "ibm-accordion-item",
 	template: `

--- a/src/button/button.directive.ts
+++ b/src/button/button.directive.ts
@@ -117,7 +117,7 @@ export class Button implements OnInit {
 	 *		[hasAssistiveText]="true"
 	 *		assistiveTextPlacement="top"
 	 *		assistiveTextAlignment="center">
-	 *		<svg class="bx--btn__icon" ibmIconCopy size="20"></svg>
+	 *		<svg class="bx--btn__icon" ibmIcon="copy" size="20"></svg>
 	 *		<span class="bx--assistive-text">Icon description</span>
 	 *	</button>
 	 * ```

--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -8,6 +8,7 @@ import {
 } from "@angular/core";
 
 import { I18n } from "carbon-components-angular/i18n";
+import { IconModule } from "../icon/icon.module";
 
 export enum SnippetType {
 	single = "single",

--- a/src/code-snippet/code-snippet.component.ts
+++ b/src/code-snippet/code-snippet.component.ts
@@ -8,7 +8,6 @@ import {
 } from "@angular/core";
 
 import { I18n } from "carbon-components-angular/i18n";
-import { IconModule } from "../icon/icon.module";
 
 export enum SnippetType {
 	single = "single",

--- a/src/code-snippet/code-snippet.stories.ts
+++ b/src/code-snippet/code-snippet.stories.ts
@@ -37,6 +37,8 @@ storiesOf("Components|Code Snippet", module).addDecorator(
 ) // that's it, no more after this line
 `;
 
+const singleLineOfCode = `import { UIShellModule } from 'carbon-components-angular'; // Single line of code`;
+
 @Component({
 	selector: "app-dynamic-code-snippet",
 	template: `
@@ -64,9 +66,9 @@ storiesOf("Components|Code Snippet", module).addDecorator(
 )
 	.addDecorator(withKnobs)
 	.add("Basic", () => ({
-		template: `<ibm-code-snippet display="single">{{code}}</ibm-code-snippet>`,
+		template: `<ibm-code-snippet display="single">{{singleCode}}</ibm-code-snippet>`,
 		props: {
-			code
+			singleCode: singleLineOfCode
 		}
 	}))
 	.add("Multi", () => ({

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -11,7 +11,6 @@ import { PlaceholderModule } from "../../placeholder";
 import { DocumentationModule } from "./../../documentation-component/documentation.module";
 import { CheckboxModule } from "../../checkbox";
 
-import { DocumentModule, SettingsModule } from "@carbon/icons-angular";
 import { ViewEncapsulation } from "@angular/core";
 
 let options;

--- a/src/dialog/overflow-menu/overflow-menu.stories.ts
+++ b/src/dialog/overflow-menu/overflow-menu.stories.ts
@@ -10,8 +10,8 @@ import { DialogModule } from "../../dialog";
 import { PlaceholderModule } from "../../placeholder";
 import { DocumentationModule } from "./../../documentation-component/documentation.module";
 import { CheckboxModule } from "../../checkbox";
-
 import { ViewEncapsulation } from "@angular/core";
+import { IconModule } from "../../icon/icon.module";
 
 let options;
 
@@ -28,11 +28,10 @@ storiesOf("Components|Overflow Menu", module)
 		moduleMetadata({
 			imports: [
 				DialogModule,
-				DocumentModule,
 				PlaceholderModule,
 				DocumentationModule,
 				CheckboxModule,
-				SettingsModule
+				IconModule
 			]
 		})
 	)
@@ -149,7 +148,7 @@ storiesOf("Components|Overflow Menu", module)
 					<ibm-overflow-menu-option type="danger" (selected)="selected($event)">Danger option</ibm-overflow-menu-option>
 				</ibm-overflow-menu>
 				<ibm-placeholder></ibm-placeholder>
-				<ng-template #customTrigger><svg ibmIconDocument size="16"></svg></ng-template>
+				<ng-template #customTrigger><svg ibmIcon="document" size="16"></svg></ng-template>
 		`,
 		props: {
 			click: () => console.log("click"),
@@ -210,7 +209,7 @@ storiesOf("Components|Overflow Menu", module)
 				[customPane]="true"
 				placement="bottom"
 				[offset]="{ x: -8, y: 0 }"
-			><svg ibmIconSettings size="16"></svg></button>
+			><svg ibmIcon="settings" size="16"></svg></button>
 			<ng-template #templateRef>
 				<div style="padding: 0 1rem;">
 					<div style="padding-top: 0.5rem; color: grey;">Columns</div>

--- a/src/dialog/tooltip/tooltip.stories.ts
+++ b/src/dialog/tooltip/tooltip.stories.ts
@@ -2,7 +2,6 @@ import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { action } from "@storybook/addon-actions";
 import { withKnobs, text, select } from "@storybook/addon-knobs/angular";
 
-import { InformationFilledModule } from "@carbon/icons-angular";
 import { DialogModule } from "../dialog.module";
 import { TagModule } from "../../tag/tag.module";
 import { PlaceholderModule } from "../../placeholder/index";
@@ -15,7 +14,6 @@ storiesOf("Components|Tooltip", module)
 			imports: [
 				DialogModule,
 				PlaceholderModule,
-				InformationFilledModule,
 				TagModule,
 				DocumentationModule
 			]

--- a/src/dialog/tooltip/tooltip.stories.ts
+++ b/src/dialog/tooltip/tooltip.stories.ts
@@ -4,6 +4,7 @@ import { withKnobs, text, select } from "@storybook/addon-knobs/angular";
 
 import { DialogModule } from "../dialog.module";
 import { TagModule } from "../../tag/tag.module";
+import { IconModule } from "../../icon/icon.module";
 import { PlaceholderModule } from "../../placeholder/index";
 import { DocumentationModule } from "../../documentation-component/documentation.module";
 import { boolean, object } from "@storybook/addon-knobs";
@@ -12,6 +13,7 @@ storiesOf("Components|Tooltip", module)
 	.addDecorator(
 		moduleMetadata({
 			imports: [
+				IconModule,
 				DialogModule,
 				PlaceholderModule,
 				TagModule,
@@ -40,7 +42,7 @@ storiesOf("Components|Tooltip", module)
 						trigger="click"
 						[placement]="placement">
 						<div role="button">
-							<ibm-icon-information-filled size="16"></ibm-icon-information-filled>
+							<svg ibmIcon="information--filled" size="16"></svg>
 						</div>
 					</span>
 				</div>
@@ -166,7 +168,7 @@ storiesOf("Components|Tooltip", module)
 						trigger="click"
 						[placement]="placement">
 						<div role="button">
-							<ibm-icon-information-filled size="16"></ibm-icon-information-filled>
+							<svg ibmIcon="information--filled" size="16"></svg>
 						</div>
 					</span>
 				</div>
@@ -229,7 +231,7 @@ storiesOf("Components|Tooltip", module)
 						trigger="click"
 						[placement]="placement">
 						<div role="button">
-							<ibm-icon-information-filled size="16"></ibm-icon-information-filled>
+							<svg ibmIcon="information--filled" size="16"></svg>
 						</div>
 					</span>
 				</div>

--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -8,8 +8,12 @@ import { IconService } from "./icon.service";
 
 // icon imports
 import Add16 from "@carbon/icons/es/add/16";
-import Subtract16 from "@carbon/icons/es/subtract/16";
+import Add20 from "@carbon/icons/es/add/20";
+import Bee16 from "@carbon/icons/es/bee/16";
+import Bee20 from "@carbon/icons/es/bee/20";
 import Calendar16 from "@carbon/icons/es/calendar/16";
+import Carbon16 from "@carbon/icons/es/carbon/16";
+import Carbon20 from "@carbon/icons/es/carbon/20";
 import CaretDown16 from "@carbon/icons/es/caret--down/16";
 import CaretLeft16 from "@carbon/icons/es/caret--left/16";
 import CaretRight16 from "@carbon/icons/es/caret--right/16";
@@ -23,10 +27,17 @@ import ChevronRight16 from "@carbon/icons/es/chevron--right/16";
 import Close16 from "@carbon/icons/es/close/16";
 import Close20 from "@carbon/icons/es/close/20";
 import Copy16 from "@carbon/icons/es/copy/16";
+import Copy20 from "@carbon/icons/es/copy/20";
+import Data216 from "@carbon/icons/es/data--2/16";
+import Data220 from "@carbon/icons/es/data--2/20";
 import Delete16 from "@carbon/icons/es/delete/16";
+import Document16 from "@carbon/icons/es/document/16";
+import Document20 from "@carbon/icons/es/document/20";
 import Download16 from "@carbon/icons/es/download/16";
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16";
 import ErrorFilled20 from "@carbon/icons/es/error--filled/20";
+import Fade16 from "@carbon/icons/es/fade/16";
+import Fade20 from "@carbon/icons/es/fade/20";
 import InformationFilled16 from "@carbon/icons/es/information--filled/16";
 import InformationFilled20 from "@carbon/icons/es/information--filled/20";
 import Menu16 from "@carbon/icons/es/menu/16";
@@ -36,6 +47,8 @@ import OverflowMenuHorizontal16 from "@carbon/icons/es/overflow-menu--horizontal
 import Save16 from "@carbon/icons/es/save/16";
 import Search16 from "@carbon/icons/es/search/16";
 import Settings16 from "@carbon/icons/es/settings/16";
+import SettingsAdjust16 from "@carbon/icons/es/settings--adjust/16";
+import Subtract16 from "@carbon/icons/es/subtract/16";
 import Warning16 from "@carbon/icons/es/warning/16";
 import WarningFilled16 from "@carbon/icons/es/warning--filled/16";
 import WarningFilled20 from "@carbon/icons/es/warning--filled/20";
@@ -71,8 +84,12 @@ export class IconModule {
 	constructor(protected iconService: IconService) {
 		iconService.registerAll([
 			Add16,
-			Subtract16,
+			Add20,
+			Bee16,
+			Bee20,
 			Calendar16,
+			Carbon16,
+			Carbon20,
 			CaretDown16,
 			CaretLeft16,
 			CaretRight16,
@@ -86,10 +103,17 @@ export class IconModule {
 			Close16,
 			Close20,
 			Copy16,
+			Copy20,
+			Data216,
+			Data220,
 			Delete16,
+			Document16,
+			Document20,
 			Download16,
 			ErrorFilled16,
 			ErrorFilled20,
+			Fade16,
+			Fade20,
 			InformationFilled16,
 			InformationFilled20,
 			Menu16,
@@ -99,6 +123,8 @@ export class IconModule {
 			Save16,
 			Search16,
 			Settings16,
+			SettingsAdjust16,
+			Subtract16,
 			Warning16,
 			WarningFilled16,
 			WarningFilled20,

--- a/src/index.stories.ts
+++ b/src/index.stories.ts
@@ -1,8 +1,8 @@
 import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { Component, OnInit, OnDestroy } from "@angular/core";
 
-import { ButtonModule } from "./";
-
+import { ButtonModule } from "./button";
+import { IconModule } from "./icon/icon.module";
 
 @Component({
 	selector: "app-welcome",
@@ -98,12 +98,12 @@ import { ButtonModule } from "./";
 			<div class="banner__links">
 				<a ibmButton="secondary" href="documentation/index.html" target="_blank">
 					Documentation
-					<svg ibmIconDocument size="20" class="bx--btn__icon"></svg>
+					<svg ibmIcon="document" size="16" class="bx--btn__icon"></svg>
 				</a>
 				&nbsp;
 				<a ibmButton="primary" href="https://github.com/carbon-design-system/carbon-angular-starter" target="_blank">
 					Starter App
-					<svg ibmIconBee size="20" class="bx--btn__icon"></svg>
+					<svg ibmIcon="bee" size="16" class="bx--btn__icon"></svg>
 				</a>
 				&nbsp;
 				<a class="banner__netlify" href="https://www.netlify.com" target="_blank">
@@ -174,8 +174,7 @@ storiesOf("Components|Welcome", module)
 	moduleMetadata({
 		imports: [
 			ButtonModule,
-			BeeModule,
-			DocumentModule
+			IconModule
 		],
 		declarations: [WelcomeStory]
 	})

--- a/src/index.stories.ts
+++ b/src/index.stories.ts
@@ -2,7 +2,7 @@ import { storiesOf, moduleMetadata } from "@storybook/angular";
 import { Component, OnInit, OnDestroy } from "@angular/core";
 
 import { ButtonModule } from "./";
-import { BeeModule, DocumentModule } from "@carbon/icons-angular";
+
 
 @Component({
 	selector: "app-welcome",

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -38,7 +38,7 @@ import { cycleTabs, getFocusElementList } from "carbon-components-angular/common
 						<section class="modal-body">
 							<h1>Sample modal works.</h1>
 							<button class="btn--icon-link" nPopover="Hello there" title="Popover title" placement="right" appendInline="true">
-								<svg ibmIcon="info" size="sm"></ibm-icon>
+								<svg ibmIcon="info" size="sm"></svg>
 							</button>
 							{{modalText}}
 						</section>

--- a/src/package.json
+++ b/src/package.json
@@ -13,8 +13,7 @@
   "license": "Apache-2.0",
   "author": "IBM",
   "peerDependencies": {
-    "carbon-components": "^10.0.0",
-    "@carbon/icons-angular": "11.0.x || >11.1.1"
+    "carbon-components": "^10.0.0"
   },
   "dependencies": {
     "@carbon/icon-helpers": "10.9.0",

--- a/src/patterns/dialogs/modal-with-table.stories.ts
+++ b/src/patterns/dialogs/modal-with-table.stories.ts
@@ -28,7 +28,7 @@ import { LinkModule } from "../../link/index";
 					(valueChange)="onSearch($event)">
 				</ibm-table-toolbar-search>
 				<button ibmButton="ghost" class="toolbar-action" size="sm">
-					<svg size="16" class="bx--toolbar-action__icon" ibmIconData_2></svg>
+					<svg size="16" class="bx--toolbar-action__icon" ibmIcon="Data_2"></svg>
 				</button>
 			</ibm-table-toolbar-content>
 		</ibm-table-toolbar>

--- a/src/patterns/dialogs/modal-with-table.stories.ts
+++ b/src/patterns/dialogs/modal-with-table.stories.ts
@@ -12,7 +12,6 @@ import {
 	TableModel,
 	TableModule
 } from "../../table/index";
-import { Data_2Module } from "@carbon/icons-angular";
 import { ButtonModule } from "../../button/index";
 import { ProgressIndicatorModule } from "../../progress-indicator";
 import { LinkModule } from "../../link/index";
@@ -209,7 +208,6 @@ storiesOf("Patterns|Dialogs", module)
 			imports: [
 				ModalModule,
 				TableModule,
-				Data_2Module,
 				ButtonModule,
 				ProgressIndicatorModule,
 				LinkModule

--- a/src/table/stories/app-function-override-filter-table.component.ts
+++ b/src/table/stories/app-function-override-filter-table.component.ts
@@ -32,10 +32,10 @@ import { TableItem } from "../table-item.class";
 					placement="bottom"
 					[flip]="true"
 					[offset]="{ x: 3, y: 0 }">
-					<ibm-icon-filter size="16" class="bx--toolbar-action__icon"></ibm-icon-filter>
+					<svg ibmIcon="filter" size="16" class="bx--toolbar-action__icon"></svg>
 				</button>
 				<button ibmButton="primary" size="sm">
-					Primary button<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+					Primary button<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
 				</button>
 			</ibm-table-toolbar-content>
 		</ibm-table-toolbar>

--- a/src/table/stories/app-model-filter-table.component.ts
+++ b/src/table/stories/app-model-filter-table.component.ts
@@ -32,10 +32,10 @@ import { TableItem } from "../table-item.class";
 					placement="bottom"
 					[flip]="true"
 					[offset]="{ x: 3, y: 0 }">
-					<ibm-icon-filter size="16" class="bx--toolbar-action__icon"></ibm-icon-filter>
+					<svg ibmIcon="filter" size="16" class="bx--toolbar-action__icon"></svg>
 				</button>
 				<button ibmButton="primary" size="sm">
-					Primary Button<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+					Primary Button<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
 				</button>
 			</ibm-table-toolbar-content>
 		</ibm-table-toolbar>

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -182,15 +182,15 @@ storiesOf("Components|Table", module).addDecorator(
 					<ibm-table-toolbar-actions>
 						<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 							Delete
-							<ibm-icon-delete size="16" class="bx--btn__icon"></ibm-icon-delete>
+							<svg ibmIcon="delete" size="16" class="bx--btn__icon"></svg>
 						</button>
 						<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 							Save
-							<ibm-icon-save size="16" class="bx--btn__icon"></ibm-icon-save>
+							<svg ibmIcon="save" size="16" class="bx--btn__icon"></svg>
 						</button>
 						<button ibmButton="primary" [tabindex]="toolbar.selected ? 0 : -1">
 							Download
-							<ibm-icon-download size="16" class="bx--btn__icon"></ibm-icon-download>
+							<svg ibmIcon="download" size="16" class="bx--btn__icon"></svg>
 						</button>
 					</ibm-table-toolbar-actions>
 					<ibm-table-toolbar-content *ngIf="!toolbar.selected">
@@ -210,7 +210,7 @@ storiesOf("Components|Table", module).addDecorator(
 							<ibm-overflow-menu-option type="danger">Danger option</ibm-overflow-menu-option>
 						</ibm-overflow-menu>
 						<button ibmButton="primary" size="sm" [tabindex]="toolbar.selected ? -1 : 0">
-							Primary button<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+							Primary button<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
 						</button>
 					</ibm-table-toolbar-content>
 				</ibm-table-toolbar>
@@ -229,7 +229,7 @@ storiesOf("Components|Table", module).addDecorator(
 					[stickyHeader]="stickyHeader"
 					[isDataGrid]="isDataGrid">
 				</app-table>
-				<ng-template #customTrigger><svg ibmIconSettings size="16"></svg></ng-template>
+				<ng-template #customTrigger><svg ibmIcon="settings" size="16"></svg></ng-template>
 			</ibm-table-container>
 		</section>
 	`,
@@ -258,24 +258,24 @@ storiesOf("Components|Table", module).addDecorator(
 				<ibm-table-toolbar-actions>
 					<button ibmButton="primary">
 						Delete
-						<ibm-icon-delete size="16" class="bx--btn__icon"></ibm-icon-delete>
+						<svg ibmIcon="delete" size="16" class="bx--btn__icon"></svg>
 					</button>
 					<button ibmButton="primary">
 						Save
-						<ibm-icon-save size="16" class="bx--btn__icon"></ibm-icon-save>
+						<svg ibmIcon="save" size="16" class="bx--btn__icon"></svg>
 					</button>
 					<button ibmButton="primary">
 						Download
-						<ibm-icon-download size="16" class="bx--btn__icon"></ibm-icon-download>
+						<svg ibmIcon="download" size="16" class="bx--btn__icon"></svg>
 					</button>
 				</ibm-table-toolbar-actions>
 				<ibm-table-toolbar-content *ngIf="!toolbar.selected">
 					<ibm-table-toolbar-search [expandable]="true"></ibm-table-toolbar-search>
 					<button ibmButton="ghost" class="toolbar-action">
-						<ibm-icon-settings size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
+						<svg ibmIcon="settings" size="16" class="bx--toolbar-action__icon"></svg>
 					</button>
 					<button ibmButton="primary" size="sm">
-						Primary button<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+						Primary button<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
 					</button>
 				</ibm-table-toolbar-content>
 			</ibm-table-toolbar>
@@ -318,10 +318,10 @@ storiesOf("Components|Table", module).addDecorator(
 				<ibm-table-toolbar-content>
 					<ibm-table-toolbar-search [expandable]="true"></ibm-table-toolbar-search>
 					<button ibmButton="ghost" class="toolbar-action">
-						<ibm-icon-settings size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
+						<svg ibmIcon="settings" size="16" class="bx--toolbar-action__icon"></svg>
 					</button>
 					<button ibmButton="primary" size="sm">
-						Primary button<ibm-icon-add size="20" class="bx--btn__icon"></ibm-icon-add>
+						Primary button<svg ibmIcon="add" size="20" class="bx--btn__icon"></svg>
 					</button>
 				</ibm-table-toolbar-content>
 			</ibm-table-toolbar>

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -21,14 +21,6 @@ import { NFormsModule, ButtonModule } from "../forms/index";
 import { DialogModule } from "../dialog/index";
 import { SearchModule } from "../search/index";
 
-import {
-	SettingsModule,
-	DeleteModule,
-	FilterModule,
-	SaveModule,
-	DownloadModule,
-	AddModule
-} from "@carbon/icons-angular";
 
 import {
 	TableStory,
@@ -93,15 +85,9 @@ storiesOf("Components|Table", module).addDecorator(
 				NFormsModule,
 				TableModule,
 				DialogModule,
-				FilterModule,
 				PaginationModule,
 				SearchModule,
 				ButtonModule,
-				SettingsModule,
-				DeleteModule,
-				SaveModule,
-				DownloadModule,
-				AddModule,
 				DocumentationModule
 			],
 			declarations: [

--- a/src/table/toolbar/table-toolbar.component.ts
+++ b/src/table/toolbar/table-toolbar.component.ts
@@ -32,7 +32,7 @@ import { TableRowSize } from "../table.types";
  *			<ibm-table-toolbar-content>
  *			<ibm-table-toolbar-search [expandable]="true"></ibm-table-toolbar-search>
  *			<button ibmButton="toolbar-action">
- *				<svg ibmIcon="settings" size="16" class="bx--toolbar-action__icon"></ibm-icon-settings>
+ *				<svg ibmIcon="settings" size="16" class="bx--toolbar-action__icon"></svg>
  *			</button>
  *			<button ibmButton="primary" size="sm">
  *				Primary Button

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -8,6 +8,7 @@ import { DialogModule } from "./../dialog/index";
 import { DocumentationModule } from "./../documentation-component/documentation.module";
 import { Component, Input } from "@angular/core";
 import { RouterModule } from "@angular/router";
+import { IconModule } from "../icon/icon.module";
 
 
 @Component({
@@ -47,6 +48,7 @@ storiesOf("Components|UI Shell", module)
 		moduleMetadata({
 			declarations: [BarComponent, FooComponent, HeaderFluidComponent],
 			imports: [
+				IconModule,
 				UIShellModule,
 				SearchModule,
 				DialogModule,
@@ -84,10 +86,10 @@ storiesOf("Components|UI Shell", module)
 				</ibm-header-navigation>
 				<ibm-header-global>
 					<ibm-header-action title="action">
-						<svg icon ibmIconFade size="20"></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 					<ibm-header-action title="action">
-						<svg icon ibmIconFade size="20"></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 				</ibm-header-global>
 			</ibm-header>
@@ -154,17 +156,17 @@ storiesOf("Components|UI Shell", module)
 				</ibm-header-navigation>
 				<ibm-header-global>
 					<ibm-header-action title="action">
-						<svg ibmIconFade size="20"></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 					<ibm-header-action title="action">
-						<svg icon ibmIconFade size="20"></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 				</ibm-header-global>
 			</ibm-header>
 
 			<ng-template #brandTemplate>
 				<a class="bx--header__name">
-					<ibm-icon-carbon size="32" style="stroke:white;fill:white"></ibm-icon-carbon>
+					<svg ibmIcon="carbon" size="32" style="stroke:white;fill:white"></svg>
 					<span class="bx--header__name--prefix">IBM</span>
 					[Platform]
 				</a>
@@ -201,15 +203,15 @@ storiesOf("Components|UI Shell", module)
 		template: `
 			<ibm-sidenav>
 				<ibm-sidenav-item>
-					<svg ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-item>
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-menu title="Category title">
-					<ibm-icon-fade icon size="16"></ibm-icon-fade>
+					<svg ibmIcon="fade" size="16"></svg>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
@@ -237,15 +239,15 @@ storiesOf("Components|UI Shell", module)
 		template: `
 			<ibm-sidenav>
 				<ibm-sidenav-item [route]="['foo']">
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-item [route]="['bar']">
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-menu title="Category title">
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					<ibm-sidenav-item [route]="['foo']">Link</ibm-sidenav-item>
 					<ibm-sidenav-item [route]="['bar']">Link</ibm-sidenav-item>
 					<ibm-sidenav-item [route]="['foo']">Link</ibm-sidenav-item>
@@ -287,24 +289,24 @@ storiesOf("Components|UI Shell", module)
 				</ibm-header-navigation>
 				<ibm-header-global>
 					<ibm-header-action #firstAction title="action">
-						<svg icon ibmIconFade size="20" ></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 					<ibm-header-action [(active)]="secondAction" title="action">
-						<svg icon ibmIconFade size="20" ></svg>
+						<svg ibmIcon="fade" size="20"></svg>
 					</ibm-header-action>
 				</ibm-header-global>
 			</ibm-header>
 			<ibm-sidenav [expanded]="active">
 				<ibm-sidenav-item>
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-item>
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-menu title="Category title">
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
 					<ibm-sidenav-item [active]="hasActiveChild">Link</ibm-sidenav-item>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
@@ -345,15 +347,15 @@ storiesOf("Components|UI Shell", module)
 		template: `
 			<ibm-sidenav rail="true" [expanded]="false">
 				<ibm-sidenav-item>
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-item>
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					Link
 				</ibm-sidenav-item>
 				<ibm-sidenav-menu title="Category title">
-					<svg icon ibmIconFade size="16"></svg>
+					<svg ibmIcon="fade" size="16"></svg>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>
 					<ibm-sidenav-item>Link</ibm-sidenav-item>

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -8,10 +8,6 @@ import { DialogModule } from "./../dialog/index";
 import { DocumentationModule } from "./../documentation-component/documentation.module";
 import { Component, Input } from "@angular/core";
 import { RouterModule } from "@angular/router";
-import {
-	CarbonModule,
-	FadeModule
-} from "@carbon/icons-angular";
 
 
 @Component({
@@ -51,10 +47,8 @@ storiesOf("Components|UI Shell", module)
 		moduleMetadata({
 			declarations: [BarComponent, FooComponent, HeaderFluidComponent],
 			imports: [
-				UIShellModule,
-				CarbonModule,
-				SearchModule,
-				FadeModule,
+				UIShellModule,				
+				SearchModule,				
 				DialogModule,
 				DocumentationModule,
 				RouterModule.forRoot([

--- a/src/ui-shell/ui-shell.stories.ts
+++ b/src/ui-shell/ui-shell.stories.ts
@@ -47,8 +47,8 @@ storiesOf("Components|UI Shell", module)
 		moduleMetadata({
 			declarations: [BarComponent, FooComponent, HeaderFluidComponent],
 			imports: [
-				UIShellModule,				
-				SearchModule,				
+				UIShellModule,
+				SearchModule,
 				DialogModule,
 				DocumentationModule,
 				RouterModule.forRoot([


### PR DESCRIPTION
This uses latest v11 version of @angular/cli
This is because the latest @angular/cli version is 12+ and @carbon/icons-angular complains about dependencies. It needs @angular/cli from v7 to v11.

And this fixes following the readme Getting started. Project now successfully builds.

#### Changelog

**New**

* README - Getting started now uses angular latest v11

**Changed**

* Changed the README.md
