### PR TITLE
fix(IconDirective): fixed typo that was ignoring IconDescriptor width

### DIFF
--- a/src/icon/icon.directive.ts
+++ b/src/icon/icon.directive.ts
@@ -68,7 +68,7 @@ export class IconDirective implements AfterViewInit {
 		svg.setAttribute("xmlns", "http://www.w3.org/2000/svg");
 
 		const attributes = getAttributes({
-			width: icon.attrs.height,
+			width: icon.attrs.width,
 			height: icon.attrs.height,
 			viewBox: icon.attrs.viewBox,
 			title: this.title,


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2055

Fixed typo in IconDirective that was ignoring IconDescriptor width

#### Changelog

**Changed**

* fixed typo to use width correctly
