### PR TITLE
fix: Remove incorrect roles from table header title & description

### DIFF
--- a/src/table/header/table-header-description.directive.ts
+++ b/src/table/header/table-header-description.directive.ts
@@ -6,7 +6,6 @@ import { Directive, HostBinding, Input } from "@angular/core";
 export class TableHeaderDescription {
 	static counter = 0;
 
-	@Input() id = `table-description-${TableHeaderDescription.counter++}`;
+	@HostBinding("attr.id") @Input() id = `table-description-${TableHeaderDescription.counter++}`;
 	@HostBinding("class.bx--data-table-header__description") descriptionClass = true;
-	@HostBinding("attr.id") setId = this.id;
 }

--- a/src/table/header/table-header-description.directive.ts
+++ b/src/table/header/table-header-description.directive.ts
@@ -1,8 +1,12 @@
-import { Directive, HostBinding } from "@angular/core";
+import { Directive, HostBinding, Input } from "@angular/core";
 
 @Directive({
 	selector: "[ibmTableHeaderDescription]"
 })
 export class TableHeaderDescription {
+	static counter = 0;
+
+	@Input() id = `table-description-${TableHeaderDescription.counter++}`;
 	@HostBinding("class.bx--data-table-header__description") descriptionClass = true;
+	@HostBinding("attr.id") setId = this.id;
 }

--- a/src/table/header/table-header-description.directive.ts
+++ b/src/table/header/table-header-description.directive.ts
@@ -5,5 +5,4 @@ import { Directive, HostBinding } from "@angular/core";
 })
 export class TableHeaderDescription {
 	@HostBinding("class.bx--data-table-header__description") descriptionClass = true;
-	@HostBinding("attr.role") role = "summary";
 }

--- a/src/table/header/table-header-title.directive.ts
+++ b/src/table/header/table-header-title.directive.ts
@@ -1,8 +1,12 @@
-import { Directive, HostBinding } from "@angular/core";
+import { Directive, HostBinding, Input } from "@angular/core";
 
 @Directive({
 	selector: "[ibmTableHeaderTitle]"
 })
 export class TableHeaderTitle {
+	static counter = 0;
+
+	@Input() id = `table-title-${TableHeaderTitle.counter++}`;
 	@HostBinding("class.bx--data-table-header__title") titleClass = true;
+	@HostBinding("attr.id") setId = this.id;
 }

--- a/src/table/header/table-header-title.directive.ts
+++ b/src/table/header/table-header-title.directive.ts
@@ -6,7 +6,6 @@ import { Directive, HostBinding, Input } from "@angular/core";
 export class TableHeaderTitle {
 	static counter = 0;
 
-	@Input() id = `table-title-${TableHeaderTitle.counter++}`;
+	@HostBinding("attr.id") @Input() id = `table-title-${TableHeaderTitle.counter++}`;
 	@HostBinding("class.bx--data-table-header__title") titleClass = true;
-	@HostBinding("attr.id") setId = this.id;
 }

--- a/src/table/header/table-header-title.directive.ts
+++ b/src/table/header/table-header-title.directive.ts
@@ -5,5 +5,4 @@ import { Directive, HostBinding } from "@angular/core";
 })
 export class TableHeaderTitle {
 	@HostBinding("class.bx--data-table-header__title") titleClass = true;
-	@HostBinding("attr.role") role = "caption";
 }

--- a/src/table/stories/app-table.component.ts
+++ b/src/table/stories/app-table.component.ts
@@ -22,7 +22,9 @@ import { TableItem } from "../table-item.class";
 			[sortable]="sortable"
 			[stickyHeader]="stickyHeader"
 			[striped]="striped"
-			[isDataGrid]="isDataGrid">
+			[isDataGrid]="isDataGrid"
+			[ariaLabelledby]="ariaLabelledby"
+			[ariaDescribedby]="ariaDescribedby">
 			<ng-content></ng-content>
 		</ibm-table>
 	`
@@ -38,6 +40,8 @@ export class TableStory implements OnInit, OnChanges {
 	@Input() noData = false;
 	@Input() stickyHeader = false;
 	@Input() skeleton = false;
+	@Input() ariaLabelledby;
+	@Input() ariaDescribedby;
 
 	ngOnInit() {
 		this.model.header = [

--- a/src/table/table-container.component.ts
+++ b/src/table/table-container.component.ts
@@ -1,4 +1,12 @@
-import { Component, HostBinding } from "@angular/core";
+import {
+	AfterContentInit,
+	Component,
+	ContentChild,
+	HostBinding
+} from "@angular/core";
+import { TableHeaderDescription } from "./header/table-header-description.directive";
+import { TableHeaderTitle } from "./header/table-header-title.directive";
+import { Table } from "./table.component";
 
 @Component({
 	selector: "ibm-table-container",
@@ -7,6 +15,19 @@ import { Component, HostBinding } from "@angular/core";
 		:host { display: block }
 	`]
 })
