### PR TITLE
fix: Allow 'enter' key to toggle switch state

### DIFF
--- a/src/toggle/toggle.component.ts
+++ b/src/toggle/toggle.component.ts
@@ -75,7 +75,8 @@ export class ToggleChange {
 			[attr.aria-labelledby]="ariaLabelledby"
 			[attr.aria-checked]="checked"
 			(change)="onChange($event)"
-			(click)="onClick($event)">
+			(click)="onClick($event)"
+			(keyup.enter)="onClick($event)">
 		<label
 			class="bx--toggle-input__label"
 			[for]="id"


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2227

#### Changelog
* Listen for keyup enter events & execute click function to toggle state change