### PR TITLE
fix(TableModel): setting totalDataLength to 0 is no longer ignoring it

### DIFF
--- a/src/table/table-model.class.ts
+++ b/src/table/table-model.class.ts
@@ -156,7 +156,7 @@ export class TableModel implements PaginationModel {
 	 */
 	set totalDataLength(length: number) {
 		// if this function is called without a parameter we need to set to null to avoid having undefined != null
-		this._totalDataLength = length || null;
+		this._totalDataLength = isNaN(length) ? null : length;
 	}
 
 	/**


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2071

`0 || null` will always evaluate as `null` making the getter pickup the data length instead. Checking if the provided length is not a number would fix the issue.

#### Changelog

**Changed**

* setting TableModel.totalDataLength to 0 is no longer ignoring it