-export class TableContainer {
+export class TableContainer implements AfterContentInit {
 	@HostBinding("class.bx--data-table-container") containerClass = true;
+
+	@ContentChild(TableHeaderTitle) headerTitle: TableHeaderTitle;
+	@ContentChild(TableHeaderDescription) headerDescription: TableHeaderDescription;
+	@ContentChild(Table) table: Table;
+
+	ngAfterContentInit() {
+		// Set aria properties if values exist otherwise keep undefined
+		if (this.table) {
+			// Using ternary instead of optional chaning since typescript version does not support it
+			this.table.ariaLabelledby = this.headerTitle ? this.headerTitle.id : undefined;
+			this.table.ariaDescribedby = this.headerDescription ? this.headerDescription.id : undefined;
+		}
+	}
 }

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -180,7 +180,9 @@ import { TableRowSize } from "./table.types";
 		[ngClass]="{'bx--data-table--sticky-header': stickyHeader}"
 		[size]="size"
 		[striped]="striped"
-		[skeleton]="skeleton">
+		[skeleton]="skeleton"
+		[attr.aria-labelledby]="ariaLabelledby"
+		[attr.aria-describedby]="ariaDescribedby">
 		<thead
 			ibmTableHead
 			[sortable]="sortable"
@@ -294,6 +296,15 @@ export class Table implements AfterViewInit, OnDestroy {
 			element.focus();
 		}
 	}
+
+	/**
+	 * Id of the table header title element
+	 */
+	@Input() ariaLabelledby: string;
+	/**
+	 * Id of the table header description element
+	 */
+	@Input() ariaDescribedby: string;
 
 	/**
 	 * `TableModel` with data the table is to display.

--- a/src/table/table.stories.ts
+++ b/src/table/table.stories.ts
@@ -10,7 +10,6 @@ import {
 } from "@storybook/addon-knobs/angular";
 
 import {
-	Table,
 	TableModule,
 	TableModel,
 	TableItem,
@@ -136,8 +135,8 @@ storiesOf("Components|Table", module).addDecorator(
 		template: `
 		<ibm-table-container>
 			<ibm-table-header>
-				<h4 ibmTableHeaderTitle>{{title}}</h4>
-				<p ibmTableHeaderDescription>{{description}}</p>
+				<h4 ibmTableHeaderTitle id="table-header">{{title}}</h4>
+				<p ibmTableHeaderDescription id="table-description">{{description}}</p>
 			</ibm-table-header>
 			<!--
 				app-* components are for demo purposes only.
@@ -148,7 +147,9 @@ storiesOf("Components|Table", module).addDecorator(
 				[size]="size"
 				[skeleton]="skeleton"
 				[showSelectionColumn]="showSelectionColumn"
-				[striped]="striped">
+				[striped]="striped"
+				ariaLabelledby="table-header"
+				ariaDescribedby="table-description">
 				<tbody><tr><td class="no-data" colspan="3"><div>No data.</div></td></tr></tbody>
 			</app-no-data-table>
 		</ibm-table-container>
@@ -170,8 +171,8 @@ storiesOf("Components|Table", module).addDecorator(
 		<section>
 			<ibm-table-container>
 				<ibm-table-header>
-					<h4 ibmTableHeaderTitle>{{title}}</h4>
-					<p ibmTableHeaderDescription>{{description}}</p>
+					<h4 ibmTableHeaderTitle id="table-header">{{title}}</h4>
+					<p ibmTableHeaderDescription id="table-description">{{description}}</p>
 				</ibm-table-header>
 				<ibm-table-toolbar
 					[model]="model"
@@ -227,7 +228,9 @@ storiesOf("Components|Table", module).addDecorator(
 					[sortable]="sortable"
 					[skeleton]="skeleton"
 					[stickyHeader]="stickyHeader"
-					[isDataGrid]="isDataGrid">
+					[isDataGrid]="isDataGrid"
+					ariaLabelledby="table-header"
+					ariaDescribedby="table-description">
 				</app-table>
 				<ng-template #customTrigger><svg ibmIcon="settings" size="16"></svg></ng-template>
 			</ibm-table-container>
@@ -312,8 +315,8 @@ storiesOf("Components|Table", module).addDecorator(
 		template: `
 		<ibm-table-container>
 			<ibm-table-header>
-				<h4 ibmTableHeaderTitle>{{title}}</h4>
-				<p ibmTableHeaderDescription>{{description}}</p>
+				<h4 ibmTableHeaderTitle id="table-header">{{title}}</h4>
+				<p ibmTableHeaderDescription id="table-description">{{description}}</p>
 			</ibm-table-header>
 			<ibm-table-toolbar>
 				<ibm-table-toolbar-content>
@@ -339,7 +342,9 @@ storiesOf("Components|Table", module).addDecorator(
 				[skeleton]="skeleton"
 				[striped]="striped"
 				[sortable]="sortable"
-				[isDataGrid]="isDataGrid">
+				[isDataGrid]="isDataGrid"
+				ariaLabelledby="table-header"
+				ariaDescribedby="table-description">
 			</app-table>
 		</ibm-table-container>
 	`,


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2261

#### Changelog
* Remove roles from Table header directives
* Add `aria-labelledby` & `aria-describedby` roles to `ibm-table`
* Update stories