### PR TITLE
fix(radio-group): fixed radio getting deselected on second click

### DIFF
--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -103,12 +103,15 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	 */
 	@Input()
 	set selected(selected: Radio | null) {
-		if (this._selected) {
-			this._selected.checked = false;
+		const alreadySelected = (this._selected && this._selected.value) === (selected && selected.value);
+		if (!alreadySelected) {
+			if (this._selected) {
+				this._selected.checked = false;
+			}
+			this._selected = selected;
+			this.value = selected ? selected.value : null;
+			this.checkSelectedRadio();
 		}
-		this._selected = selected;
-		this.value = selected ? selected.value : null;
-		this.checkSelectedRadio();
 	}
 
 	/**
@@ -229,7 +232,7 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	updateSelectedRadioFromValue() {
 		let alreadySelected = this._selected != null && this._selected.value === this._value;
 		if (this.radios && !alreadySelected) {
-			if (this.selected) {
+			if (this.selected && this.value) {
 				this.selected.checked = false;
 			}
 			this._selected = null;
@@ -342,15 +345,17 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	protected updateRadioChangeHandler() {
 		this.radios.forEach(radio => {
 			radio.registerRadioChangeHandler((event: RadioChange) => {
-				// deselect previous radio
-				if (this.selected) {
-					this.selected.checked = false;
+				if (this.value !== event.value) {
+					// deselect previous radio
+					if (this.selected) {
+						this.selected.checked = false;
+					}
+					// update selected and value from the event
+					this._selected = event.source;
+					this._value = event.value;
+					// bubble the event
+					this.emitChangeEvent(event);
 				}
-				// update selected and value from the event
-				this._selected = event.source;
-				this._value = event.value;
-				// bubble the event
-				this.emitChangeEvent(event);
 			});
 		});
 	}

--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -348,7 +348,7 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	protected updateRadioChangeHandler() {
 		this.radios.forEach(radio => {
 			radio.registerRadioChangeHandler((event: RadioChange) => {
-				if (this.selected.value !== event.value) {
+				if ((this.selected && this.selected.value) !== event.value) {
 					// deselect previous radio
 					if (this.selected) {
 						this.selected.checked = false;

--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -241,6 +241,9 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 					this._selected = radio;
 				}
 			});
+			if (this.selected && !this.value) {
+				this._value = this.selected.value;
+			}
 		}
 	}
 
@@ -345,7 +348,7 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	protected updateRadioChangeHandler() {
 		this.radios.forEach(radio => {
 			radio.registerRadioChangeHandler((event: RadioChange) => {
-				if (this.value !== event.value) {
+				if (this.selected.value !== event.value) {
 					// deselect previous radio
 					if (this.selected) {
 						this.selected.checked = false;

--- a/src/radio/radio-group.component.ts
+++ b/src/radio/radio-group.component.ts
@@ -104,14 +104,17 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	@Input()
 	set selected(selected: Radio | null) {
 		const alreadySelected = (this._selected && this._selected.value) === (selected && selected.value);
-		if (!alreadySelected) {
-			if (this._selected) {
-				this._selected.checked = false;
-			}
-			this._selected = selected;
-			this.value = selected ? selected.value : null;
-			this.checkSelectedRadio();
+		if (alreadySelected) {
+			// no need to redo
+			return;
 		}
+
+		if (this._selected) {
+			this._selected.checked = false;
+		}
+		this._selected = selected;
+		this.value = selected ? selected.value : null;
+		this.checkSelectedRadio();
 	}
 
 	/**
@@ -348,17 +351,19 @@ export class RadioGroup implements AfterContentInit, AfterViewInit, ControlValue
 	protected updateRadioChangeHandler() {
 		this.radios.forEach(radio => {
 			radio.registerRadioChangeHandler((event: RadioChange) => {
-				if ((this.selected && this.selected.value) !== event.value) {
-					// deselect previous radio
-					if (this.selected) {
-						this.selected.checked = false;
-					}
-					// update selected and value from the event
-					this._selected = event.source;
-					this._value = event.value;
-					// bubble the event
-					this.emitChangeEvent(event);
+				if ((this.selected && this.selected.value) === event.value) {
+					// no need to redo
+					return;
 				}
+				// deselect previous radio
+				if (this.selected) {
+					this.selected.checked = false;
+				}
+				// update selected and value from the event
+				this._selected = event.source;
+				this._value = event.value;
+				// bubble the event
+				this.emitChangeEvent(event);
 			});
 		});
 	}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#1986

Fixed bad radio button behaviour letting the user deselect the value clicking a second time.
Also fixed initial `[checked]="true"` property on radio being overridden.

#### Changelog

**Changed**

* fixed ability to deselect radio button (shouldn't be allowed)