### PR TITLE
Remove V4 deprecations & update label/helpertext styles for disabled state

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -284,10 +284,8 @@ export class ComboBox implements OnChanges, AfterViewInit, AfterContentInit, OnD
 	@Input() type: "single" | "multi" = "single";
 	/**
 	 * Combo box render size.
-	 *
-	 * @deprecated since v4
 	 */
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Specifies the property to be used as the return value to `ngModel`
 	 */

--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -53,7 +53,8 @@ import { Observable } from "rxjs";
 					'cds--list-box--light': theme === 'light',
 					'cds--list-box--expanded': open,
 					'cds--list-box--sm': size === 'sm',
-					'cds--list-box--lg': size === 'xl',
+					'cds--list-box--md': size === 'md',
+					'cds--list-box--lg': size === 'lg',
 					'cds--list-box--disabled': disabled,
 					'cds--combo-box--warning cds--list-box--warning': warn
 				}"

--- a/src/combobox/combobox.stories.ts
+++ b/src/combobox/combobox.stories.ts
@@ -46,7 +46,7 @@ const getOptions = (override = {}) => {
 		],
 		selected: action("selection changed"),
 		submit: action("submit"),
-		size: select("size", ["sm", "md", "xl"], "md"),
+		size: select("size", ["sm", "md", "lg"], "md"),
 		theme: select("theme", ["dark", "light"], "dark"),
 		search: action("search")
 	};

--- a/src/context-menu/context-menu-divider.component.ts
+++ b/src/context-menu/context-menu-divider.component.ts
@@ -11,7 +11,6 @@ import { Component, HostBinding } from "@angular/core";
 	`]
 })
 export class ContextMenuDividerComponent {
-	@HostBinding("class.cds--context-menu-divider") dividerContextClass = true; // deprecated
 	@HostBinding("class.cds--menu-divider") dividerClass = true;
 	@HostBinding("attr.role") role = "separator";
 }

--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -40,7 +40,6 @@ import { ContextMenuComponent } from "./context-menu.component";
 	`]
 })
 export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDestroy {
-	@HostBinding("class.cds--context-menu-option") optionContextClass = true; // deprecated
 	@HostBinding("class.cds--menu-option") optionClass = true;
 	@HostBinding("attr.role") role = "menuitem";
 	@HostBinding("attr.tabindex") tabindex = -1;

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -22,7 +22,11 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 				'cds--skeleton' : skeleton
 			}">
 			<div class="cds--date-picker-container">
-				<label *ngIf="label" [for]="id" class="cds--label">
+				<label
+					*ngIf="label"
+					[for]="id"
+					class="cds--label"
+					[ngClass]="{'cds--label--disabled': disabled}">
 					<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 					<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 				</label>

--- a/src/datepicker-input/datepicker-input.component.ts
+++ b/src/datepicker-input/datepicker-input.component.ts
@@ -43,7 +43,8 @@ import { NG_VALUE_ACCESSOR } from "@angular/forms";
 						class="cds--date-picker__input"
 						[ngClass]="{
 							'cds--date-picker__input--sm': size === 'sm',
-							'cds--date-picker__input--xl': size === 'xl'
+							'cds--date-picker__input--md': size === 'md',
+							'cds--date-picker__input--lg': size === 'lg'
 						}"
 						[attr.data-invalid]="invalid ? true : undefined"
 						[value]="value"
