### PR TITLE
fix(content-switcher): White Text on Content Switcher

### DIFF
--- a/src/content-switcher/content-switcher.component.ts
+++ b/src/content-switcher/content-switcher.component.ts
@@ -37,7 +37,7 @@ import { isFocusInLastItem, isFocusInFirstItem } from "carbon-components-angular
 			[class.bx--content-switcher--light]="theme === 'light'"
 			role="tablist">
 			<span class="bx--content-switcher__label">
-			<ng-content></ng-content>
+				<ng-content></ng-content>
 			</span>
 		</div>
 	`

--- a/src/content-switcher/content-switcher.component.ts
+++ b/src/content-switcher/content-switcher.component.ts
@@ -36,7 +36,9 @@ import { isFocusInLastItem, isFocusInFirstItem } from "carbon-components-angular
 			class="bx--content-switcher"
 			[class.bx--content-switcher--light]="theme === 'light'"
 			role="tablist">
+			<span class="bx--content-switcher__label">
 			<ng-content></ng-content>
+			</span>
 		</div>
 	`
 })


### PR DESCRIPTION
BugFix: White Text on Content Switcher

Upgrading Carbon on our Angular app made the white text disappear on the selected Carbon content switcher. I was told carbon-components-angular was missing <span class="bx--content-switcher__label"> and needed to be added. Please slack me on IBM's slack @jhoose if I'm incorrect as I do not check my personal gitHub account often.

jhoose-bugFixWhiteTextOnContentSwitcher