### PR TITLE
fix(file uploader): prevent filesChange from emitting twice

### DIFF
--- a/src/file-uploader/file-uploader.component.ts
+++ b/src/file-uploader/file-uploader.component.ts
@@ -260,11 +260,15 @@ export class FileUploader {
 	}
 
 	removeFile(fileItem) {
+		let shouldEmit = true;
 		if (this.files) {
+			shouldEmit = this.files.has(fileItem);
 			this.files.delete(fileItem);
 		}
 		this.fileInput.nativeElement.value = "";
-		this.filesChange.emit(this.files);
+		if (shouldEmit) {
+			this.filesChange.emit(this.files);
+		}
 	}
 
 	public isTemplate(value) {


### PR DESCRIPTION
Closes #1939 

If `multiple` is set to `false`, `removeFile` gets called due to `files` being cleared in `onFilesAdded`. This is because in the file item component, onDestroy emits remove which then calls removeFile. It does this to be able to trick the input into detecting a change when same files are uploaded after being deleted in the past through the model (files). This PR prevents removeFile from emitting filesChange if a file was removed through onFilesAdded. The component also used to emit filesChange when a file item was manually removed from files outside of the component, it no longer does that. This was inconsistent because if you manually update the files input from outside of the component in any other way (adding items) it did not emit filesChange.
