### PR TITLE
fix: Remove tabindex

### DIFF
--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -14,7 +14,7 @@
 		'bx--toolbar-search-container-expandable': tableSearch && expandable,
 		'bx--toolbar-search-container-active': tableSearch && expandable && active
 	}"
-	role="search"
+	role="searchbox"
 	[attr.aria-label]="ariaLabel"
 	tabindex="0"
 	(click)="openSearch()">

--- a/src/search/search.component.html
+++ b/src/search/search.component.html
@@ -14,9 +14,8 @@
 		'bx--toolbar-search-container-expandable': tableSearch && expandable,
 		'bx--toolbar-search-container-active': tableSearch && expandable && active
 	}"
-	role="searchbox"
+	role="search"
 	[attr.aria-label]="ariaLabel"
-	tabindex="0"
 	(click)="openSearch()">
 	<label class="bx--label" [for]="id">{{label}}</label>
 

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -241,7 +241,12 @@ import { TableRowSize } from "./table.types";
 			</tr>
 		</tfoot>
 	</table>
-	`
+	`,
+	styles: [`
+		:host {
+			display: block;
+		}
+	`]
 })
 export class Table implements AfterViewInit, OnDestroy {
 	/**
@@ -450,6 +455,11 @@ export class Table implements AfterViewInit, OnDestroy {
 	 * Set to `false` to remove table rows (zebra) stripes.
 	 */
 	@Input() striped = true;
+
+	/**
+	 * Allows table content to scroll horizontally
+	 */
+	@HostBinding("class.bx--data-table-content") tableContent = true;
 
 	/**
 	 * Set to `true` to stick the header to the top of the table


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2184

~Change role from `search` to `searchbox`~

~I believe `searchbox` is the correct widget role based on https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles~

Remove the unnecessary `tabindex`

#### Changelog

**New**

* {{new thing}}

**Changed**

* [src/search/search.component.html](https://github.com/IBM/carbon-components-angular/compare/master...makandre:carbon-components-angular:patch-2#diff-d18ddec221752adaa51aabfcf9d75769a9608dc390c37b3722eb87cb9433cbb6)

**Removed**

* {{removed thing}}
