### PR TITLE
fix: correct aria-haspopup value & add aria-controls attribute 

### DIFF
--- a/src/combobox/combobox.component.ts
+++ b/src/combobox/combobox.component.ts
@@ -110,7 +110,7 @@ import { Observable } from "rxjs";
 						[attr.aria-expanded]="open"
 						aria-haspopup="listbox"
 						[attr.maxlength]="maxLength"
-						aria-haspopup="true"
+						[attr.aria-controls]="open ? view.listId : null"
 						[attr.aria-autocomplete]="autocomplete"
 						[placeholder]="placeholder"/>
 					<svg

--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -56,6 +56,7 @@ import { ScrollCustomEvent } from "./scroll-custom-event.interface";
 			(scroll)="emitScroll($event)"
 			(keydown)="navigateList($event)"
 			tabindex="-1"
+			[attr.id]="listId"
 			[attr.aria-label]="ariaLabel"
 			[attr.aria-activedescendant]="highlightedItem">
 			<li


### PR DESCRIPTION
Closes IBM/carbon-components-angular#2276

#### Changelog
* Dropdown list now has an id attribute
* Combobox references dropdown list id attribute when open
* Removes redundant `aria-haspopup` attribute (View line 111 & 113)