@@ -135,7 +136,7 @@ export class DatePickerInput {
 
 	@Input() value = "";
 
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 
 	// @ts-ignore
 	@ViewChild("input", { static: false }) input: ElementRef;

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -144,20 +144,8 @@ export class DatePicker implements
 
 	/**
 	 * The pattern for the underlying input element
-	 * @deprecated as of v4 - switch to inputPattern
 	 */
-	@Input() pattern = "^\\d{1,2}/\\d{1,2}/\\d{4}$";
-
-	/**
-	 * The pattern for the underlying input element
-	 */
-	@Input() set inputPattern(value: string) {
-		this.pattern = value;
-	}
-
-	get inputPattern() {
-		return this.pattern;
-	}
+	@Input() inputPattern = "^\\d{1,2}/\\d{1,2}/\\d{4}$";
 
 	@Input() id = `datepicker-${DatePicker.datePickerCount++}`;
 
@@ -192,7 +180,7 @@ export class DatePicker implements
 	 */
 	@Input() warnText: string | TemplateRef<any>;
 
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Set to `true` to display the invalid state for the second datepicker input.
 	 */

--- a/src/datepicker/datepicker.stories.ts
+++ b/src/datepicker/datepicker.stories.ts
@@ -172,7 +172,7 @@ storiesOf("Components|Date Picker", module)
 			invalid: boolean("Show form validation", false),
 			warn: boolean("Show the warning state", false),
 			warnText: text("Text for the warning", "This is a warning"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			disabled: boolean("Disabled", false),
 			valueChange: action("Date change fired!")
 		}
@@ -214,7 +214,7 @@ storiesOf("Components|Date Picker", module)
 		`,
 		props: {
 			language: select("Calendar language", ["en", "de", "fi", "ja", "zh", "es", "fr", "it", "ko", "pt"], "en"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			valueChange: action("Date change fired!"),
 			theme: select("Theme", ["dark", "light"], "dark"),
 			label: text("Label text", "Date Picker Label"),
@@ -273,7 +273,7 @@ storiesOf("Components|Date Picker", module)
 		`,
 		props: {
 			language: select("Calendar language", ["en", "de", "fi", "ja", "zh", "es", "fr", "it", "ko", "pt"], "en"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			valueChange: action("Date change fired!"),
 			theme: select("Theme", ["dark", "light"], "dark"),
 			label: text("Label text", "Date Picker Label"),
@@ -350,7 +350,7 @@ storiesOf("Components|Date Picker", module)
 		`,
 		props: {
 			date: new Date(new Date().getFullYear(), 5, 15),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			rangeDates: [
 				new Date(new Date().getFullYear(), 5, 15),
 				new Date(new Date().getFullYear(), 8, 19)
@@ -420,7 +420,7 @@ storiesOf("Components|Date Picker", module)
 		`,
 		props: {
 			valueChange: action("Date change fired!"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			theme: select("Theme", ["dark", "light"], "dark"),
 			label: text("Label text", "Date Picker Label"),
 			placeholder: text("Placeholder text", "mm/dd/yyyy"),

--- a/src/dialog/dialog.service.ts
+++ b/src/dialog/dialog.service.ts
@@ -128,14 +128,6 @@ export class DialogService {
 	}
 
 	/**
-	 * Closes all known `Dialog`s. Does not focus any previous elements, since we can't know which would be correct
-	 *
-	 * @deprecated since v4. Use the static `DialogService.closeAll` instead
-	 */
-	closeAll() {
-		DialogService.closeAll();
-	}
-	/**
 	 * Fix for safari hijacking clicks.
 	 *
 	 * Runs on `ngOnInit` of every dialog. Ensures we don't have multiple listeners

--- a/src/dropdown/abstract-dropdown-view.class.ts
+++ b/src/dropdown/abstract-dropdown-view.class.ts
@@ -43,10 +43,8 @@ export class AbstractDropdownView {
 	public type: "single" | "multi" = "single";
 	/**
 	 * Specifies the render size of the items within the `AbstractDropdownView`.
-	 *
-	 * @deprecated since v4
 	 */
-	public size: "sm" | "md" | "xl" = "md";
+	public size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Returns the `ListItem` that is subsequent to the selected item in the `DropdownList`.
 	 */

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -188,10 +188,8 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	@Input() clearText: string = this.i18n.get().DROPDOWN.CLEAR;
 	/**
 	 * Size to render the dropdown field.
-	 *
-	 * @deprecated since v4
 	 */
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Defines whether or not the `Dropdown` supports selecting multiple items as opposed to single
 	 * item selection.
@@ -242,19 +240,6 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 * Used to trigger closing the dropdown if it scrolls outside of the viewport of the `scrollableContainer`.
 	 */
 	@Input() scrollableContainer: string;
-	/**
-	 * Deprecated. Use `itemValueKey` instead.
-	 * Specifies the property to be used as the return value to `ngModel`
-	 * @deprecated since v4 use itemValueKey instead
-	 */
-	@Input() set value (newValue: string) {
-		console.warn("Dropdown `value` property has been deprecated. Use `itemValueKey` instead");
-		this.itemValueKey = newValue;
-	}
-
-	get value() {
-		return this.itemValueKey;
-	}
 	/**
 	 * Specifies the property to be used as the return value to `ngModel`
 	 */

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -73,8 +73,9 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			'cds--dropdown--disabled cds--list-box--disabled': disabled,
 			'cds--dropdown--invalid': invalid,
 			'cds--dropdown--warning cds--list-box--warning': warn,
-			'cds--dropdown--xl cds--list-box--xl': size === 'xl',
 			'cds--dropdown--sm cds--list-box--sm': size === 'sm',
+			'cds--dropdown--md cds--list-box--md': size === 'md',
+			'cds--dropdown--lg cds--list-box--lg': size === 'lg',
 			'cds--list-box--expanded': !menuIsClosed
 		}">
 		<button

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -52,7 +52,11 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 @Component({
 	selector: "ibm-dropdown",
 	template: `
-	<label *ngIf="label" [for]="id" class="cds--label">
+	<label
+		*ngIf="label"
+		[for]="id"
+		class="cds--label"
+		[ngClass]="{'cds--label--disabled': disabled}">
 		<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 		<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 	</label>
@@ -142,7 +146,12 @@ import { hasScrollableParents } from "carbon-components-angular/utils";
 			<ng-content *ngIf="!menuIsClosed"></ng-content>
 		</div>
 	</div>
-	<div *ngIf="helperText && !invalid && !warn" class="cds--form__helper-text">
+	<div
+		*ngIf="helperText && !invalid && !warn"
+		class="cds--form__helper-text"
+		[ngClass]="{
+			'cds--form__helper-text--disabled': disabled
+		}">
 		<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 		<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 	</div>
@@ -245,11 +254,11 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 */
 	@Input() itemValueKey: string;
 	/**
-     * Specify feedback (mode) of the selection.
-     * `top`: selected item jumps to top
-     * `fixed`: selected item stays at it's position
-     * `top-after-reopen`: selected item jump to top after reopen dropdown
-     */
+	 * Specify feedback (mode) of the selection.
+	 * `top`: selected item jumps to top
+	 * `fixed`: selected item stays at it's position
+	 * `top-after-reopen`: selected item jump to top after reopen dropdown
+	 */
 	@Input() selectionFeedback: "top" | "fixed" | "top-after-reopen" = "top-after-reopen";
 	/**
 	 * Accessible label for the button that opens the dropdown list.
@@ -336,7 +345,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		protected i18n: I18n,
 		protected dropdownService: DropdownService,
 		protected appRef: ApplicationRef,
-		protected elementService: ElementService) {}
+		protected elementService: ElementService) { }
 
 	/**
 	 * Updates the `type` property in the `@ContentChild`.
@@ -383,7 +392,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 				if (this.itemValueKey && this.view.getSelected()) {
 					const values = this.view.getSelected().map(item => item[this.itemValueKey]);
 					this.propagateChange(values);
-				// otherwise just pass up the values from `getSelected`
+					// otherwise just pass up the values from `getSelected`
 				} else {
 					this.propagateChange(this.view.getSelected());
 				}
@@ -405,7 +414,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		//    (where we _do_ want to append to the placeholder)
 		if (this.appendInline === null && hasScrollableParents(this.elementRef.nativeElement)) {
 			this.appendInline = false;
-		// 2. otherwise we should append inline
+			// 2. otherwise we should append inline
 		} else if (this.appendInline === null) {
 			this.appendInline = true;
 		}
@@ -481,7 +490,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	/**
 	 * function passed in by `registerOnChange`
 	 */
-	propagateChange = (_: any) => {};
+	propagateChange = (_: any) => { };
 
 	/**
 	 * `ControlValueAccessor` method to programmatically disable the dropdown.
@@ -578,9 +587,9 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		}
 		let selected = this.view.getSelected();
 		if (this.type === "multi") {
-			return {items: selected};
+			return { items: selected };
 		} else if (selected && selected.length > 0) {
-			return {item: selected[0]}; // this is to be compatible with the dropdown-list template
+			return { item: selected[0] }; // this is to be compatible with the dropdown-list template
 		} else {
 			return {};
 		}
@@ -611,7 +620,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 		return false;
 	}
 
-	_noop() {}
+	_noop() { }
 	/**
 	 * Handles clicks outside of the `Dropdown`.
 	 */
@@ -644,7 +653,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 			// this way focus will start on the next focusable item from the dropdown
 			// not the top of the body!
 			this.dropdownButton.nativeElement.focus();
-			this.dropdownButton.nativeElement.dispatchEvent(new KeyboardEvent("keydown", {bubbles: true, cancelable: true, key: "Tab"}));
+			this.dropdownButton.nativeElement.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }));
 			this.closeMenu();
 		}
 	}
@@ -714,8 +723,7 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 					if (!value.visible) {
 						this.closeMenu();
 					}
-				}
-			);
+				});
 			this._appendToBody();
 		}
 

--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -52,7 +52,7 @@ const modalText =
 
 const getProps = (overrides = {}) => Object.assign({}, {
 	invalid: boolean("Invalid", false),
-	size: select("Size", ["sm", "md", "xl"], "md"),
+	size: select("Size", ["sm", "md", "lg"], "md"),
 	invalidText: "This is not a validation text",
 	warn: boolean("Show the warning state", false),
 	warnText: text("Text for the warning", "This is a warning"),

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -181,10 +181,8 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 
 	/**
 	 * Defines the rendering size of the `DropdownList` input component.
-	 *
-	 * @deprecated since v4
 	 */
-	public size: "sm" | "md" | "xl" = "md";
+	public size: "sm" | "md" | "lg" = "md";
 	public listId = `listbox-${DropdownList.listCount++}`;
 	public highlightedItem = null;
 	/**
@@ -488,39 +486,6 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 			this.index = this.displayItems.indexOf(selected[0]);
 		} else if (this.hasNextElement()) {
 			this.getNextElement();
-		}
-	}
-
-	/**
-	 * Manages the keyboard accessibility for navigation and selection within a `DropdownList`.
-	 * @deprecated since v4
-	 */
-	doKeyDown(event: KeyboardEvent, item: ListItem) {
-		// "Spacebar", "Down", and "Up" are IE specific values
-		if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
-				if (this.listElementList.some(option => option.nativeElement === event.target)) {
-					event.preventDefault();
-				}
-				if (event.key === "Enter") {
-					this.doClick(event, item);
-				}
-		} else if (event.key === "ArrowDown" || event.key === "ArrowUp" || event.key === "Down" || event.key === "Up") {
-			event.preventDefault();
-			if (event.key === "ArrowDown" || event.key === "Down") {
-				if (this.hasNextElement()) {
-					// this.getNextElement().focus();
-					this.getNextElement();
-				} else {
-					this.blurIntent.emit("bottom");
-				}
-			} else if (event.key === "ArrowUp" || event.key === "Up") {
-				if (this.hasPrevElement()) {
-					// this.getPrevElement().focus();
-					this.getPrevElement();
-				} else {
-					this.blurIntent.emit("top");
-				}
-			}
 		}
 	}
 

--- a/src/input/input.directive.ts
+++ b/src/input/input.directive.ts
@@ -23,15 +23,19 @@ export class TextInput {
 	/**
 	 * Input field render size
 	 */
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 
 	@HostBinding("class.cds--text-input") inputClass = true;
-	@HostBinding("class.cds--text-input--xl") get isSizeXl() {
-		return this.size === "xl";
-	}
 	@HostBinding("class.cds--text-input--sm") get isSizeSm() {
 		return this.size === "sm";
 	}
+	@HostBinding("class.cds--text-input--md") get isSizeMd() {
+		return this.size === "md";
+	}
+	@HostBinding("class.cds--text-input--lg") get isSizelg() {
+		return this.size === "lg";
+	}
+
 	@HostBinding("class.cds--text-input--invalid") @Input() invalid = false;
 	@HostBinding("class.cds--text-input__field-wrapper--warning") @Input() warn = false;
 	@HostBinding("class.cds--skeleton") @Input() skeleton = false;

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -40,7 +40,7 @@ storiesOf("Components|Input", module).addDecorator(
 	`,
 		props: {
 			theme: select("Theme", ["dark", "light"], "dark"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			disabled: boolean("Disabled", false),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Validation message here"),

--- a/src/input/input.stories.ts
+++ b/src/input/input.stories.ts
@@ -24,6 +24,7 @@ storiesOf("Components|Input", module).addDecorator(
 			[invalid]="invalid"
 			[invalidText]="invalidText"
 			[warn]="warn"
+			[disabled]="disabled"
 			[warnText]="warnText">
 			{{label}}
 			<input
@@ -56,6 +57,7 @@ storiesOf("Components|Input", module).addDecorator(
 		<ibm-label
 			[helperText]="helperText"
 			[invalid]="invalid"
+			[disabled]="disabled"
 			[invalidText]="invalidText">
 			{{label}}
 			<textarea

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -88,13 +88,6 @@ import { TextArea } from "./text-area.directive";
 	`
 })
 export class Label implements AfterContentInit, AfterViewInit {
-	@Input() set disabled(disable: boolean) {
-		this._disabled = disable;
-	}
-
-	get disabled(): boolean {
-		return this._disabled;
-	}
 	/**
 	 * Used to build the id of the input item associated with the `Label`.
 	 */
@@ -108,7 +101,10 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * its input counterpart through the 'for' attribute.
 	*/
 	@Input() labelInputID = `ibm-label-${Label.labelCounter++}`;
-
+	/**
+	 * Set to `true` for disabled state.
+	 */
+	@Input() disabled = false;
 	/**
 	 * State of the `Label` will determine the styles applied.
 	 */
@@ -149,10 +145,6 @@ export class Label implements AfterContentInit, AfterViewInit {
 	@ContentChild(TextArea, { static: false }) textArea: TextArea;
 
 	@HostBinding("class.cds--form-item") labelClass = true;
-	/**
-	 * Set to `true` for disabled state.
-	 */
-	private _disabled = false;
 
 	/**
 	 * Update wrapper class if a textarea is hosted.

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -42,7 +42,8 @@ import { TextArea } from "./text-area.directive";
 			[attr.aria-label]="ariaLabel"
 			class="cds--label"
 			[ngClass]="{
-				'cds--skeleton': skeleton
+				'cds--skeleton': skeleton,
+				'cds--label--disabled': disabled && !skeleton
 			}">
 			<ng-content></ng-content>
 		</label>
@@ -67,7 +68,12 @@ import { TextArea } from "./text-area.directive";
 			</svg>
 			<ng-content select="input,textarea,div"></ng-content>
 		</div>
-		<div *ngIf="!skeleton && helperText && !invalid && !warn" class="cds--form__helper-text">
+		<div
+			*ngIf="!skeleton && helperText && !invalid && !warn"
+			class="cds--form__helper-text"
+			[ngClass]="{
+				'cds--form__helper-text--disabled': disabled
+			}">
 			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 		</div>
@@ -82,6 +88,13 @@ import { TextArea } from "./text-area.directive";
 	`
 })
 export class Label implements AfterContentInit, AfterViewInit {
+	@Input() set disabled(disable: boolean) {
+		this._disabled = disable;
+	}
+
+	get disabled(): boolean {
+		return this._disabled;
+	}
 	/**
 	 * Used to build the id of the input item associated with the `Label`.
 	 */
@@ -94,7 +107,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
 	 * its input counterpart through the 'for' attribute.
 	*/
-	@Input() labelInputID = "ibm-label-" + Label.labelCounter;
+	@Input() labelInputID = `ibm-label-${Label.labelCounter++}`;
 
 	/**
 	 * State of the `Label` will determine the styles applied.
@@ -136,13 +149,10 @@ export class Label implements AfterContentInit, AfterViewInit {
 	@ContentChild(TextArea, { static: false }) textArea: TextArea;
 
 	@HostBinding("class.cds--form-item") labelClass = true;
-
 	/**
-	 * Creates an instance of Label.
+	 * Set to `true` for disabled state.
 	 */
-	constructor() {
-		Label.labelCounter++;
-	}
+	private _disabled = false;
 
 	/**
 	 * Update wrapper class if a textarea is hosted.
@@ -157,6 +167,11 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * Sets the id on the input item associated with the `Label`.
 	 */
 	ngAfterViewInit() {
+		/**
+		 * @todo
+		 * Perhaps user can pass disabled in here & we can programmatically set it in input/textarea?
+		 * Not sure how that would work for reactive forms
+		 */
 		if (this.wrapper) {
 			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea,div");
 			if (inputElement) {

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -167,11 +167,6 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * Sets the id on the input item associated with the `Label`.
 	 */
 	ngAfterViewInit() {
-		/**
-		 * @todo
-		 * Perhaps user can pass disabled in here & we can programmatically set it in input/textarea?
-		 * Not sure how that would work for reactive forms
-		 */
 		if (this.wrapper) {
 			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea,div");
 			if (inputElement) {

--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -113,17 +113,7 @@ export class Modal implements AfterViewInit, OnChanges {
 
 	/**
 	 * Label for the modal.
-	 *
-	 * @deprecated since v4
 	 */
-	@Input() set modalLabel(value: string) {
-		this.ariaLabel = value;
-	}
-
-	get modalLabel() {
-		return this.ariaLabel;
-	}
-
 	@Input() ariaLabel = "default";
 
 	/**

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -44,7 +44,8 @@ export class NumberChange {
 				'cds--number--helpertext': helperText,
 				'cds--skeleton' : skeleton,
 				'cds--number--sm': size === 'sm',
-				'cds--number--xl': size === 'xl'
+				'cds--number--md': size === 'md',
+				'cds--number--lg': size === 'lg'
 			}">
 			<label *ngIf="skeleton && label" class="cds--label cds--skeleton"></label>
 			<label
@@ -164,7 +165,7 @@ export class NumberComponent implements ControlValueAccessor {
 	/**
 	 * Number input field render size
 	 */
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Reflects the required attribute of the `input` element.
 	 */

--- a/src/number-input/number.component.ts
+++ b/src/number-input/number.component.ts
@@ -47,7 +47,11 @@ export class NumberChange {
 				'cds--number--xl': size === 'xl'
 			}">
 			<label *ngIf="skeleton && label" class="cds--label cds--skeleton"></label>
-			<label *ngIf="!skeleton && label" [for]="id" class="cds--label">
+			<label
+				*ngIf="!skeleton && label"
+				[for]="id"
+				class="cds--label"
+				[ngClass]="{'cds--label--disabled': disabled}">
 				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 			</label>
@@ -102,7 +106,12 @@ export class NumberChange {
 					<div class="cds--number__rule-divider"></div>
 				</div>
 			</div>
-			<div *ngIf="helperText && !invalid && !warn" class="cds--form__helper-text">
+			<div
+				*ngIf="helperText && !invalid && !warn"
+				class="cds--form__helper-text"
+				[ngClass]="{
+					'cds--form__helper-text--disabled': disabled
+				}">
 				<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 				<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 			</div>

--- a/src/number-input/number.stories.ts
+++ b/src/number-input/number.stories.ts
@@ -30,7 +30,7 @@ storiesOf("Components|Number", module).addDecorator(
 		`,
 		props: {
 			label: text("label", "Number Input Label"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			helperText: text("helper text", "Optional helper text."),
 			invalidText: text("Form validation content", "Invalid number"),
 			warn: boolean("Show the warning state", false),
@@ -65,7 +65,7 @@ storiesOf("Components|Number", module).addDecorator(
 		props: {
 			value: 0,
 			label: text("label", "Number Input Label"),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			helperText: text("helper text", "Optional helper text."),
 			invalidText: text("Form validation content", "Invalid number"),
 			theme: select("theme", ["dark", "light"], "dark"),

--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -2,8 +2,8 @@
 	class="cds--search"
 	[ngClass]="{
 		'cds--search--sm': size === 'sm',
-		'cds--search--lg': size === 'md',
-		'cds--search--xl': size === 'xl',
+		'cds--search--md': size === 'md',
+		'cds--search--lg': size === 'lg',
 		'cds--search--light': theme === 'light',
 		'cds--skeleton': skeleton,
 		'cds--search--expandable': expandable && !tableSearch,

--- a/src/search/search.component.spec.ts
+++ b/src/search/search.component.spec.ts
@@ -58,9 +58,9 @@ describe("Search", () => {
 
 	it("should display component of the correct size", () => {
 		containerElement = fixture.debugElement.query(By.css(".cds--search")).nativeElement;
-		component.size = "xl";
+		component.size = "lg";
 		fixture.detectChanges();
-		expect(containerElement.className.includes("cds--search--xl")).toEqual(true);
+		expect(containerElement.className.includes("cds--search--lg")).toEqual(true);
 		component.size = "sm";
 		fixture.detectChanges();
 		expect(containerElement.className.includes("cds--search--sm")).toEqual(true);

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -39,17 +39,12 @@ export class Search implements ControlValueAccessor {
 	 * `light` or `dark` search theme.
 	 */
 	@Input() theme: "light" | "dark" = "dark";
+
 	/**
 	 * Size of the search field.
 	 */
+	@Input() size: "sm" | "md" | "lg" = "md";
 
-	@Input() set size(value: "sm" | "md" | "xl") {
-		this._size = value;
-	}
-
-	get size(): "sm" | "md" | "xl" {
-		return this._size;
-	}
 	/**
 	 * Set to `true` for a disabled search input.
 	 */
@@ -137,8 +132,6 @@ export class Search implements ControlValueAccessor {
 	 * Sets `true` when composing text via IME.
 	 */
 	protected isComposing = false;
-
-	protected _size: "sm" | "md" | "xl" = "md";
 
 	/**
 	 * Creates an instance of `Search`.

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -29,7 +29,7 @@ storiesOf("Components|Search", module).addDecorator(
 			</ibm-search>
 		`,
 		props: {
-			size: select("size", ["sm", "md", "xl"], "md"),
+			size: select("size", ["sm", "md", "lg"], "md"),
 			theme: select("theme", ["dark", "light"], "dark"),
 			disabled: boolean("disabled", false),
 			autocomplete: text("autocomplete", "on"),
@@ -52,7 +52,7 @@ storiesOf("Components|Search", module).addDecorator(
 			</ibm-search>
 		`,
 		props: {
-			size: select("size", ["sm", "md", "xl"], "md"),
+			size: select("size", ["sm", "md", "lg"], "md"),
 			theme: select("theme", ["dark", "light"], "dark"),
 			disabled: boolean("disabled", false),
 			autocomplete: text("autocomplete", "on"),

--- a/src/search/search.stories.ts
+++ b/src/search/search.stories.ts
@@ -61,13 +61,6 @@ storiesOf("Components|Search", module).addDecorator(
 			clear: action("clear fired!")
 		}
 	}))
-	.add("Toolbar search", () => ({
-		template: `
-		<div class="cds--toolbar">
-			<ibm-search placeholder="search" size="sm" toolbar="true"></ibm-search>
-		</div>
-		`
-	}))
 	.add("Skeleton", () => ({
 		template: `
 		<div style="width: 200px;">

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -47,11 +47,20 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					'cds--select--warning': warn,
 					'cds--select--disabled': disabled
 				}">
-				<label *ngIf="label" [for]="id" class="cds--label">
+				<label
+					*ngIf="label"
+					[for]="id"
+					class="cds--label"
+					[ngClass]="{'cds--label--disabled': disabled}">
 					<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 					<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 				</label>
-				<div *ngIf="helperText" class="cds--form__helper-text">
+				<div
+					*ngIf="helperText"
+					class="cds--form__helper-text"
+					[ngClass]="{
+						'cds--form__helper-text--disabled': disabled
+					}">
 					<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
 					<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
 				</div>
@@ -103,7 +112,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					class="cds--select__invalid-icon cds--select__invalid-icon--warning">
 				</svg>
 			</div>
-			<div *ngIf="invalid && invalidText && !warn" role="alert" class="cds--form-requirement" aria-live="polite">
+			<div
+				*ngIf="invalid && invalidText && !warn" role="alert" class="cds--form-requirement" aria-live="polite">
 				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
 				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
 			</div>

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -82,8 +82,9 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 					[attr.aria-invalid]="invalid ? 'true' : null"
 					class="cds--select-input"
 					[ngClass]="{
-						'cds--select-input--xl': size === 'xl',
-						'cds--select-input--sm': size === 'sm'
+						'cds--select-input--sm': size === 'sm',
+						'cds--select-input--md': size === 'md',
+						'cds--select-input--lg': size === 'lg'
 					}">
 					<ng-content></ng-content>
 				</select>
@@ -177,7 +178,7 @@ export class Select implements ControlValueAccessor, AfterViewInit {
 	/**
 	 * Number input field render size
 	 */
-	@Input() size: "sm" | "md" | "xl" = "md";
+	@Input() size: "sm" | "md" | "lg" = "md";
 	/**
 	 * Set to true to disable component.
 	 */

--- a/src/select/select.stories.ts
+++ b/src/select/select.stories.ts
@@ -102,7 +102,7 @@ storiesOf("Components|Select", module).addDecorator(
 	`,
 		props: {
 			disabled: boolean("Disabled", false),
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			invalid: boolean("Show form validation", false),
 			invalidText: text("Form validation content", "Please select an option."),
 			warn: boolean("Show the warning state", false),
@@ -133,7 +133,7 @@ storiesOf("Components|Select", module).addDecorator(
 			</div>
 		`,
 		props: {
-			size: select("Size", ["sm", "md", "xl"], "md"),
+			size: select("Size", ["sm", "md", "lg"], "md"),
 			model: "option2",
 			selectRandom: function() {
 				this.model = [

--- a/src/slider/slider.component.ts
+++ b/src/slider/slider.component.ts
@@ -54,7 +54,12 @@ import { EventService } from "carbon-components-angular/utils";
 	selector: "ibm-slider",
 	template: `
 		<ng-container *ngIf="!skeleton; else skeletonTemplate">
-			<label *ngIf="label" [for]="id" [id]="labelId" class="cds--label">
+			<label
+				*ngIf="label"
+				[for]="id"
+				[id]="labelId"
+				class="cds--label"
+				[ngClass]="{'cds--label--disabled': disabled}">
 				<ng-container *ngIf="!isTemplate(label)">{{label}}</ng-container>
 				<ng-template *ngIf="isTemplate(label)" [ngTemplateOutlet]="label"></ng-template>
 			</label>

--- a/src/structured-list/list-row.component.ts
+++ b/src/structured-list/list-row.component.ts
@@ -39,7 +39,7 @@ import { ListColumn } from "./list-column.component";
 			<input
 				#input
 				tabindex="-1"
-				class="cds--structured-list-input"
+				class="cds--structured-list-input cds--visually-hidden"
 				type="radio"
 				[value]="value"
 				[name]="name"
@@ -53,6 +53,9 @@ import { ListColumn } from "./list-column.component";
 	`
 })
 export class ListRow implements AfterContentInit {
+	@HostBinding("class.cds--structured-list-row--focused-within") get focusClass() {
+		return this.isFocused;
+	}
 	@Input() @HostBinding("class.cds--structured-list-row--selected") selected = false;
 	/**
 	 * Applies an accessible label to the row. Defaults to no label.
@@ -78,11 +81,14 @@ export class ListRow implements AfterContentInit {
 
 	@HostBinding("class.cds--structured-list-row") wrapper = true;
 	@HostBinding("attr.tabindex") tabindex = this.selection ? "0" : null;
+	@HostBinding("attr.role") role = "row";
 
 	@ContentChildren(ListColumn) columns: QueryList<ListColumn>;
 
 	// @ts-ignore
 	@ViewChild("input", { static: false }) input: ElementRef;
+
+	private isFocused = false;
 
 	ngAfterContentInit() {
 		this.columns.forEach(column => {
@@ -96,6 +102,16 @@ export class ListRow implements AfterContentInit {
 		if (this.selection) {
 			this.input.nativeElement.click();
 		}
+	}
+
+	@HostListener("focus")
+	onfocus() {
+		this.isFocused = true;
+	}
+
+	@HostListener("blur")
+	onblur() {
+		this.isFocused = false;
 	}
 
 	onChange(event) {

--- a/src/tiles/tile.component.ts
+++ b/src/tiles/tile.component.ts
@@ -31,7 +31,7 @@ export class Tile {
 	}
 
 	/**
-	 * @deprecated
+	 * @deprecated since v5
 	 * Theme property binding will be deprecated in next major version
 	 * Use layers instead
 	 */

--- a/src/timepicker/timepicker.component.ts
+++ b/src/timepicker/timepicker.component.ts
@@ -89,7 +89,7 @@ export class TimePicker implements ControlValueAccessor {
 	@Input() skeleton = false;
 
 	/**
-	 * @deprecated
+	 * @deprecated since v5
 	 * Theme property binding will be deprecated in next major version
 	 * Use layers instead
 	 */


### PR DESCRIPTION
**New**
- Applied conditional disable state classes to both label & helper text

**Changed**
- Added focus styling to structured list row 
  - Styles are applied on focus 
- Standardize size property to `sm`, `md`, `lg` (Previously was `sm`, `md`, `xl`)
  - Reflected this change in storybook & templates


**Removed**
- Deprecated input properties
  - Includes updating sizes
