### PR TITLE
fix(table): set focus on sort table header button

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -274,9 +274,7 @@ export class Table implements AfterViewInit, OnDestroy {
 
 	static setTabIndex(element: HTMLElement, index: -1 | 0) {
 		const focusElementList = getFocusElementList(element, tabbableSelectorIgnoreTabIndex);
-		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 1) {
-			focusElementList[1].tabIndex = index;
-		} else if (focusElementList.length > 0) {
+		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 0) {
 			focusElementList[0].tabIndex = index;
 		} else {
 			element.tabIndex = index;
@@ -285,9 +283,7 @@ export class Table implements AfterViewInit, OnDestroy {
 
 	static focus(element: HTMLElement) {
 		const focusElementList = getFocusElementList(element, tabbableSelectorIgnoreTabIndex);
-		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 1) {
-			focusElementList[1].focus();
-		} else if (focusElementList.length > 0) {
+		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 0) {
 			focusElementList[0].focus();
 		} else {
 			element.focus();
@@ -642,7 +638,7 @@ export class Table implements AfterViewInit, OnDestroy {
 	}
 
 	enableDataGridInteractions() {
-		// if we have an `interactioModel` we've already enabled datagrid
+		// if we have an `interactionModel` we've already enabled datagrid
 		if (this.interactionModel) {
 			return;
 		}
@@ -660,7 +656,7 @@ export class Table implements AfterViewInit, OnDestroy {
 
 			// if the model has just initialized don't focus or reset anything
 			if (previousRow === -1 || previousColumn === -1) { return; }
-			// Make the previous cell unfocusable (if it's not the current)
+			// Make the previous cell un-focusable (if it's not the current)
 			if (previousRow !== currentRow || previousColumn !== currentColumn) {
 				const previousElement = tableAdapter.getCell(previousRow, previousColumn);
 				Table.setTabIndex(previousElement, -1);


### PR DESCRIPTION
Closes #2182 
Closes #2217 

Set focus on table header button on sorting
Fix tab focus on table header with sort button

#### Changelog

**Changed**

* Set focus on table header button on sorting
* Fix tab focus on table header with sort button

**After**
![ezgif-1-9d2a7e2233](https://user-images.githubusercontent.com/49565062/183282976-c15f1832-53d8-4c30-a9ab-e71266092e48.gif)

