### PR TITLE
feat(dropdown): added maxSelected as an option

### DIFF
--- a/src/dropdown/abstract-dropdown-view.class.ts
+++ b/src/dropdown/abstract-dropdown-view.class.ts
@@ -22,6 +22,11 @@ export class AbstractDropdownView {
 
 	get items(): Array<ListItem> | Observable<Array<ListItem>> { return; }
 	/**
+	 * Defines whether there is a maximum number of items
+	 * that can be selected simultaneously
+	 */
+	@Input() maxSelected: number = null;
+	/**
 	 * Emits selection events to controlling classes
 	 */
 	@Output() select: EventEmitter<{item: ListItem } | ListItem[]>;

--- a/src/dropdown/dropdown.component.ts
+++ b/src/dropdown/dropdown.component.ts
@@ -281,6 +281,18 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 */
 	@Input() dropUp: boolean;
 	/**
+	 * Defines the maximum number of selected items
+	 * for a multi-select dropdown list
+	 */
+	@Input() set maxSelected(value: number) {
+		this._maxSelected = value;
+		this.view.maxSelected = this._maxSelected;
+	}
+
+	get maxSelected() {
+		return this._maxSelected;
+	}
+	/**
 	 * Emits selection events.
 	 */
 	@Output() selected: EventEmitter<Object> = new EventEmitter<Object>();
@@ -319,6 +331,11 @@ export class Dropdown implements OnInit, AfterContentInit, AfterViewInit, OnDest
 	 * controls whether the `drop-up` class is applied
 	 */
 	_dropUp = false;
+
+	/**
+	 * controls the maximum number of items that can simultaneously be selected
+	 */
+	_maxSelected = null;
 
 	// .bind creates a new function, so we declare the methods below
 	// but .bind them up here

--- a/src/dropdown/dropdown.stories.ts
+++ b/src/dropdown/dropdown.stories.ts
@@ -19,7 +19,8 @@ import {
 	select,
 	boolean,
 	object,
-	text
+	text,
+	number
 } from "@storybook/addon-knobs/angular";
 
 import { of } from "rxjs";
@@ -249,6 +250,37 @@ storiesOf("Components|Dropdown", module)
 			model: [2],
 			selectionFeedback: select("Selection feedback", ["top", "fixed", "top-after-reopen"], "top-after-reopen")
 		})
+	}))
+	.add("Multi-select with maxSelected", () => ({
+			template: `
+			<div style="width: 300px">
+				<ibm-dropdown
+					[label]="label"
+					[helperText]="helperText"
+					[size]="size"
+					[dropUp]="dropUp"
+					[invalid]="invalid"
+					[invalidText]="invalidText"
+					[selectionFeedback]="selectionFeedback"
+					[maxSelected]="maxSelected"
+					type="multi"
+					placeholder="Multi-select"
+					[disabled]="disabled"
+					(selected)="selected($event)"
+					(onClose)="onClose($event)">
+					<ibm-dropdown-list [items]="items"></ibm-dropdown-list>
+				</ibm-dropdown>
+			</div>
+		`,
+		props: {
+			...getProps(),
+			selectionFeedback: select(
+				"Selection feedback",
+				["top", "fixed", "top-after-reopen"],
+				"top-after-reopen"
+			),
+			maxSelected: number("maxSelected", 2)
+		}
 	}))
 	.add("With ngModel", () => ({
 		template: `

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -180,6 +180,11 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 	@Input() showTitles = true;
 
 	/**
+	 * Defines whether there is a maximum number of items that can be selected simultaneously
+	 */
+	@Input() maxSelected: number = null;
+
+	/**
 	 * Defines the rendering size of the `DropdownList` input component.
 	 *
 	 * @deprecated since v4
@@ -571,7 +576,15 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 					if (item !== otherItem) { otherItem.selected = false; }
 				}
 			} else {
-				item.selected = !item.selected;
+				// Checks if a maxSelected is set, if we are unseleceting an item or if we under the maxSelect limit
+				if (
+					!this.maxSelected ||
+					item.selected ||
+					(this.maxSelected &&
+						this.getSelected().length < this.maxSelected)
+				) {
+					item.selected = !item.selected;
+				}
 			}
 			this.index = this.displayItems.indexOf(item);
 			this.highlightedItem = this.getItemId(this.index);

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -576,7 +576,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 					if (item !== otherItem) { otherItem.selected = false; }
 				}
 			} else {
-				// Checks if a maxSelected is set, if we are unseleceting an item or if we under the maxSelect limit
+				// Checks if a maxSelected is set, if we are unselecting an item or if the # of selected items is under the maxSelect limit
 				if (
 					!this.maxSelected ||
 					item.selected ||


### PR DESCRIPTION
Closes IBM/carbon-components-angular#

adds a maxSelected option to the multiselect dropdown menu, the option allows users to specify if they want to have a maximum for the number of elements selected.

#### Changelog

**New**

* adds maxSelected as an input, as well as an example on the storybook

**Changed**

* changed the logic on the `doClick` function in `dropdown-list.component.ts` to work with the new option


gif shows the dropdown menu with `maxSelected` set to `2`
![ezgif-1-7a0c70e1c0](https://user-images.githubusercontent.com/45938909/173120886-e2b32aaf-c44c-4d53-9d98-b70ce01a519c.gif)

