### PR TITLE
fix(table): enable horizontal scroll in table

### DIFF
--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -241,7 +241,12 @@ import { TableRowSize } from "./table.types";
 			</tr>
 		</tfoot>
 	</table>
-	`
+	`,
+	styles: [`
+		:host {
+			display: block;
+		}
+	`]
 })
 export class Table implements AfterViewInit, OnDestroy {
 	/**
@@ -450,6 +455,11 @@ export class Table implements AfterViewInit, OnDestroy {
 	 * Set to `false` to remove table rows (zebra) stripes.
 	 */
 	@Input() striped = true;
+
+	/**
+	 * Allows table content to scroll horizontally
+	 */
+	@HostBinding("class.bx--data-table-content") tableContent = true;
 
 	/**
 	 * Set to `true` to stick the header to the top of the table


### PR DESCRIPTION
Enable horizontal scroll in table to match Carbon React implementation.

Replaces https://github.com/IBM/carbon-components-angular/pull/2128.