### PR TITLE
chore: Fix missing context-menu in index.ts, resolves #1925

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "carbon-components-angular/checkbox";
 export * from "carbon-components-angular/code-snippet";
 export * from "carbon-components-angular/combobox";
 export * from "carbon-components-angular/content-switcher";
+export * from "carbon-components-angular/context-menu";
 export * from "carbon-components-angular/datepicker";
 export * from "carbon-components-angular/datepicker-input";
 export * from "carbon-components-angular/dialog";


### PR DESCRIPTION
Corrected the package so ContextMenuModule can be used.
