### PR TITLE
fix(combobox): don't trigger search for type 'single' on items change…

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -454,10 +454,12 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	ngOnChanges(changes) {
 		if (changes.items) {
 			this.view.items = changes.items.currentValue;
-			// If new items are added into the combobox while there is search input,
-			// repeat the search.
-			this.onSearch(this.input.nativeElement.value, false);
 			this.updateSelected();
+			// If new items are added into the combobox while there is search input,
+			// repeat the search. Search should only trigger for type 'single' when there is no value selected.
+			if ( this.type === "multi" || (this.type === "single" && !this.selectedValue)) {
+				this.onSearch(this.input.nativeElement.value, false);
+			}
 		}
 	}
 


### PR DESCRIPTION
…s if there is a selected value

Closes IBM/carbon-components-angular#1733

When items are changed it is triggering a search and filtering items based on  the native input element value. For type "single" comboboxes this means the selected value is used to filter the list. Added a condition to prevent this from happening for comboboxes with type 'single' if there is a selected value. 

See scenario to reproduce in linked issue

#### Changelog

**Changed**

* ngOnChanges
