### PR TITLE
fix(table-toolbar-search): fixing styling issue with latest carbon-components

### DIFF
--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -6,11 +6,13 @@
 		'bx--search--xl': size === 'xl',
 		'bx--search--light': theme === 'light',
 		'bx--skeleton': skeleton,
-		'bx--toolbar-search': toolbar && !tableSearch,
-		'bx--toolbar-search--active': toolbar && !tableSearch && active,
-		'bx--toolbar-search-container-persistent': tableSearch && !toolbar,
-		'bx--toolbar-search-container-expandable': tableSearch && toolbar,
-		'bx--toolbar-search-container-active': tableSearch && toolbar && active
+		'bx--search--expandable': expandable && !tableSearch,
+		'bx--search--expanded': expandable && !tableSearch && active,
+		'bx--toolbar-search': toolbar && !expandable,
+		'bx--toolbar-search--active': toolbar && !expandable && active,
+		'bx--toolbar-search-container-persistent': tableSearch && !expandable,
+		'bx--toolbar-search-container-expandable': tableSearch && expandable,
+		'bx--toolbar-search-container-active': tableSearch && expandable && active
 	}"
 	role="search"
 	[attr.aria-label]="ariaLabel"

--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -6,8 +6,11 @@
 		'bx--search--xl': size === 'xl',
 		'bx--search--light': theme === 'light',
 		'bx--skeleton': skeleton,
-		'bx--toolbar-search': toolbar,
-		'bx--toolbar-search--active': toolbar && active
+		'bx--toolbar-search': toolbar && !tableSearch,
+		'bx--toolbar-search--active': toolbar && !tableSearch && active,
+		'bx--toolbar-search-container-persistent': tableSearch && !toolbar,
+		'bx--toolbar-search-container-expandable': tableSearch && toolbar,
+		'bx--toolbar-search-container-active': tableSearch && toolbar && active
 	}"
 	role="search"
 	[attr.aria-label]="ariaLabel"

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -60,6 +60,7 @@ export class Search implements ControlValueAccessor {
 	@Input() toolbar = false;
 	/**
 	 * Set to `true` to make the search component expandable.
+	 * `expandable` would override `toolbar` property behaviours.
 	 */
 	@Input() expandable = false;
 	/**

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -33,7 +33,7 @@ export class Search implements ControlValueAccessor {
 	 */
 	static searchCount = 0;
 
-	@HostBinding("class.bx--form-item") get containerClass() { return !this.toolbar; }
+	@HostBinding("class.bx--form-item") get containerClass() { return !(this.toolbar || this.expandable); }
 
 	/**
 	 * `light` or `dark` search theme.
@@ -58,6 +58,10 @@ export class Search implements ControlValueAccessor {
 	 * Set to `true` for a toolbar search component.
 	 */
 	@Input() toolbar = false;
+	/**
+	 * Set to `true` to make the search component expandable.
+	 */
+	@Input() expandable = false;
 	/**
 	 * Set to `true` for a loading search component.
 	 */
@@ -217,7 +221,7 @@ export class Search implements ControlValueAccessor {
 
 	@HostListener("keydown", ["$event"])
 	keyDown(event: KeyboardEvent) {
-		if (this.toolbar) {
+		if (this.toolbar || this.expandable) {
 			if (event.key === "Escape") {
 				this.active = false;
 			} else if (event.key === "Enter") {
@@ -229,10 +233,10 @@ export class Search implements ControlValueAccessor {
 	@HostListener("focusout", ["$event"])
 	focusOut(event) {
 		this.onTouched();
-		if (this.toolbar &&
+		if ((this.expandable || this.toolbar) &&
 			this.inputRef &&
 			this.inputRef.nativeElement.value === "" &&
-			event.relatedTarget === null) {
+			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget)) {
 			this.active = false;
 			this.open.emit(this.active);
 		}

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -38,6 +38,29 @@ storiesOf("Components|Search", module).addDecorator(
 			clear: action("clear fired!")
 		}
 	}))
+	.add("Expandable", () => ({
+		template: `
+			<ibm-search
+				[expandable]="true"
+				[theme]="theme"
+				[placeholder]="placeholder"
+				[autocomplete]="autocomplete"
+				[disabled]="disabled"
+				[size]="size"
+				(valueChange)="valueChange($event)"
+				(clear)="clear()">
+			</ibm-search>
+		`,
+		props: {
+			size: select("size", ["sm", "md", "xl"], "md"),
+			theme: select("theme", ["dark", "light"], "dark"),
+			disabled: boolean("disabled", false),
+			autocomplete: text("autocomplete", "on"),
+			placeholder: text("placeholder", "Search"),
+			valueChange: action("value change fired!"),
+			clear: action("clear fired!")
+		}
+	}))
 	.add("Toolbar search", () => ({
 		template: `
 		<div class="bx--toolbar">

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -210,7 +210,7 @@ storiesOf("Components|Table", module).addDecorator(
 					<ibm-table-toolbar-content *ngIf="!toolbar.selected">
 						<ibm-table-toolbar-search
 							ngDefaultControl
-							[expandable]="true"
+							[expandable]="searchExpandable"
 							[(ngModel)]="searchModel">
 						</ibm-table-toolbar-search>
 						<ibm-overflow-menu
@@ -253,6 +253,7 @@ storiesOf("Components|Table", module).addDecorator(
 			},
 			description: text("Description", "With toolbar"),
 			searchModel: text("Search model", "Initial search value"),
+			searchExpandable: boolean("Expandable Search", true),
 			enableSingleSelect: boolean("Enable single select", false),
 			batchText: object("Toolbar batch text", {
 				SINGLE: "1 item selected",

--- a/src/table/toolbar/table-toolbar-search.component.ts
+++ b/src/table/toolbar/table-toolbar-search.component.ts
@@ -19,19 +19,10 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 		}
 	]
 })
-export class TableToolbarSearch extends Search implements OnInit, AfterViewInit {
+export class TableToolbarSearch extends Search implements AfterViewInit {
 	tableSearch = true;
 
-	@Input() expandable = false;
-
 	@HostBinding("class.bx--toolbar-content") hostClass = true;
-
-	ngOnInit() {
-		this.size = "xl";
-		if (this.expandable) {
-			this.toolbar = true;
-		}
-	}
 
 	ngAfterViewInit() {
 		setTimeout(() => {

--- a/src/table/toolbar/table-toolbar-search.component.ts
+++ b/src/table/toolbar/table-toolbar-search.component.ts
@@ -22,16 +22,12 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 export class TableToolbarSearch extends Search implements OnInit, AfterViewInit {
 	tableSearch = true;
 
-	@HostBinding("class.bx--toolbar-search-container-expandable") @Input() expandable = false;
+	@Input() expandable = false;
 
-	@HostBinding("class.bx--toolbar-search-container-persistent") get persistentClass() { return !this.expandable; }
-
-	@HostBinding("class.bx--toolbar-search-container-active") get activeClass() {
-		return this.active && (this.value !== null || this.value !== "");
-	}
+	@HostBinding("class.bx--toolbar-content") hostClass = true;
 
 	ngOnInit() {
-		this.size = "sm";
+		this.size = "xl";
 		if (this.expandable) {
 			this.toolbar = true;
 		}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1856

Fixing styling issues with table-toolbar-search when using latest styling from carbon-components

#### Changelog

**Changed**

* moved relevant classes into search component
* show toolbar classes only when search is only in toolbar mode
* moved `expandable` property into search component and applied new classes from carbon styles
* fixed issue with close on blur when focusing a focusable element (eg a button) outside the search component which wasn't closing the expandable search
