### PR TITLE
fix(radio-group): fix reactive form set value not always working

### DIFF
--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -102,6 +102,9 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	 */
 	@Input()
 	set selected(selected: Radio | null) {
+		if (this._selected) {
+			this._selected.checked = false;
+		}
 		this._selected = selected;
 		this.value = selected ? selected.value : null;
 		this.checkSelectedRadio();
@@ -225,6 +228,9 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	updateSelectedRadioFromValue() {
 		let alreadySelected = this._selected != null && this._selected.value === this._value;
 		if (this.radios && !alreadySelected) {
+			if (this.selected) {
+				this.selected.checked = false;
+			}
 			this._selected = null;
 			this.radios.forEach(radio => {
 				if (radio.checked || radio.value === this._value) {
@@ -330,6 +336,10 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	protected updateRadioChangeHandler() {
 		this.radios.forEach(radio => {
 			radio.registerRadioChangeHandler((event: RadioChange) => {
+				// deselect previous radio
+				if (this.selected) {
+					this.selected.checked = false;
+				}
 				// update selected and value from the event
 				this._selected = event.source;
 				this._value = event.value;


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1968

RadioGroup wasn't clearing previous radio `checked` status which was resulting in updating the wrong selection at line 237 as multiple items in the array were having `checked` set to `true`

#### Changelog

**Changed**

* RadioGroup now clears previous `checked` status when a new radio in the group is selected
