### PR TITLE
feat(accordion): add multiple sizes (#2022)

### DIFF
--- a/src/accordion/accordion.component.spec.ts
+++ b/src/accordion/accordion.component.spec.ts
@@ -8,7 +8,7 @@ import { Accordion } from "./accordion.component";
 
 @Component({
 	template: `
-	<ibm-accordion>
+	<ibm-accordion [size]="size">
 		<ibm-accordion-item
 		[title]="title"
 		[skeleton]="skeleton">
@@ -19,6 +19,7 @@ import { Accordion } from "./accordion.component";
 class AccordionTest {
 	title = "Section 1";
 	skeleton = "false";
+	size = "md";
 }
 
 describe("Accordion", () => {
@@ -76,5 +77,13 @@ describe("Accordion", () => {
 		fixture.detectChanges();
 		debugElement = fixture.debugElement.query(By.css("ibm-accordion .bx--accordion__title"));
 		expect(debugElement.nativeElement.textContent).toContain("Section 1");
+	});
+
+	it("should apply style for specified size (md)", () => {
+		fixture = TestBed.createComponent(AccordionTest);
+		wrapper = fixture.componentInstance;
+		fixture.detectChanges();
+		debugElement = fixture.debugElement.query(By.css("ibm-accordion .bx--accordion"));
+		expect(debugElement.nativeElement.classList).toContain("bx--accordion--md");
 	});
 });

--- a/src/accordion/accordion.component.ts
+++ b/src/accordion/accordion.component.ts
@@ -16,14 +16,20 @@ import { AccordionItem } from "./accordion-item.component";
 	selector: "ibm-accordion",
 	template: `
 		<ul class="bx--accordion"
-			[class.bx--accordion--end]="align == 'end'"
-			[class.bx--accordion--start]="align == 'start'">
+			[ngClass]="{
+				'bx--accordion--end': align == 'end',
+				'bx--accordion--start': align == 'start',
+				'bx--accordion--sm': size == 'sm',
+				'bx--accordion--md': size == 'md',
+				'bx--accordion--lg': size == 'lg'
+			}">
 			<ng-content></ng-content>
 		</ul>
 	`
 })
 export class Accordion implements AfterContentInit {
 	@Input() align: "start" | "end" = "end";
+	@Input() size: "sm" | "md" | "lg" = "md";
 
 	@ContentChildren(AccordionItem) children: QueryList<AccordionItem>;
 

--- a/src/accordion/accordion.stories.ts
+++ b/src/accordion/accordion.stories.ts
@@ -17,7 +17,7 @@ storiesOf("Components|Accordion", module)
 	.addDecorator(withKnobs)
 	.add("Basic", () => ({
 		template: `
-			<ibm-accordion [align]="align">
+			<ibm-accordion [align]="align" [size]="size">
 				<ibm-accordion-item title="Section 1 title" (selected)="selected($event)">Lorem ipsum dolor sit amet, \
 				consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore \
 				et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation \
@@ -52,7 +52,8 @@ storiesOf("Components|Accordion", module)
 				}
 			],
 			selected: action("item expanded"),
-			align: select("Align", ["start", "end"], "end")
+			align: select("Align", ["start", "end"], "end"),
+			size: select("Size", ["sm", "md", "lg"], "md")
 		}
 	}))
 	.add("With title template", () => ({


### PR DESCRIPTION
Hello there,

I saw the open issue and thought I'd make a contribution.

It took me a while to realise, but the latest `@carbon/styles` should have the necessary styles (specifically, just the `sm` and `lg` variants) to support the changes to add the size variations to the accordion component.

As an aside, I checked out the `next` branch out of curiosity and it looks like the story for the accordion doesn't have a knob for varying the size. There's been some file movement which appears to undo the knob added previously. Not sure if this is intentional.

#### Changelog

**New**

* Adds size variations for the accordion component

**Changed**

* N/A

**Removed**

* N/A

---

Closes IBM/carbon-components-angular#2022