### PR TITLE
docs: index getting started content

### DIFF
--- a/src/carbon.yml
+++ b/src/carbon.yml
@@ -6,6 +6,8 @@ library:
   externalDocsUrl: https://angular.carbondesignsystem.com
   inherits: carbon-styles
   navData:
+    - title: Get started
+      path: "https://github.com/carbon-design-system/carbon-website/blob/carbon-platform/src/pages/developing/frameworks/angular.mdx"
     - title: Tutorial
       items:
         - title: Overview


### PR DESCRIPTION
As found in https://github.com/carbon-design-system/carbon-platform/issues/907, added a "Get started" page to the Carbon Angular library with https://carbondesignsystem.com/developing/frameworks/angular content.