### PR TITLE
fix(table): set focus on sort table header button

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -274,9 +274,7 @@ export class Table implements AfterViewInit, OnDestroy {
 
 	static setTabIndex(element: HTMLElement, index: -1 | 0) {
 		const focusElementList = getFocusElementList(element, tabbableSelectorIgnoreTabIndex);
-		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 1) {
-			focusElementList[1].tabIndex = index;
-		} else if (focusElementList.length > 0) {
+		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 0) {
 			focusElementList[0].tabIndex = index;
 		} else {
 			element.tabIndex = index;
@@ -285,9 +283,7 @@ export class Table implements AfterViewInit, OnDestroy {
 
 	static focus(element: HTMLElement) {
 		const focusElementList = getFocusElementList(element, tabbableSelectorIgnoreTabIndex);
-		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 1) {
-			focusElementList[1].focus();
-		} else if (focusElementList.length > 0) {
+		if (element.firstElementChild && element.firstElementChild.classList.contains("bx--table-sort") && focusElementList.length > 0) {
 			focusElementList[0].focus();
 		} else {
 			element.focus();


### PR DESCRIPTION
Closes #2182 
Closes #2217 

Set focus on table header button on sorting
Fix tab focus on table header with sort button

#### Changelog

**Changed**

* Set focus on table header button on sorting
* Fix tab focus on table header with sort button

**After**
![ezgif-1-9d2a7e2233](https://user-images.githubusercontent.com/49565062/183282976-c15f1832-53d8-4c30-a9ab-e71266092e48.gif)