### PR TITLE
fix: missing id on popup menu

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts
@@ -10,6 +10,7 @@ import { Dialog } from "../dialog.component";
 	selector: "ibm-overflow-custom-menu-pane",
 	template: `
 		<div
+			[attr.id]="dialogConfig.compID"
 			[attr.aria-label]="dialogConfig.menuLabel"
 			[attr.data-floating-menu-direction]="placement ? placement : null"
 			[ngClass]="{'bx--overflow-menu--flip': dialogConfig.flip}"

--- a/src/dialog/overflow-menu/overflow-menu-pane.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu-pane.component.ts
@@ -23,13 +23,13 @@ import { closestAttr } from "carbon-components-angular/utils";
 	selector: "ibm-overflow-menu-pane",
 	template: `
 		<ul
+			[attr.id]="dialogConfig.compID"
 			[attr.aria-label]="dialogConfig.menuLabel"
 			[attr.data-floating-menu-direction]="placement ? placement : null"
 			[ngClass]="{'bx--overflow-menu--flip': dialogConfig.flip}"
 			role="menu"
 			#dialog
 			class="bx--overflow-menu-options bx--overflow-menu-options--open"
-			role="menu"
 			(click)="onClose($event)"
 			[attr.aria-label]="dialogConfig.menuLabel">
 			<ng-template


### PR DESCRIPTION
Signed-off-by: Andrew Mak <makandre@ca.ibm.com>

Closes IBM/carbon-components-angular#2213

The popup menu was missing id attribute

#### Changelog

**New**

* {{new thing}}

**Changed**

* [src/dialog/overflow-menu/overflow-menu-custom-pane.component.ts](https://github.com/IBM/carbon-components-angular/compare/master...makandre:carbon-components-angular:2213?expand=1#diff-6d4776c34026a3e7d95851bbb2ea7cbeebed7e21b9f27232385cb8913e3b23b1)
* [src/dialog/overflow-menu/overflow-menu-pane.component.ts](https://github.com/IBM/carbon-components-angular/compare/master...makandre:carbon-components-angular:2213?expand=1#diff-01e8ba07b56f1149d15573781b7708caaa7a397ac17dc98360a41e6cbb038b08)

**Removed**

* {{removed thing}}
