### PR TITLE
1911 combobox should disable native input autocomplete

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -336,7 +336,8 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	 */
 	@Input() selectionFeedback: "top" | "fixed" | "top-after-reopen" = "top-after-reopen";
 	/**
-	 * Specify autocomplete attribute of text input
+	 * Specify aria-autocomplete attribute of text input.
+	 * "list", is the expected value for a combobox that invokes a drop-down list
 	 */
 	@Input() autocomplete = "list";
 	/**

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -93,6 +93,7 @@ import { Observable } from "rxjs";
 					<input
 						#input
 						type="text"
+						autocomplete="off"
 						role="combobox"
 						[disabled]="disabled"
 						(input)="onSearch($event.target.value)"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1911

fix autocomplete attribute for native `<input>` element inside `<ibm-combo-box>` component

#### Changelog

**New**

* add `autocomplete="off"` to `<input>`

**Changed**

* updated comments
