### PR TITLE
Toggle v11

### DIFF
--- a/src/checkbox/checkbox.component.spec.ts
+++ b/src/checkbox/checkbox.component.spec.ts
@@ -12,7 +12,7 @@ import CheckboxExportedTest from "./checkbox-exported-tests";
 	template: `
 	<ibm-checkbox
 		[hideLabel]="hideLabel"
-		(change)="onChange()"
+		(checkedChange)="onChange()"
 		(indeterminateChange)="onIndeterminateChange()"
 		[indeterminate]="indeterminate"
 		[(ngModel)]="model">
@@ -61,7 +61,7 @@ describe("Checkbox", () => {
 		expect(element.componentInstance.checked).toBe(false);
 	});
 
-	it("should emit a change event on click and propagate the change back to the form", () => {
+	it("should emit a checkedChange event on click and propagate the change back to the form", () => {
 		fixture = TestBed.createComponent(CheckboxTest);
 		wrapper = fixture.componentInstance;
 		spyOn(wrapper, "onChange");

--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -8,7 +8,6 @@ import {
 	Input,
 	Output,
 	ViewChild,
-	HostBinding,
 	HostListener
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from "@angular/forms";
@@ -22,22 +21,6 @@ export enum CheckboxState {
 	Indeterminate,
 	Checked,
 	Unchecked
-}
-
-/**
- * Used to emit changes performed on checkbox components.
- *
- * @deprecated since v4
- */
-export class CheckboxChange {
-	/**
-	 * Contains the `Checkbox` that has been changed.
-	 */
-	source: Checkbox;
-	/**
-	 * The state of the `Checkbox` encompassed in the `CheckboxChange` class.
-	 */
-	checked: boolean;
 }
 
 /**
@@ -92,18 +75,6 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	static checkboxCount = 0;
 
 	/**
-	 * Size of the checkbox.
-	 *
-	 * @deprecated since v4
-	 */
-	@Input() size: "sm" | "md" = "md";
-	/**
-	 * Set to `true` for checkbox to be rendered with nested styles.
-	 *
-	 * @deprecated since v4
-	 */
-	@Input() nested: boolean;
-	/**
 	 * Set to `true` for checkbox to be rendered without any classes on the host element.
 	 */
 	@Input() inline = false;
@@ -135,41 +106,10 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Sets the value attribute on the `input` element.
 	 */
 	@Input() value: CheckboxValue;
-	/**
-	 * Used to set the `aria-label` attribute on the input element.
-	 *
-	 * @deprecated since v4 use the `ariaLabel` input instead
-	 */
 	// tslint:disable-next-line:no-input-rename
-	@Input("aria-label") set ariaLabel(value: string) {
-		this._ariaLabel = value;
-	}
-
-	get ariaLabel() {
-		return this._ariaLabel;
-	}
-
-	// TODO: drop the `_`
+	@Input("ariaLabel") ariaLabel = "";
 	// tslint:disable-next-line:no-input-rename
-	@Input("ariaLabel") _ariaLabel = "";
-
-	/**
-	 * Used to set the `aria-labelledby` attribute on the input element.
-	 *
-	 * @deprecated since v4 use the `ariaLabelledby` input instead
-	 */
-	// tslint:disable-next-line:no-input-rename
-	@Input("aria-labelledby") set ariaLabelledby(value: string) {
-		this._ariaLabelledby = value;
-	}
-
-	get ariaLabelledby() {
-		return this._ariaLabelledby;
-	}
-
-	// TODO: drop the `_`
-	// tslint:disable-next-line:no-input-rename
-	@Input("ariaLabelledby") _ariaLabelledby: string;
+	@Input("ariaLabelledby") ariaLabelledby: string;
 
 	/**
 	 * Set the checkbox's indeterminate state to match the parameter and transition the view to reflect the change.
@@ -223,13 +163,6 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Emits click event.
 	 */
 	@Output() click = new EventEmitter<void>();
-	/**
-	 * Emits event notifying other classes when a change in state occurs on a checkbox after a
-	 * click.
-	 *
-	 * @deprecated since v4 use `checked` and `checkedChange` instead
-	 */
-	@Output() change = new EventEmitter<any>();
 
 	/**
 	 * Emits an event when the value of the checkbox changes.
@@ -365,13 +298,6 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 * Creates instance of `CheckboxChange` used to propagate the change event.
 	 */
 	emitChangeEvent() {
-		/* begin deprecation */
-		let event = new CheckboxChange();
-		event.source = this;
-		event.checked = this.checked;
-		this.change.emit(event);
-		/* end deprecation */
-
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
 	}

--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -107,9 +107,9 @@ export class Checkbox implements ControlValueAccessor, AfterViewInit {
 	 */
 	@Input() value: CheckboxValue;
 	// tslint:disable-next-line:no-input-rename
-	@Input("ariaLabel") ariaLabel = "";
+	@Input() ariaLabel = "";
 	// tslint:disable-next-line:no-input-rename
-	@Input("ariaLabelledby") ariaLabelledby: string;
+	@Input() ariaLabelledby: string;
 
 	/**
 	 * Set the checkbox's indeterminate state to match the parameter and transition the view to reflect the change.

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -1,3 +1,3 @@
-export { Checkbox, CheckboxState, CheckboxChange } from "./checkbox.component";
+export { Checkbox, CheckboxState } from "./checkbox.component";
 export { CheckboxModule } from "./checkbox.module";
 export { CheckboxValue } from "./checkbox.types";

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -5,14 +5,12 @@ export { NFormsModule } from "./forms.module";
 export {
 	CheckboxModule,
 	Checkbox,
-	CheckboxChange,
 	CheckboxState,
 	CheckboxValue
 } from "carbon-components-angular/checkbox";
 export {
 	ToggleModule,
 	Toggle,
-	ToggleChange,
 	ToggleState
 } from "carbon-components-angular/toggle";
 export {

--- a/src/table/cell/table-checkbox.component.ts
+++ b/src/table/cell/table-checkbox.component.ts
@@ -18,11 +18,10 @@ import { TableRowSize } from "../table.types";
 			*ngIf="!skeleton"
 			inline="true"
 			[name]="name"
-			[aria-label]="getLabel() | i18nReplace:getSelectionLabelValue(row) | async"
-			[size]="(size !== 'sm' ? 'md' : 'sm')"
+			[ariaLabel]="getLabel() | i18nReplace:getSelectionLabelValue(row) | async"
 			[checked]="selected"
 			[disabled]="disabled"
-			(change)="change.emit()">
+			(checkedChange)="change.emit()">
 		</ibm-checkbox>
 	`
 })

