### PR TITLE
fix: prevent host & button from having same id

### DIFF
--- a/src/button/icon-button.component.ts
+++ b/src/button/icon-button.component.ts
@@ -29,7 +29,7 @@ import { ButtonSize, ButtonType } from "./button.types";
 		(click)="emitClickEvent($event, 'tooltip')">
 		<button
 			#button
-			[id]="id"
+			[id]="buttonId"
 			[disabled]="disabled"
 			[attr.type]="type"
 			[iconOnly]="true"
@@ -88,7 +88,7 @@ export class IconButton extends BaseIconButton implements AfterViewInit {
 	/**
 	 * Override id
 	 */
-	@Input() id = `icon-btn-${IconButton.iconButtonCounter++}`;
+	@Input() buttonId = `icon-btn-${IconButton.iconButtonCounter++}`;
 	/**
 	 * Sets the button type.
 	 */

--- a/src/button/icon-button.stories.ts
+++ b/src/button/icon-button.stories.ts
@@ -64,7 +64,7 @@ const Template: Story<IconButton> = (args) => ({
 	props: args,
 	template: `
 		<ibm-icon-button
-			id="icon-btn1"
+			buttonId="icon-btn1"
 			type="button"
 			[kind]="kind"
 			[size]="size"


### PR DESCRIPTION
Prevents the same id from being assigned to the host element & the button by updating the id prop.