### PR TITLE
fix: remove combobox arrow button focus

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -138,6 +138,7 @@ import { Observable } from "rxjs";
 					<button
 						type="button"
 						role="button"
+						tabindex="-1"
 						class="bx--list-box__menu-icon"
 						[title]="open ? closeMenuAria : openMenuAria"
 						[attr.aria-label]="open ? closeMenuAria : openMenuAria"


### PR DESCRIPTION
Closes #2153  #2160 

Remove focus of combobox arrow button on tab key press
FYI: carbon component (react, vue, web component) have same behaviour which i implemented here.

#### Changelog

**New**

* add `tabindex` property for combobox open/close button.

**Changed**

**Before**
![ezgif-5-8f29027946](https://user-images.githubusercontent.com/49565062/175537424-86e749db-4fd9-4e9d-8fd0-ca9a0c46d365.gif)

**After**
![ezgif-5-13f92c8522](https://user-images.githubusercontent.com/49565062/175537488-57268125-9c50-42f2-b927-290182fe52fd.gif)