--- a/src/table/head/table-head-checkbox.component.ts
+++ b/src/table/head/table-head-checkbox.component.ts
@@ -16,12 +16,11 @@ import { TableRowSize } from "../table.types";
 		<ibm-checkbox
 			*ngIf="!skeleton"
 			inline="true"
-			[size]="(size !== 'sm' ? 'md' : 'sm')"
 			[name]="name"
 			[checked]="checked"
 			[indeterminate]="indeterminate"
 			(checkedChange)="change.emit()"
-			[aria-label]="getAriaLabel() | async">
+			[ariaLabel]="getAriaLabel() | async">
 		</ibm-checkbox>
 	`,
 	styles: [`

--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 
 import { I18nModule } from "../i18n/index";
-import { Toggle, ToggleChange } from "./toggle.component";
+import { Toggle } from "./toggle.component";
 
 describe("Toggle", () => {
 	let component: Toggle;
@@ -20,19 +20,19 @@ describe("Toggle", () => {
 		fixture = TestBed.createComponent(Toggle);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
+		buttonElement = fixture.debugElement.query(By.css("button")).nativeElement;
 		labelElement = fixture.debugElement.query(By.css("label")).nativeElement;
-		buttonElement = fixture.debugElement.query(By.css("input")).nativeElement;
 	});
 
 	it("should work", () => {
 		expect(component instanceof Toggle).toBe(true);
 	});
 
-	it("should have input with class 'cds--toggle-input'", () => {
-		expect(buttonElement.className.includes("cds--toggle-input")).toEqual(true);
+	it("should have button with class 'cds--toggle__button'", () => {
+		expect(buttonElement.className.includes("cds--toggle__button")).toEqual(true);
 		component.size = "sm";
 		fixture.detectChanges();
-		expect(buttonElement.className.includes("cds--toggle-input")).toEqual(true);
+		expect(buttonElement.className.includes("cds--toggle__button")).toEqual(true);
 	});
 
 	it("should change state", () => {
@@ -46,10 +46,10 @@ describe("Toggle", () => {
 	});
 
 	it("should display small version of toggle when size equals sm", () => {
-		expect(buttonElement.className.includes("cds--toggle-input--small")).toEqual(false);
+		expect(labelElement.querySelector('div').className.includes("cds--toggle__appearance--sm")).toEqual(false);
 		component.size = "sm";
 		fixture.detectChanges();
-		expect(buttonElement.className.includes("cds--toggle-input--small")).toEqual(true);
+		expect(labelElement.querySelector('div').className.includes("cds--toggle__appearance--sm")).toEqual(true);
 	});
 
 	it("should match the input checked value", () => {
@@ -58,9 +58,9 @@ describe("Toggle", () => {
 		expect(buttonElement.attributes.getNamedItem("aria-checked").value).toEqual("true");
 	});
 
-	it("should emit ToggleChange event", (done: any) => {
-		component.change.subscribe((data: any) => {
-			expect(data instanceof ToggleChange).toEqual(true);
+	it("should emit boolean event", (done: any) => {
+		component.checkedChange.subscribe((data: any) => {
+			expect(typeof data === "boolean").toEqual(true);
 			done();
 		});
 		component.emitChangeEvent();

--- a/src/toggle/toggle.component.spec.ts
+++ b/src/toggle/toggle.component.spec.ts
@@ -46,10 +46,10 @@ describe("Toggle", () => {
 	});
 
 	it("should display small version of toggle when size equals sm", () => {
-		expect(labelElement.querySelector('div').className.includes("cds--toggle__appearance--sm")).toEqual(false);
+		expect(labelElement.querySelector("div").className.includes("cds--toggle__appearance--sm")).toEqual(false);
 		component.size = "sm";
 		fixture.detectChanges();
-		expect(labelElement.querySelector('div').className.includes("cds--toggle__appearance--sm")).toEqual(true);
+		expect(labelElement.querySelector("div").className.includes("cds--toggle__appearance--sm")).toEqual(true);
 	});
 
 	it("should match the input checked value", () => {

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -3,13 +3,12 @@ import {
 	ChangeDetectorRef,
 	Component,
 	Input,
-	Output,
-	EventEmitter,
+	HostBinding,
 	TemplateRef
 } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
-import { I18n, Overridable } from "carbon-components-angular/i18n";
+import { I18n } from "carbon-components-angular/i18n";
 import { Observable } from "rxjs";
 
 /**
@@ -20,22 +19,6 @@ export enum ToggleState {
 	Indeterminate,
 	Checked,
 	Unchecked
-}
-
-/**
- * Used to emit changes performed on toggle components.
- *
- * @deprecated since v4
- */
-export class ToggleChange {
-	/**
-	 * Contains the `Toggle` that has been changed.
-	 */
-	source: Toggle;
-	/**
-	 * The state of the `Toggle` encompassed in the `ToggleChange` class.
-	 */
-	checked: boolean;
 }
 
 /**
@@ -50,37 +33,51 @@ export class ToggleChange {
 @Component({
 	selector: "ibm-toggle",
 	template: `
-		<label *ngIf="label" [id]="ariaLabelledby" class="cds--label">
-			<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
-			<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
-		</label>
-		<input
-			class="cds--toggle-input"
-			type="checkbox"
-			[ngClass]="{
-				'cds--toggle-input--small': size === 'sm',
-				'cds--skeleton': skeleton
-			}"
-			[id]="id"
-			[value]="value"
-			[name]="name"
-			[required]="required"
-			[checked]="checked"
+		<button
+			class="cds--toggle__button"
 			[disabled]="disabled"
-			[attr.aria-labelledby]="ariaLabelledby"
+			[id]="id"
+			role="switch"
+			type="button"
 			[attr.aria-checked]="checked"
-			(change)="onChange($event)"
 			(click)="onClick($event)">
+		</button>
 		<label
-			class="cds--toggle-input__label"
-			[for]="id"
-			[ngClass]="{
-				'cds--skeleton': skeleton
-			}">
-			<span class="cds--toggle__switch">
-				<span class="cds--toggle__text--off">{{(!skeleton ? getOffText() : null) | async }}</span>
-				<span class="cds--toggle__text--on">{{(!skeleton ? getOnText() : null) | async}}</span>
+			class="cds--toggle__label"
+			[for]="id">
+			<span
+				class="cds--toggle__label-text"
+				[ngClass]="{
+					'cds--visually--hidden': hideLabel
+				}">
+				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
+				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 			</span>
+			<div
+				class="cds--toggle__appearance"
+				[ngClass]="{
+					'cds--toggle__appearance--sm': size === 'sm'
+				}">
+				<div
+					class="cds--toggle__switch"
+					[ngClass]="{
+						'cds--toggle__switch--checked': checked
+					}">
+					<svg
+						*ngIf="size === 'sm'"
+						class='cds--toggle__check'
+						width="6px"
+						height="5px"
+						viewBox="0 0 6 5">
+						<path d="M2.2 2.7L5 0 6 1 2.2 5 0 2.7 1 1.5z" />
+					</svg>
+				</div>
+				<span class="cds--toggle__text">
+					{{
+						(hideLabel ? label : (getCheckedText() | async))
+					}}
+				</span>
+			</div>
 		</label>
 	`,
 	providers: [
@@ -129,22 +126,19 @@ export class Toggle extends Checkbox {
 	 */
 	@Input() size: "sm" | "md" = "md";
 	/**
-	 * Set to `true` for a loading toggle.
+	 * Set to `true` to hide the toggle label & set toggle on/off text to label.
 	 */
-	@Input() skeleton = false;
+	@Input() hideLabel = false;
+
+	@HostBinding("class.cds--toggle") toggleClass = true;
+	@HostBinding("class.cds--toggle--disabled") get disabledClass () {
+		return this.disabled;
+	}
 
 	/**
 	 * The unique id allocated to the `Toggle`.
 	 */
 	id = "toggle-" + Toggle.toggleCount;
-
-	/**
-	 * Emits event notifying other classes when a change in state occurs on a toggle after a
-	 * click.
-	 *
-	 * @deprecated since v4
-	 */
-	@Output() change = new EventEmitter<ToggleChange>();
 
 	protected _offValues = this.i18n.getOverridable("TOGGLE.OFF");
 	protected _onValues = this.i18n.getOverridable("TOGGLE.ON");
@@ -175,17 +169,17 @@ export class Toggle extends Checkbox {
 		return this._onValues.subject;
 	}
 
+	getCheckedText(): Observable<string> {
+		if (this.checked) {
+			return this._onValues.subject;
+		}
+		return this._offValues.subject;
+	}
+
 	/**
 	 * Creates instance of `ToggleChange` used to propagate the change event.
 	 */
 	emitChangeEvent() {
-		/* begin deprecation */
-		let event = new ToggleChange();
-		event.source = this;
-		event.checked = this.checked;
-		this.change.emit(event);
-		/* end deprecation */
-
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
 	}

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -179,7 +179,6 @@ export class Toggle extends Checkbox {
 	emitChangeEvent() {
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
-		console.log(this.checked);
 	}
 
 	public isTemplate(value) {

--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -16,7 +16,6 @@ import { Observable } from "rxjs";
  */
 export enum ToggleState {
 	Init,
-	Indeterminate,
 	Checked,
 	Unchecked
 }
@@ -48,7 +47,7 @@ export enum ToggleState {
 			<span
 				class="cds--toggle__label-text"
 				[ngClass]="{
-					'cds--visually--hidden': hideLabel
+					'cds--visually-hidden': hideLabel
 				}">
 				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
@@ -73,9 +72,7 @@ export enum ToggleState {
 					</svg>
 				</div>
 				<span class="cds--toggle__text">
-					{{
-						(hideLabel ? label : (getCheckedText() | async))
-					}}
+					{{(hideLabel ? label : (getCheckedText() | async))}}
 				</span>
 			</div>
 		</label>
@@ -182,6 +179,7 @@ export class Toggle extends Checkbox {
 	emitChangeEvent() {
 		this.checkedChange.emit(this.checked);
 		this.propagateChange(this.checked);
+		console.log(this.checked);
 	}
 
 	public isTemplate(value) {

--- a/src/toggle/toggle.stories.ts
+++ b/src/toggle/toggle.stories.ts
@@ -5,6 +5,7 @@ import {
 	select,
 	text
 } from "@storybook/addon-knobs/angular";
+import { action } from "@storybook/addon-actions";
 
 import {
 	FormBuilder,
@@ -14,7 +15,7 @@ import {
 } from "@angular/forms";
 import { Component, OnInit } from "@angular/core";
 
-import { ToggleModule } from "../";
+import { ToggleModule } from "./";
 import { DocumentationModule } from "../documentation-component/documentation.module";
 
 @Component({
@@ -68,30 +69,24 @@ storiesOf("Components|Toggle", module).addDecorator(
 		template: `
 			<ibm-toggle
 				[label]="label"
+				[hideLabel]="hideLabel"
 				[onText]="onText"
 				[offText]="offText"
 				[disabled]="disabled"
 				[checked]="checked"
-				[size]="size">
-			</ibm-toggle>
-			<ibm-toggle
-				[label]="label"
-				[onText]="altOnText"
-				[offText]="altOffText"
-				[disabled]="disabled"
-				[checked]="checked"
+				(checkedChange)="onChange($event)"
 				[size]="size">
 			</ibm-toggle>
 		`,
 		props: {
 			disabled: boolean("Disabled", false),
 			checked: boolean("Checked", false),
+			hideLabel: boolean("Hide label", false),
 			size: select("Size", ["md", "sm"], "md"),
-			label: text("Label text", ""),
+			label: text("Label text", "Toggle element label"),
 			onText: text("On text", "On"),
 			offText: text("Off text", "Off"),
-			altOffText: text("Alternative off text", "Dark"),
-			altOnText: text("Alternative on text", "Light")
+			onChange: action("On change fired!")
 		}
 	}))
 	.add("With reactive forms", () => ({
@@ -101,13 +96,6 @@ storiesOf("Components|Toggle", module).addDecorator(
 				You can create your own implementation by using the component source as an example.
 			-->
 			<app-reactive-forms></app-reactive-forms>
-		`
-	}))
-	.add("Skeleton", () => ({
-		template: `
-			<ibm-toggle skeleton="true"></ibm-toggle>
-			&nbsp;
-			<ibm-toggle skeleton="true" size="sm"></ibm-toggle>
 		`
 	}))
 	.add("Documentation", () => ({


### PR DESCRIPTION
Fixes toggle in v11

**New**
* Updated toggle to use new carbon styles
* Added hide label
* Template has been changed to now use a button instead of a checkbox

**Removed**
* Deprecated property bindings for checkbox
  * Applied these changes in other components