### PR TITLE
fix(pagination): add bx--btn__icon to caret svgs

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -165,7 +165,7 @@ export interface PaginationTranslations {
 					[attr.aria-label]="backwardText.subject | async"
 					(click)="selectPage.emit(previousPage)"
 					[disabled]="(currentPage <= 1 || disabled ? true : null)">
-					<svg ibmIcon="caret--left" size="16"></svg>
+					<svg ibmIcon="caret--left" size="16" class="bx--btn__icon"></svg>
 				</button>
 
 				<button
@@ -181,7 +181,7 @@ export interface PaginationTranslations {
 					[attr.aria-label]="forwardText.subject | async"
 					(click)="selectPage.emit(nextPage)"
 					[disabled]="(currentPage >= lastPage || disabled ? true : null)">
-					<svg ibmIcon="caret--right" size="16"></svg>
+					<svg ibmIcon="caret--right" size="16" class="bx--btn__icon"></svg>
 				</button>
 			</div>
 		</div>


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

Add `bx--btn__icon` to caret svgs to match Carbon React. Without this fix, the left/right icons look pretty small with latest Carbon styles.

**Before:**

![image](https://user-images.githubusercontent.com/34791554/151639851-284d6405-7a15-4cae-97f2-46efab7d5225.png)

**After:**

![image](https://user-images.githubusercontent.com/34791554/151639865-5363664a-49ac-4d73-9459-e61164735dcf.png)

**Carbon Design:**

![image](https://user-images.githubusercontent.com/34791554/151639955-42f040e3-7fee-4362-8e64-801f7efcb302.png)
