### PR TITLE
fix(ContentSwitcher): correctly displaying all switcher options (and update utils-position version)

### DIFF
--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -4,13 +4,15 @@ import {
 	Input,
 	HostListener,
 	Output,
-	EventEmitter
+	EventEmitter,
+	ElementRef,
+	OnInit
 } from "@angular/core";
 
 @Directive({
 	selector: "[ibmContentOption]"
 })
-export class ContentSwitcherOption {
+export class ContentSwitcherOption implements OnInit {
 	/**
 	 * Used to activate the option. Only one option may be `active` at a time
 	 */
@@ -49,6 +51,8 @@ export class ContentSwitcherOption {
 
 	protected _active = false;
 
+	constructor(private hostElement: ElementRef) {}
+
 	@HostListener("click", ["$event"])
 	hostClick(event: MouseEvent) {
 		this.onClick.emit(event);
@@ -65,5 +69,18 @@ export class ContentSwitcherOption {
 		if (this.active) { return; }
 		this.active = true;
 		this.selected.emit(true);
+	}
+
+	/*
+	* encapsulating the content in a span with bx--content-switcher__label class
+	* to mimic what is done in the react version
+	*/
+	ngOnInit(): void {
+		const hostNativeElement = (this.hostElement.nativeElement as HTMLElement);
+		const spanWrapper = document.createElement("span");
+		spanWrapper.className = "bx--content-switcher__label";
+		spanWrapper.innerHTML = hostNativeElement.innerHTML;
+		hostNativeElement.innerHTML = "";
+		hostNativeElement.appendChild(spanWrapper);
 	}
 }

--- a/src/content-switcher/content-switcher-option.directive.ts
+++ b/src/content-switcher/content-switcher-option.directive.ts
@@ -6,7 +6,8 @@ import {
 	Output,
 	EventEmitter,
 	ElementRef,
-	OnInit
+	OnInit,
+	Renderer2
 } from "@angular/core";
 
 @Directive({
@@ -51,7 +52,7 @@ export class ContentSwitcherOption implements OnInit {
 
 	protected _active = false;
 
-	constructor(private hostElement: ElementRef) {}
+	constructor(private renderer: Renderer2, private hostElement: ElementRef) {}
 
 	@HostListener("click", ["$event"])
 	hostClick(event: MouseEvent) {
@@ -77,10 +78,14 @@ export class ContentSwitcherOption implements OnInit {
 	*/
 	ngOnInit(): void {
 		const hostNativeElement = (this.hostElement.nativeElement as HTMLElement);
-		const spanWrapper = document.createElement("span");
-		spanWrapper.className = "bx--content-switcher__label";
-		spanWrapper.innerHTML = hostNativeElement.innerHTML;
-		hostNativeElement.innerHTML = "";
-		hostNativeElement.appendChild(spanWrapper);
+		const spanWrapper = this.renderer.createElement("span");
+		this.renderer.addClass(spanWrapper, "bx--content-switcher__label");
+		const hostChildren: ChildNode[] = [];
+		hostNativeElement.childNodes.forEach(node => hostChildren.push(node));
+		hostChildren.forEach(node => {
+			this.renderer.removeChild(hostNativeElement, node);
+			this.renderer.appendChild(spanWrapper, node);
+		});
+		this.renderer.appendChild(hostNativeElement, spanWrapper);
 	}
 }

--- a/src/content-switcher/content-switcher.component.ts
+++ b/src/content-switcher/content-switcher.component.ts
@@ -36,9 +36,7 @@ import { isFocusInLastItem, isFocusInFirstItem } from "carbon-components-angular
 			class="bx--content-switcher"
 			[class.bx--content-switcher--light]="theme === 'light'"
 			role="tablist">
-			<span class="bx--content-switcher__label">
-				<ng-content></ng-content>
-			</span>
+			<ng-content></ng-content>
 		</div>
 	`
 })

--- a/src/package.json
+++ b/src/package.json
@@ -19,7 +19,7 @@
     "@carbon/icon-helpers": "10.9.0",
     "@carbon/icons": "10.20.0",
     "@carbon/telemetry": "0.0.0-alpha.6",
-    "@carbon/utils-position": "1.1.3",
+    "@carbon/utils-position": "1.1.4",
     "flatpickr": "4.6.1"
   }
 }


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2104
Closes IBM/carbon-components-angular#2084

Removing the span to mimic the react version of this component

#### Changelog

**Changed**

* removed span with `bx--content-switcher__label` to fix the issue
