### PR TITLE
fix: remove aria-checked from checkbox

### DIFF
--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -60,7 +60,6 @@ export class CheckboxChange {
 				[checked]="checked"
 				[disabled]="disabled"
 				[attr.aria-labelledby]="ariaLabelledby"
-				[attr.aria-checked]="(indeterminate ? 'mixed' : checked)"
 				(change)="onChange($event)"
 				(click)="onClick($event)">
 			<label


### PR DESCRIPTION
closes #2156 

Removed the aria-checked attribute from the checkbox to conform to the accessibility directives of the IBM Accessibility Checker tool.

#### Changelog

**Removed**

* Removed `[attr.aria-checked]` from ibm-checkbox component
