### PR TITLE
docs: index compatible design kits

### DIFF
--- a/src/carbon.yml
+++ b/src/carbon.yml
@@ -22,6 +22,41 @@ library:
           path: "https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/angular-tutorial/step-5.mdx"
         - title: Wrapping up
           path: "https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/angular-tutorial/wrapping-up.mdx"
+  designKits:
+    carbon-white-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-white-sketch
+    carbon-g10-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g10-sketch
+    carbon-g90-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g90-sketch
+    carbon-g100-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g100-sketch
+    carbon-shell-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-shell-sketch
+    carbon-white-adobe-xd:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-white-adobe-xd
+    carbon-g10-adobe-xd:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g10-adobe-xd
+    carbon-g90-adobe-xd:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g90-adobe-xd
+    carbon-g100-adobe-xd:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g100-adobe-xd
+    axure-widget-library:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/axure-widget-library
+    text-toolbar-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/text-toolbar-sketch
+    carbon-mid-fi-sketch:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-mid-fi-sketch
+    carbon-wireframe-invision-freehand:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-wireframe-invision-freehand
+    carbon-white-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-white-figma
+    carbon-g10-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g10-figma
+    carbon-g90-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g90-figma
+    carbon-g100-figma:
+      $ref: https://unpkg.com/@carbon-platform/resources/carbon.yml#/designKits/carbon-g100-figma
 assets:
   accordion:
     status: stable


### PR DESCRIPTION
Related: https://github.com/carbon-design-system/carbon-platform/issues/967

The Carbon Angular library has a design kits page, to list compatible design kits with the components/patterns in the Carbon Angular library: https://next.carbondesignsystem.com/libraries/carbon-components-angular/latest/design-kits

This list of `designKits` would normally be inherited from the `carbon-styles` library (PR https://github.com/carbon-design-system/carbon/pull/12033), but Carbon Angular has yet to upgrade to v11.

By not inheriting `designKits`, we can specify in this library so the v10 Figma kits are listed, not the new v11 Figma kits.

Once Carbon Angular updates to v11, we can remove the `designKits` array in the config file.

#### Changelog

**New**

* `carbon.yml` `designKits` array of compatible design kits for documentation purposes

**Changed**

* N/A

**Removed**

* N/A
