### PR TITLE
docs: update library description

### DIFF
--- a/src/carbon.yml
+++ b/src/carbon.yml
@@ -2,7 +2,7 @@
 library:
   id: carbon-components-angular
   name: Carbon Angular
-  description: Angular implementation of Carbon Components.
+  description: Build user interfaces with Carbon's core components.
   externalDocsUrl: https://angular.carbondesignsystem.com
   inherits: carbon-styles
 assets:
@@ -391,7 +391,7 @@ assets:
     type: component
     platform: web
     framework: angular
-    thumbnailPath: './thumbnails.tooltip-icon.svg'
+    thumbnailPath: './thumbnails/tooltip-icon.svg'
     demoLinks:
       - type: storybook
         name: Storybook


### PR DESCRIPTION
#### Changelog

**New**

* N/A

**Changed**

* Updated indexed library description from https://airtable.com/shrdwElZNyJdGtZkS/tblE2Y75BfY0Z0T2O/viwiUj1cNATMWrkSy/recDgpWsjanG4u8y1
* Fixed broken thumbnail path

**Removed**

* N/A

**Testing**

New description:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1691245/186950164-e19aeb0e-e258-45e1-83cc-c4b8f00e86d6.png">

The tooltip icon component's thumbnail now renders:
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1691245/186950380-77a93aee-ae24-4927-bc75-9f535e18088d.png">
