### PR TITLE
fix(modal): fix rounding issue in shouldShowScrollbar

### DIFF
--- a/src/modal/modal.component.ts
+++ b/src/modal/modal.component.ts
@@ -218,7 +218,7 @@ export class Modal implements AfterViewInit, OnChanges {
 		const modalContent = this.modal ? this.modal.nativeElement.querySelector(".bx--modal-content") : null;
 		if (modalContent) {
 			// get rounded value from height to match integer returned from scrollHeight
-			const modalContentHeight = Math.round(modalContent.getBoundingClientRect().height);
+			const modalContentHeight = Math.ceil(modalContent.getBoundingClientRect().height);
 			const modalContentScrollHeight = modalContent.scrollHeight;
 			return modalContentScrollHeight > modalContentHeight;
 		} else {


### PR DESCRIPTION
`shouldShowScrollbar` uses `scrollHeight` to determine whether the modal content is scrollable or not. The problem is that `scrollHeight` returns a rounded value, and its implementation (round up or down) is browser-specific. For text elements, with the default Carbon styles, the modal content height is `28.02 px`. Different browsers may return different values. e.g.:

- Chrome seems to always return `28`.
- FireFox returns `28` for some languages (e.g. English), but returns `29` for some other languages (e.g. Chinese).

The previous implementation uses `Math.round` to round `getBoundingClientRect().height` before comparison. This results in false positive for some languages like Chinese. It seems we should use `Math.ceil` instead.

Before:

<img width="873" alt="image" src="https://user-images.githubusercontent.com/34791554/182444091-48a18140-f310-4b3f-8178-d0efae992e48.png">

After:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/34791554/182444189-218899f0-435a-4fb1-a32e-971df1cb31a1.png">
