### PR TITLE
fix: Remove unnecessary setTimeout to prevent padding between callback

### DIFF
--- a/src/dialog/dialog.directive.ts
+++ b/src/dialog/dialog.directive.ts
@@ -286,11 +286,9 @@ export class DialogDirective implements OnInit, OnDestroy, OnChanges {
 	 * Helper method to close the dialogRef.
 	 */
 	close(meta: CloseMeta = { reason: CloseReasons.interaction }) {
-		setTimeout(() => {
-			if (this.dialogRef) {
-				this.dialogRef.instance.doClose(meta);
-			}
-		});
+		if (this.dialogRef) {
+			this.dialogRef.instance.doClose(meta);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Similar to PR #2488

### Changelog

**Changed**

* Removes setTimeout call on `close` function call. The setTimeout pads blocking master thread when the cb's are called.  


Tested removal of setTimeout with Tooltip components & overflow. No errors were reported in console or tests.