### PR TITLE
#1865 Added item title to dropdown-list.component

### DIFF
--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -65,6 +65,7 @@ import { ScrollCustomEvent } from "./scroll-custom-event.interface";
 				class="bx--list-box__menu-item"
 				[attr.aria-selected]="item.selected"
 				[id]="getItemId(i)"
+				[title]="item.content"
 				[ngClass]="{
 					'bx--list-box__menu-item--active': item.selected,
 					'bx--list-box__menu-item--highlighted': highlightedItem === getItemId(i),


### PR DESCRIPTION
#1865 
Added item title to dropdown list. Title were in the code before, but they were removed by this change: https://github.com/IBM/carbon-components-angular/commit/4e7a5b95bd6b4385327b1254dacf59b4027c720e#diff-706d42b7488bc5798a1d6c651e13f184b3e173958dd7f2ff8198bab0063ad818

I consider missing title attribute in <li> elements  as bug and our customers want it back.
I find issue related to this (#1865 ).

