### PR TITLE
fix: prioritize input/textarea over div when setting id

### DIFF
--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -169,9 +169,16 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 */
 	ngAfterViewInit() {
 		if (this.wrapper) {
-			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea,div");
+			// Prioritize setting id to `input` & `textarea` over div
+			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea");
 			if (inputElement) {
 				inputElement.setAttribute("id", this.labelInputID);
+				return;
+			}
+
+			const divElement = this.wrapper.nativeElement.querySelector("div");
+			if (divElement) {
+				divElement.setAttribute("id", this.labelInputID);
 			}
 		}
 	}


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2136

#### Changelog
* Prioritize input & textarea over div - this will ensure that the id is not assigned to the div if the textarea & input are wrapped within a div.
