### PR TITLE
fix(loading): update loading icon size

### DIFF
--- a/src/inline-loading/inline-loading.component.ts
+++ b/src/inline-loading/inline-loading.component.ts
@@ -35,9 +35,9 @@ export enum InlineLoadingState {
 				[ngClass]="{
 					'bx--loading--stop': state === InlineLoadingState.Inactive
 				}">
-				<svg class="bx--loading__svg" viewBox="-75 -75 150 150">
-					<circle class="bx--loading__background" cx="0" cy="0" r="30" />
-					<circle class="bx--loading__stroke" cx="0" cy="0" r="30" />
+				<svg class="bx--loading__svg" viewBox="0 0 100 100">
+					<circle class="bx--loading__background" cx="50%" cy="50%" r="44" />
+					<circle class="bx--loading__stroke" cx="50%" cy="50%" r="44" />
 				</svg>
 			</div>
 			<svg

--- a/src/loading/loading.component.ts
+++ b/src/loading/loading.component.ts
@@ -16,9 +16,9 @@ import { I18n } from "carbon-components-angular/i18n";
 				'bx--loading-overlay--stop': !isActive && overlay
 			}"
 			class="bx--loading">
-			<svg class="bx--loading__svg" viewBox="-75 -75 150 150">
+			<svg class="bx--loading__svg" viewBox="0 0 100 100">
 				<title>{{title}}</title>
-				<circle class="bx--loading__stroke" cx="0" cy="0" r="37.5" />
+				<circle class="bx--loading__stroke" cx="50%" cy="50%" r="44" />
 			</svg>
 		</div>
 	`


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Update loading icon size to be consistent with Carbon React. https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Loading/Loading.js

Before:

![image](https://user-images.githubusercontent.com/34791554/145692663-4e51bf49-3988-42ce-9c99-eb0bc8931d2f.png)

After:

![image](https://user-images.githubusercontent.com/34791554/145692666-0233fd44-1ab5-4089-890c-84ec972a58b1.png)

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
