### PR TITLE
fix(datepicker): reduce flatpickr reset on changes

### DIFF
--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -305,18 +305,17 @@ export class DatePicker implements
 
 	ngOnChanges(changes: SimpleChanges) {
 		// Reset the flatpickr instance on input changes that affect flatpickr.
-		const resetOnInputs = [
+		const flatpickrChangeKeys = [
 			"range",
 			"dateFormat",
 			"language",
 			"id",
 			"value",
-			"theme",
 			"plugins",
 			"flatpickrOptions"
 		];
 		const changeKeys = Object.keys(changes);
-		if (changeKeys.some(key => resetOnInputs.includes(key))) {
+		if (changeKeys.some(key => flatpickrChangeKeys.includes(key))) {
 			this.resetFlatpickrInstance(changes.value);
 		}
 	}

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -298,13 +298,27 @@ export class DatePicker implements
 		if (this.i18n.getLocale() !== "en") {
 			this.i18n.getLocaleObservable().subscribe(locale => {
 				this.language = locale;
-				this.resetFlackpickrInstance();
+				this.resetFlatpickrInstance();
 			});
 		}
 	}
 
 	ngOnChanges(changes: SimpleChanges) {
-		this.resetFlackpickrInstance(changes.value);
+		// Reset the flatpickr instance on input changes that affect flatpickr.
+		const resetOnInputs = [
+			"range",
+			"dateFormat",
+			"language",
+			"id",
+			"value",
+			"theme",
+			"plugins",
+			"flatpickrOptions"
+		];
+		const changeKeys = Object.keys(changes);
+		if (changeKeys.some(key => resetOnInputs.includes(key))) {
+			this.resetFlatpickrInstance(changes.value);
+		}
 	}
 
 	ngAfterViewInit() {
@@ -523,7 +537,7 @@ export class DatePicker implements
 	 *
 	 * @param newDates An optional SimpleChange of date values
 	 */
-	protected resetFlackpickrInstance(newDates?: SimpleChange) {
+	protected resetFlatpickrInstance(newDates?: SimpleChange) {
 		if (this.isFlatpickrLoaded()) {
 			let dates = this.flatpickrInstance.selectedDates;
 			if (newDates && this.didDateValueChange(newDates.currentValue, newDates.previousValue)) {


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Currently, the date picker component resets the flatpickr instance on all input changes. This is unnecessary for input changes irrelevant to flatpickr, and can cause problems in some cases esp. for range date picker. For example, if the caller updates the validation status when the user selects a start date, then the flatpickr instance will be reset (destroyed) before the user can select an end date.

This PR limits the reset to relevant input changes only.

#### Changelog

**New**

* {{new thing}}

**Changed**

* {{change thing}}

**Removed**

* {{removed thing}}
