### PR TITLE
fix(table): Allow setting of `title: ""` to hide the default cell tooltip

### DIFF
--- a/src/table/table-item.class.ts
+++ b/src/table/table-item.class.ts
@@ -107,7 +107,7 @@ export class TableItem {
 	colSpan = 1;
 
 	get title() {
-		if (this._title) {
+		if (typeof this._title === "string") {
 			return this._title;
 		}
 


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1914


#### Changelog

**Changed**

* Changed comparison to be aware of empty strings

