### PR TITLE
fix: Error svg should not have tab index

### DIFF
--- a/src/file-uploader/file.component.ts
+++ b/src/file-uploader/file.component.ts
@@ -24,8 +24,7 @@ import { FileItem } from "./file-item.interface";
 				*ngIf="isInvalidText"
 				ibmIcon="warning--filled"
 				class="bx--file--invalid"
-				size="16"
-				tabindex="-1">
+				size="16">
 			</svg>
 			<svg
 				ibmIcon="close"

--- a/src/file-uploader/file.component.ts
+++ b/src/file-uploader/file.component.ts
@@ -25,7 +25,7 @@ import { FileItem } from "./file-item.interface";
 				ibmIcon="warning--filled"
 				class="bx--file--invalid"
 				size="16"
-				tabindex="0">
+				tabindex="-1">
 			</svg>
 			<svg
 				ibmIcon="close"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2233

Fix accessibility violation, the error svg icon should not be focusable.

#### Changelog

**New**

* {{new thing}}

**Changed**

* [src/file-uploader/file.component.ts](https://github.com/IBM/carbon-components-angular/compare/master...makandre:carbon-components-angular:patch-1#diff-16e04c1cd0f6cf955ab565e43d10815ef46c58f259ad86045fd9cd8c04267dff)

**Removed**

* {{removed thing}}
