### PR TITLE
fix(pagination): Use pageText instead of itemsPerPageText to fix a11y label

### DIFF
--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -112,7 +112,7 @@ export interface PaginationTranslations {
 				<div
 					class="bx--select bx--select--inline bx--select__page-number"
 					[class.bx--select--disabled]="pageInputDisabled">
-					<label [for]="currentPageSelectId" class="bx--label bx--visually-hidden">{{itemsPerPageText.subject | async}}</label>
+					<label [for]="currentPageSelectId" class="bx--label bx--visually-hidden">{{pageText.subject | async}}</label>
 					<input
 						*ngIf="pageOptions.length > pageSelectThreshold"
 						style="padding-right: 1rem; margin-right: 1rem;"


### PR DESCRIPTION
closes #2264

Update pagination component to fix a11y label of page selector

#### Changelog

**New**

N/A

**Changed**

Change hidden label for page selector

**Removed**

N/A
