### PR TITLE
fix: Remove inline js from anchors

### DIFF
--- a/src/ui-shell/header/header-item.component.ts
+++ b/src/ui-shell/header/header-item.component.ts
@@ -98,7 +98,7 @@ export class HeaderItem {
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
 		} else if (this._href === "#") {
-			return false;
+			event.preventDefault();
 		}
 	}
 }

--- a/src/ui-shell/header/header-item.component.ts
+++ b/src/ui-shell/header/header-item.component.ts
@@ -88,7 +88,7 @@ export class HeaderItem {
 	 */
 	@Output() navigation = new EventEmitter<Promise<boolean>>();
 
-	protected _href = "javascript:void(0)";
+	protected _href = "#";
 
 	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) { }
 
@@ -97,6 +97,8 @@ export class HeaderItem {
 			event.preventDefault();
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
+		} else if (this._href === "#") {
+			return false;
 		}
 	}
 }

--- a/src/ui-shell/header/header-menu.component.ts
+++ b/src/ui-shell/header/header-menu.component.ts
@@ -24,7 +24,7 @@ import { HeaderItemInterface } from "./header-navigation-items.interface";
 				tabindex="0"
 				aria-haspopup="true"
 				[attr.aria-expanded]="expanded"
-				(click)="navigate()">
+				(click)="navigate($event)">
 				{{title}}
 				<ng-template *ngIf="icon; else defaultIcon" [ngTemplateOutlet]="icon"></ng-template>
 				<ng-template #defaultIcon>
@@ -106,9 +106,9 @@ export class HeaderMenu {
 		}
 	}
 
-	navigate() {
+	navigate(event) {
 		if (this._href === "#") {
-			return false;
+			event.preventDefault();
 		}
 	}
 }

--- a/src/ui-shell/header/header-menu.component.ts
+++ b/src/ui-shell/header/header-menu.component.ts
@@ -23,7 +23,8 @@ import { HeaderItemInterface } from "./header-navigation-items.interface";
 				[href]="href"
 				tabindex="0"
 				aria-haspopup="true"
-				[attr.aria-expanded]="expanded">
+				[attr.aria-expanded]="expanded"
+				(click)="navigate()">
 				{{title}}
 				<ng-template *ngIf="icon; else defaultIcon" [ngTemplateOutlet]="icon"></ng-template>
 				<ng-template #defaultIcon>
@@ -73,7 +74,7 @@ export class HeaderMenu {
 
 	public expanded = false;
 
-	protected _href = "javascript:void(0)";
+	protected _href = "#";
 
 	constructor(protected domSanitizer: DomSanitizer, protected elementRef: ElementRef) { }
 
@@ -102,6 +103,12 @@ export class HeaderMenu {
 	onFocusOut(event) {
 		if (!this.elementRef.nativeElement.contains(event.relatedTarget)) {
 			this.expanded = false;
+		}
+	}
+
+	navigate() {
+		if (this._href === "#") {
+			return false;
 		}
 	}
 }

--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -104,7 +104,7 @@ export class Header {
 	 */
 	@Output() navigation = new EventEmitter<Promise<boolean>>();
 
-	protected _href = "javascript:void(0)";
+	protected _href = "#";
 
 	constructor(
 		public i18n: I18n,
@@ -120,6 +120,8 @@ export class Header {
 			event.preventDefault();
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
+		} else if (this._href === "#") {
+			return false;
 		}
 	}
 }

--- a/src/ui-shell/header/header.component.ts
+++ b/src/ui-shell/header/header.component.ts
@@ -121,7 +121,7 @@ export class Header {
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
 		} else if (this._href === "#") {
-			return false;
+			event.preventDefault();
 		}
 	}
 }

--- a/src/ui-shell/panel/switcher-list-item.component.ts
+++ b/src/ui-shell/panel/switcher-list-item.component.ts
@@ -76,7 +76,7 @@ export class SwitcherListItem {
 
 	@HostBinding("attr.role") itemRole = "listitem";
 
-	protected _href = "javascript:void(0)";
+	protected _href = "#";
 	protected _target = "";
 
 	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) { }
@@ -86,6 +86,8 @@ export class SwitcherListItem {
 			event.preventDefault();
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
+		} else if (this._href === "#") {
+			return false;
 		}
 	}
 }

--- a/src/ui-shell/panel/switcher-list-item.component.ts
+++ b/src/ui-shell/panel/switcher-list-item.component.ts
@@ -87,7 +87,7 @@ export class SwitcherListItem {
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
 		} else if (this._href === "#") {
-			return false;
+			event.preventDefault();
 		}
 	}
 }

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -88,7 +88,7 @@ export class SideNavItem implements OnChanges {
 	 */
 	@Output() selected = new EventEmitter<boolean>();
 
-	protected _href = "javascript:void(0)";
+	protected _href = "#";
 
 	constructor(protected domSanitizer: DomSanitizer, @Optional() protected router: Router) {}
 
@@ -103,6 +103,8 @@ export class SideNavItem implements OnChanges {
 			event.preventDefault();
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
+		} else if (this._href === "#") {
+			return false;
 		}
 	}
 }

--- a/src/ui-shell/sidenav/sidenav-item.component.ts
+++ b/src/ui-shell/sidenav/sidenav-item.component.ts
@@ -104,7 +104,7 @@ export class SideNavItem implements OnChanges {
 			const status = this.router.navigate(this.route, this.routeExtras);
 			this.navigation.emit(status);
 		} else if (this._href === "#") {
-			return false;
+			event.preventDefault();
 		}
 	}
 }


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2223


#### Changelog
* Remove inline JS from anchors to enable secure CSP headers
* Set default `_href` value to `#` and return false if `_href` value equals `#` on click.