### PR TITLE
feat(accordion): add item disable (#2021)

### DIFF
--- a/src/accordion/accordion-item.component.ts
+++ b/src/accordion/accordion-item.component.ts
@@ -12,6 +12,7 @@ import {
 	template: `
 		<button
 			type="button"
+			[disabled]="disabled"
 			[attr.aria-expanded]="expanded"
 			[attr.aria-controls]="id"
 			(click)="toggleExpanded()"
@@ -50,6 +51,7 @@ export class AccordionItem {
 
 	@HostBinding("class.bx--accordion__item") itemClass = true;
 	@HostBinding("class.bx--accordion__item--active") @Input() expanded = false;
+	@HostBinding("class.bx--accordion__item--disabled") @Input() disabled = false;
 	@HostBinding("style.display") itemType = "list-item";
 	@HostBinding("attr.role") role = "heading";
 	@HostBinding("attr.aria-level") @Input() ariaLevel = 3;

--- a/src/accordion/accordion.component.spec.ts
+++ b/src/accordion/accordion.component.spec.ts
@@ -10,6 +10,7 @@ import { Accordion } from "./accordion.component";
 	template: `
 	<ibm-accordion>
 		<ibm-accordion-item
+		[disabled]="disabled"
 		[title]="title"
 		[skeleton]="skeleton">
 			test-content
@@ -17,6 +18,7 @@ import { Accordion } from "./accordion.component";
 	<ibm-accordion>`
 })
 class AccordionTest {
+	disabled = false;
 	title = "Section 1";
 	skeleton = "false";
 }
@@ -60,6 +62,17 @@ describe("Accordion", () => {
 		debugElement.triggerEventHandler("click", null);
 		fixture.detectChanges();
 		expect(debugElement.nativeElement.getAttribute("aria-expanded")).toEqual("true");
+	});
+
+	it("should not expand disabled items", () => {
+		fixture = TestBed.createComponent(AccordionTest);
+		wrapper = fixture.componentInstance;
+		wrapper.disabled = true;
+		fixture.detectChanges();
+		debugElement = fixture.debugElement.query(By.css(".bx--accordion__heading"));
+		debugElement.nativeElement.click();
+		fixture.detectChanges();
+		expect(debugElement.nativeElement.getAttribute("aria-expanded")).toEqual("false");
 	});
 
 	it("should set test-content into accordion item", () => {

--- a/src/accordion/accordion.stories.ts
+++ b/src/accordion/accordion.stories.ts
@@ -55,6 +55,14 @@ storiesOf("Components|Accordion", module)
 			align: select("Align", ["start", "end"], "end")
 		}
 	}))
+	.add("With disabled item", () => ({
+		template: `
+			<ibm-accordion>
+				<ibm-accordion-item title="Enabled"></ibm-accordion-item>
+				<ibm-accordion-item title="Disabled" disabled="true"></ibm-accordion-item>
+			</ibm-accordion>
+		`
+	}))
 	.add("With title template", () => ({
 		template: `
 			<div style="width: 500px">


### PR DESCRIPTION
Hello there,

Following from #2271, I thought I'd also backport the support for disabled accordion items from the `next` branch.

If there are any conflicts, I'll keep an eye out and resolve them.

#### Changelog

**New**

* Adds disable attribute for accordion items

**Changed**

* N/A

**Removed**

* N/A

---

Closes IBM/carbon-components-angular#2021