### PR TITLE
Update button.types.ts: support button type 'normal'

### DIFF
--- a/src/button/button.types.ts
+++ b/src/button/button.types.ts
@@ -1,4 +1,4 @@
 export type DangerButtonType = "danger--primary" | "danger--tertiary" | "danger--ghost";
 export type ButtonType = "primary" | "secondary" | "tertiary" | "ghost" | "danger" | DangerButtonType | "toolbar-action";
 
-export type ButtonSize = "sm" | "field" | "lg" | "xl";
+export type ButtonSize = "sm" | "field" | "normal" |  "lg" | "xl";


### PR DESCRIPTION

Closes IBM/carbon-components-angular#

Button type 'normal' is not supported in the last version but present in the published storybook version of the library

#### Changelog

**Changed**

* include button type 'normal'

