### PR TITLE
Fix not touched on focus out

### DIFF
--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -8,7 +8,8 @@ import {
 	Output,
 	QueryList,
 	HostBinding,
-	AfterViewInit
+	AfterViewInit,
+	HostListener
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
 import { Radio } from "./radio.component";
@@ -309,6 +310,11 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	 */
 	public registerOnTouched(fn: any) {
 		this.onTouched = fn;
+	}
+
+	@HostListener("focusout")
+	focusOut() {
+		this.onTouched();
 	}
 
 	/**


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Added focuout listerner on host to mark the form control as touched

#### Changelog

**Changed**

* Now RadioGroup correctly marks itself as touched when focus leaves the component without any change
