### PR TITLE
fix(number-input): Setting ariaLabel as a directive for number input

### DIFF
--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -65,6 +65,7 @@ export class NumberChange {
 					[attr.step]="step"
 					[disabled]="disabled"
 					[required]="required"
+					[attr.aria-label]="ariaLabel"
 					(input)="onNumberInputChange($event)"/>
 				<svg
 					*ngIf="!skeleton && !warn && invalid"
@@ -209,6 +210,10 @@ export class NumberComponent implements ControlValueAccessor {
 	 * Sets the warning text
 	 */
 	@Input() warnText: string | TemplateRef<any>;
+	/**
+	 * Sets the arialabel for input
+	 */
+	@Input() ariaLabel: string;
 	/**
 	 * Emits event notifying other classes when a change in state occurs in the input.
 	 */


### PR DESCRIPTION
Adds ariaLabel as a directive for the number input component

#### Changelog

**New**

* Number input component now can receive ariaLabel directive, which value will be passed as aria-label to the input tag. 
