### PR TITLE
fix: fix focus change issue when tab key press

### DIFF
--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -244,11 +244,12 @@ export class Search implements ControlValueAccessor {
 	}
 
 	@HostListener("focusin", ["$event"])
-	focusin(event) {
+	focusIn(event) {
 		this.onTouched();
+		// set input focus if search icon get focus from tab key press event.
 		if ((this.expandable || this.toolbar) &&
-			this.inputRef &&
-			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget) && !event.relatedTarget) {
+			this.inputRef && !event.relatedTarget &&
+			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget) ) {
 			this.openSearch();
 		}
 	}

--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -243,6 +243,16 @@ export class Search implements ControlValueAccessor {
 		}
 	}
 
+	@HostListener("focusin", ["$event"])
+	focusin(event) {
+		this.onTouched();
+		if ((this.expandable || this.toolbar) &&
+			this.inputRef &&
+			!(this.elementRef.nativeElement as HTMLElement).contains(event.relatedTarget) && !event.relatedTarget) {
+			this.openSearch();
+		}
+	}
+
 	/**
 	 * Called when using IME composition.
 	 */


### PR DESCRIPTION
fix focus change issue when tab key press

Closes IBM/carbon-components-angular#2111

Fix issue while user go through tab key press. Set initial focus on input search when search get focus from tab key press.

#### Changelog

**New**

* Implement focusIn HostListener method to improve tab key press event performance. 

**Before**

<img width="1791" alt="169205806-0548a28f-5d8c-41fc-bd85-adcc78593794" src="https://user-images.githubusercontent.com/49565062/170789706-f5f46ec9-ff66-45de-85a5-a48b4a568f1a.png">

**After**

![ezgif-4-3d2c0dc44a](https://user-images.githubusercontent.com/49565062/170789979-dafdb3e2-b4bd-45cd-9703-e21f5ba5449f.gif)

