### PR TITLE
feat: add additional wrapper components

### DIFF
--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -16,7 +16,8 @@ import { ButtonModule } from "carbon-components-angular/button";
 		ToggleModule,
 		RadioModule,
 		InputModule,
-		ButtonModule
+		ButtonModule,
+		InputModule
 	],
 	imports: [
 		CommonModule,

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -25,7 +25,9 @@ export {
 	InputModule,
 	Label,
 	TextArea,
-	TextInput
+	TextInput,
+	TextInputLabelComponent,
+	TextareaLabelComponent
 } from "carbon-components-angular/input";
 export {
 	ButtonModule,

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -2,3 +2,5 @@ export * from "./input.directive";
 export * from "./input.module";
 export * from "./label.component";
 export * from "./text-area.directive";
+export * from "./text-input-label.component";
+export * from "./textarea-label.component";

--- a/src/input/input.module.ts
+++ b/src/input/input.module.ts
@@ -7,16 +7,22 @@ import { CommonModule } from "@angular/common";
 import { Label } from "./label.component";
 import { TextInput } from "./input.directive";
 import { TextArea } from "./text-area.directive";
+import { TextareaLabelComponent } from "./textarea-label.component";
+import { TextInputLabelComponent } from "./text-input-label.component";
 import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
 	declarations: [
 		Label,
 		TextInput,
-		TextArea
+		TextArea,
+		TextareaLabelComponent,
+		TextInputLabelComponent
 	],
 	exports: [
 		Label,
+		TextareaLabelComponent,
+		TextInputLabelComponent,
 		TextInput,
 		TextArea
 	],

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -202,8 +202,6 @@ export class Label implements AfterContentInit, AfterViewInit {
 			this.type = "TextArea";
 		} else if (this.textInput) {
 			this.type = "TextInput";
-		} else {
-			this.type = undefined;
 		}
 	}
 

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -17,7 +17,7 @@ import { TextInput } from "./input.directive";
 /**
  * [See demo](../../?path=/story/components-input--label)
  *
- * To prevent attribute drilling, use `ibm-input-label` or `textarea-label` components
+ * To prevent attribute drilling, use `ibm-text-label` or `ibm-textarea-label` components
  *
  * ```html
  * <ibm-label>
@@ -41,7 +41,7 @@ import { TextInput } from "./input.directive";
 
 		<ng-container [ngSwitch]="type">
 			<ng-container *ngSwitchCase="'TextArea'">
-				<ibm-textarea
+				<ibm-textarea-label
 					[labelInputID]="labelInputID"
 					[disabled]="disabled"
 					[skeleton]="skeleton"
@@ -53,10 +53,10 @@ import { TextInput } from "./input.directive";
 					[ariaLabel]="ariaLabel"
 					[labelTemplate]="labelContentTemplate"
 					[textAreaTemplate]="inputContentTemplate">
-				</ibm-textarea>
+				</ibm-textarea-label>
 			</ng-container>
 			<ng-container *ngSwitchCase="'TextInput'">
-				<ibm-text-input
+				<ibm-text-label
 					[labelInputID]="labelInputID"
 					[disabled]="disabled"
 					[skeleton]="skeleton"
@@ -68,7 +68,7 @@ import { TextInput } from "./input.directive";
 					[ariaLabel]="ariaLabel"
 					[labelTemplate]="labelContentTemplate"
 					[textInputTemplate]="inputContentTemplate">
-				</ibm-text-input>
+				</ibm-text-label>
 			</ng-container>
 			<ng-container *ngSwitchDefault>
 				<ng-template [ngTemplateOutlet]="default"></ng-template>
@@ -97,10 +97,7 @@ import { TextInput } from "./input.directive";
 					*ngIf="!warn && invalid"
 					ibmIcon="warning--filled"
 					size="16"
-					[ngClass]="{
-						'bx--text-input__invalid-icon': !textArea,
-						'bx--text-area__invalid-icon': textArea
-					}">
+					class="bx--text-input__invalid-icon">
 				</svg>
 				<svg
 					*ngIf="!invalid && warn"

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -187,7 +187,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 		return this.type === undefined;
 	}
 
-	protected type: "TextArea" | "TextInput";
+	type: "TextArea" | "TextInput";
 
 	/**
 	 * Creates an instance of Label.

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -12,24 +12,17 @@ import {
 } from "@angular/core";
 
 import { TextArea } from "./text-area.directive";
+import { TextInput } from "./input.directive";
 
 /**
  * [See demo](../../?path=/story/components-input--label)
  *
+ * To prevent attribute drilling, use `ibm-input-label` or `textarea-label` components
+ *
  * ```html
- * <ibm-label labelState="success">
- * 	<label label>Field with success</label>
- * 	<input type="text" class="input-field">
- * </ibm-label>
- *
- * <ibm-label labelState="warning">
- * 	<label label>Field with warning</label>
- * 	<input type="text" class="input-field">
- * </ibm-label>
- *
- * <ibm-label labelState="error">
- * 	<label label>Field with error</label>
- * 	<input type="text" class="input-field">
+ * <ibm-label>
+ * 	Label
+ * 	<input ibmText type="text" class="input-field">
  * </ibm-label>
  * ```
  *
@@ -38,55 +31,101 @@ import { TextArea } from "./text-area.directive";
 @Component({
 	selector: "ibm-label",
 	template: `
-		<label
-			[for]="labelInputID"
-			[attr.aria-label]="ariaLabel"
-			class="bx--label"
-			[ngClass]="{
-				'bx--label--disabled': disabled,
-				'bx--skeleton': skeleton
-			}">
-			<ng-content></ng-content>
-		</label>
-		<div
-			[class]="wrapperClass"
-			[ngClass]="{
-				'bx--text-input__field-wrapper--warning': warn
-			}"
-			[attr.data-invalid]="(invalid ? true : null)"
-			#wrapper>
-			<svg
-				*ngIf="!warn && invalid"
-				ibmIcon="warning--filled"
-				size="16"
-				[ngClass]="{
-					'bx--text-input__invalid-icon': !textArea,
-					'bx--text-area__invalid-icon': textArea
-				}">
-			</svg>
-			<svg
-				*ngIf="!invalid && warn"
-				ibmIcon="warning--alt--filled"
-				size="16"
-				class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
-			</svg>
+		<ng-template #inputContentTemplate>
 			<ng-content select="input,textarea,div"></ng-content>
-		</div>
-		<div
-			*ngIf="!skeleton && helperText && !invalid && !warn"
-			class="bx--form__helper-text"
-			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
-			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
-			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
-		</div>
-		<div *ngIf="!warn && invalid" class="bx--form-requirement">
-			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
-			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
-		</div>
-		<div *ngIf="!invalid && warn" class="bx--form-requirement">
-			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
-			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
-		</div>
+		</ng-template>
+
+		<ng-template #labelContentTemplate>
+			<ng-content></ng-content>
+		</ng-template>
+
+		<ng-container [ngSwitch]="type">
+			<ng-container *ngSwitchCase="'TextArea'">
+				<ibm-textarea
+					[labelInputID]="labelInputID"
+					[disabled]="disabled"
+					[skeleton]="skeleton"
+					[helperText]="helperText"
+					[invalid]="invalid"
+					[invalidText]="invalidText"
+					[warn]="warn"
+					[warnText]="warnText"
+					[ariaLabel]="ariaLabel"
+					[labelTemplate]="labelContentTemplate"
+					[textAreaTemplate]="inputContentTemplate">
+				</ibm-textarea>
+			</ng-container>
+			<ng-container *ngSwitchCase="'TextInput'">
+				<ibm-text-input
+					[labelInputID]="labelInputID"
+					[disabled]="disabled"
+					[skeleton]="skeleton"
+					[helperText]="helperText"
+					[invalid]="invalid"
+					[invalidText]="invalidText"
+					[warn]="warn"
+					[warnText]="warnText"
+					[ariaLabel]="ariaLabel"
+					[labelTemplate]="labelContentTemplate"
+					[textInputTemplate]="inputContentTemplate">
+				</ibm-text-input>
+			</ng-container>
+			<ng-container *ngSwitchDefault>
+				<ng-template [ngTemplateOutlet]="default"></ng-template>
+			</ng-container>
+		</ng-container>
+
+		<ng-template #default>
+			<label
+				[for]="labelInputID"
+				[attr.aria-label]="ariaLabel"
+				class="bx--label"
+				[ngClass]="{
+					'bx--label--disabled': disabled,
+					'bx--skeleton': skeleton
+				}">
+				<ng-template [ngTemplateOutlet]="labelContentTemplate"></ng-template>
+			</label>
+			<div
+				class="bx--text-input__field-wrapper"
+				[ngClass]="{
+					'bx--text-input__field-wrapper--warning': warn
+				}"
+				[attr.data-invalid]="(invalid ? true : null)"
+				#wrapper>
+				<svg
+					*ngIf="!warn && invalid"
+					ibmIcon="warning--filled"
+					size="16"
+					[ngClass]="{
+						'bx--text-input__invalid-icon': !textArea,
+						'bx--text-area__invalid-icon': textArea
+					}">
+				</svg>
+				<svg
+					*ngIf="!invalid && warn"
+					ibmIcon="warning--alt--filled"
+					size="16"
+					class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
+				</svg>
+				<ng-template [ngTemplateOutlet]="inputContentTemplate"></ng-template>
+			</div>
+			<div
+				*ngIf="!skeleton && helperText && !invalid && !warn"
+				class="bx--form__helper-text"
+				[ngClass]="{'bx--form__helper-text--disabled': disabled}">
+				<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+				<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+			</div>
+			<div *ngIf="!warn && invalid" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
+				<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+			</div>
+			<div *ngIf="!invalid && warn" class="bx--form-requirement">
+				<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+				<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
+			</div>
+		</ng-template>
 	`
 })
 export class Label implements AfterContentInit, AfterViewInit {
@@ -95,16 +134,13 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 */
 	static labelCounter = 0;
 	/**
-	 * The class of the wrapper
-	 */
-	wrapperClass = "bx--text-input__field-wrapper";
-	/**
 	 * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
 	 * its input counterpart through the 'for' attribute.
 	*/
-	@Input() labelInputID = "ibm-label-" + Label.labelCounter;
+	@Input() labelInputID = "ibm-label-" + Label.labelCounter++;
 
 	/**
+	 * @deprecated as of v4
 	 * State of the `Label` will determine the styles applied.
 	 */
 	@Input() labelState: "success" | "warning" | "error" | "" = "";
@@ -147,21 +183,30 @@ export class Label implements AfterContentInit, AfterViewInit {
 	// @ts-ignore
 	@ContentChild(TextArea, { static: false }) textArea: TextArea;
 
-	@HostBinding("class.bx--form-item") labelClass = true;
+	// @ts-ignore
+	@ContentChild(TextInput, { static: false }) textInput: TextInput;
+
+	@HostBinding("class.bx--form-item") get labelClass() {
+		return this.type === undefined;
+	}
+
+	protected type: "TextArea" | "TextInput";
 
 	/**
 	 * Creates an instance of Label.
 	 */
-	constructor(protected changeDetectorRef: ChangeDetectorRef) {
-		Label.labelCounter++;
-	}
+	constructor(protected changeDetectorRef: ChangeDetectorRef) {}
 
 	/**
 	 * Update wrapper class if a textarea is hosted.
 	 */
 	ngAfterContentInit() {
 		if (this.textArea) {
-			this.wrapperClass = "bx--text-area__wrapper";
+			this.type = "TextArea";
+		} else if (this.textInput) {
+			this.type = "TextInput";
+		} else {
+			this.type = undefined;
 		}
 	}
 

--- a/src/input/label.component.ts
+++ b/src/input/label.component.ts
@@ -209,6 +209,7 @@ export class Label implements AfterContentInit, AfterViewInit {
 	 * Sets the id on the input item associated with the `Label`.
 	 */
 	ngAfterViewInit() {
+		// Will only be called when `default` template is being used
 		if (this.wrapper) {
 			// Prioritize setting id to `input` & `textarea` over div
 			const inputElement = this.wrapper.nativeElement.querySelector("input,textarea");

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -10,7 +10,7 @@ import {
 } from "@angular/core";
 
 @Component({
-	selector: 'ibm-text-input',
+	selector: 'ibm-text-label',
 	template: `
 		<label
 			[for]="labelInputID"

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -87,7 +87,6 @@ export class TextInputLabelComponent implements AfterViewInit {
 	@Input() skeleton = false;
 
 	/**
-	 * **Internal**
 	 * Helper input property for ease of migration
 	 * Since we cannot pass ng-content down easily from label component, we will accept the templates
 	 */

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -1,0 +1,162 @@
+import {
+	Component,
+	Input,
+	AfterViewInit,
+	ElementRef,
+	HostBinding,
+	TemplateRef,
+	ViewChild,
+	ChangeDetectorRef
+} from "@angular/core";
+
+@Component({
+	selector: 'ibm-text-input',
+	template: `
+		<label
+			[for]="labelInputID"
+			[attr.aria-label]="ariaLabel"
+			class="bx--label"
+			[ngClass]="{
+				'bx--label--disabled': disabled,
+				'bx--skeleton': skeleton
+			}">
+			<ng-template *ngIf="labelTemplate; else labelContent" [ngTemplateOutlet]="labelTemplate"></ng-template>
+			<ng-template #labelContent>
+				<ng-content></ng-content>
+			</ng-template>
+		</label>
+		<div
+			class="bx--text-input__field-wrapper"
+			[ngClass]="{
+				'bx--text-input__field-wrapper--warning': warn
+			}"
+			[attr.data-invalid]="(invalid ? true : null)"
+			#wrapper>
+			<svg
+				*ngIf="!warn && invalid"
+				ibmIcon="warning--filled"
+				size="16"
+				class="bx--text-input__invalid-icon">
+			</svg>
+			<svg
+				*ngIf="!invalid && warn"
+				ibmIcon="warning--alt--filled"
+				size="16"
+				class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
+			</svg>
+			<ng-template *ngIf="textInputTemplate; else textInputContent" [ngTemplateOutlet]="textInputTemplate"></ng-template>
+			<ng-template #textInputContent>
+				<ng-content select="input[type=text],div"></ng-content>
+			</ng-template>
+		</div>
+		<div
+			*ngIf="!skeleton && helperText && !invalid && !warn"
+			class="bx--form__helper-text"
+			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
+			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+		</div>
+		<div *ngIf="!warn && invalid" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
+			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+		</div>
+		<div *ngIf="!invalid && warn" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
+		</div>
+	`
+})
+export class TextInputLabelComponent implements AfterViewInit {
+	/**
+	 * Used to build the id of the input item associated with the `Label`.
+	 */
+	static labelCounter = 0;
+	/**
+	 * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
+	 * its input counterpart through the 'for' attribute.
+	*/
+	@Input() labelInputID = "ibm-text-input-" + TextInputLabelComponent.labelCounter++;
+
+	/**
+	 * Set to `true` for a disabled label.
+	 */
+	@Input() disabled = false;
+	/**
+	 * Set to `true` for a loading label.
+	 */
+	@Input() skeleton = false;
+
+	/**
+	 * **Internal**
+	 * Helper input property for ease of migration
+	 * Since we cannot pass ng-content down easily from label component, we will accept the templates
+	 */
+	@Input() labelTemplate: TemplateRef<any>;
+	@Input() textInputTemplate: TemplateRef<any>;
+	/**
+	 * Optional helper text that appears under the label.
+	 */
+	@Input() helperText: string | TemplateRef<any>;
+	/**
+	 * Sets the invalid text.
+	 */
+	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	 * Set to `true` for an invalid label component.
+	 */
+	@Input() invalid = false;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
+	/**
+	 * Set the arialabel for label
+	 */
+	@Input() ariaLabel: string;
+
+	// @ts-ignore
+	@ViewChild("wrapper", { static: false }) wrapper: ElementRef<HTMLDivElement>;
+
+	@HostBinding("class.bx--form-item") labelClass = true;
+
+	/**
+	 * Creates an instance of Label.
+	 */
+	constructor(protected changeDetectorRef: ChangeDetectorRef) {}
+
+	/**
+	 * Sets the id on the input item associated with the `Label`.
+	 */
+	ngAfterViewInit() {
+		if (this.wrapper) {
+			// Prioritize setting id to `input` & `textarea` over div
+			const inputElement = this.wrapper.nativeElement.querySelector("input");
+			if (inputElement) {
+				// avoid overriding ids already set by the user reuse it instead
+				if (inputElement.id) {
+					this.labelInputID = inputElement.id;
+					this.changeDetectorRef.detectChanges();
+				}
+				inputElement.setAttribute("id", this.labelInputID);
+				return;
+			}
+
+			const divElement = this.wrapper.nativeElement.querySelector("div");
+			if (divElement) {
+				if (divElement.id) {
+					this.labelInputID = divElement.id;
+					this.changeDetectorRef.detectChanges();
+				}
+				divElement.setAttribute("id", this.labelInputID);
+			}
+		}
+	}
+
+	public isTemplate(value) {
+		return value instanceof TemplateRef;
+	}
+}

--- a/src/input/text-input-label.component.ts
+++ b/src/input/text-input-label.component.ts
@@ -132,7 +132,7 @@ export class TextInputLabelComponent implements AfterViewInit {
 	 */
 	ngAfterViewInit() {
 		if (this.wrapper) {
-			// Prioritize setting id to `input` & `textarea` over div
+			// Prioritize setting id to `input` over div
 			const inputElement = this.wrapper.nativeElement.querySelector("input");
 			if (inputElement) {
 				// avoid overriding ids already set by the user reuse it instead

--- a/src/input/textarea-label.component.ts
+++ b/src/input/textarea-label.component.ts
@@ -138,7 +138,7 @@ export class TextareaLabelComponent implements AfterViewInit {
 	 */
 	ngAfterViewInit() {
 		if (this.wrapper) {
-			// Prioritize setting id to `input` & `textarea` over div
+			// Prioritize setting id to `textarea` over div
 			const inputElement = this.wrapper.nativeElement.querySelector("textarea");
 			if (inputElement) {
 				// avoid overriding ids already set by the user reuse it instead

--- a/src/input/textarea-label.component.ts
+++ b/src/input/textarea-label.component.ts
@@ -13,7 +13,7 @@ import {
 import { TextArea } from "./text-area.directive";
 
 @Component({
-	selector: 'ibm-textarea',
+	selector: 'ibm-textarea-label',
 	template: `
 		<label
 			[for]="labelInputID"

--- a/src/input/textarea-label.component.ts
+++ b/src/input/textarea-label.component.ts
@@ -90,7 +90,6 @@ export class TextareaLabelComponent implements AfterViewInit {
 	@Input() skeleton = false;
 
 	/**
-	 * **Internal**
 	 * Helper input property for ease of migration
 	 * Since we cannot pass ng-content down easily from label component, we will accept the templates
 	 */

--- a/src/input/textarea-label.component.ts
+++ b/src/input/textarea-label.component.ts
@@ -1,0 +1,168 @@
+import {
+	Component,
+	Input,
+	AfterViewInit,
+	ElementRef,
+	HostBinding,
+	TemplateRef,
+	ViewChild,
+	ContentChild,
+	ChangeDetectorRef
+} from "@angular/core";
+
+import { TextArea } from "./text-area.directive";
+
+@Component({
+	selector: 'ibm-textarea',
+	template: `
+		<label
+			[for]="labelInputID"
+			[attr.aria-label]="ariaLabel"
+			class="bx--label"
+			[ngClass]="{
+				'bx--label--disabled': disabled,
+				'bx--skeleton': skeleton
+			}">
+			<ng-template *ngIf="labelTemplate; else labelContent" [ngTemplateOutlet]="labelTemplate"></ng-template>
+			<ng-template #labelContent>
+				<ng-content></ng-content>
+			</ng-template>
+		</label>
+		<div
+			class="bx--text-area__wrapper"
+			[ngClass]="{
+				'bx--text-input__field-wrapper--warning': warn
+			}"
+			[attr.data-invalid]="(invalid ? true : null)"
+			#wrapper>
+			<svg
+				*ngIf="!warn && invalid"
+				ibmIcon="warning--filled"
+				size="16"
+				class="bx--text-area__invalid-icon">
+			</svg>
+			<svg
+				*ngIf="!invalid && warn"
+				ibmIcon="warning--alt--filled"
+				size="16"
+				class="bx--text-input__invalid-icon bx--text-input__invalid-icon--warning">
+			</svg>
+			<ng-template *ngIf="textAreaTemplate; else textAreaContent" [ngTemplateOutlet]="textAreaTemplate"></ng-template>
+			<ng-template #textAreaContent>
+				<ng-content select="textarea"></ng-content>
+			</ng-template>
+		</div>
+		<div
+			*ngIf="!skeleton && helperText && !invalid && !warn"
+			class="bx--form__helper-text"
+			[ngClass]="{'bx--form__helper-text--disabled': disabled}">
+			<ng-container *ngIf="!isTemplate(helperText)">{{helperText}}</ng-container>
+			<ng-template *ngIf="isTemplate(helperText)" [ngTemplateOutlet]="helperText"></ng-template>
+		</div>
+		<div *ngIf="!warn && invalid" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(invalidText)">{{invalidText}}</ng-container>
+			<ng-template *ngIf="isTemplate(invalidText)" [ngTemplateOutlet]="invalidText"></ng-template>
+		</div>
+		<div *ngIf="!invalid && warn" class="bx--form-requirement">
+			<ng-container *ngIf="!isTemplate(warnText)">{{warnText}}</ng-container>
+			<ng-template *ngIf="isTemplate(warnText)" [ngTemplateOutlet]="warnText"></ng-template>
+		</div>
+	`
+})
+export class TextareaLabelComponent implements AfterViewInit {
+	/**
+	 * Used to build the id of the input item associated with the `Label`.
+	 */
+	static labelCounter = 0;
+	/**
+	 * The id of the input item associated with the `Label`. This value is also used to associate the `Label` with
+	 * its input counterpart through the 'for' attribute.
+	*/
+	@Input() labelInputID = "ibm-textarea-" + TextareaLabelComponent.labelCounter;
+
+	/**
+	 * Set to `true` for a disabled label.
+	 */
+	@Input() disabled = false;
+	/**
+	 * Set to `true` for a loading label.
+	 */
+	@Input() skeleton = false;
+
+	/**
+	 * **Internal**
+	 * Helper input property for ease of migration
+	 * Since we cannot pass ng-content down easily from label component, we will accept the templates
+	 */
+	@Input() labelTemplate: TemplateRef<any>;
+	@Input() textAreaTemplate: TemplateRef<any>;
+	/**
+	 * Optional helper text that appears under the label.
+	 */
+	@Input() helperText: string | TemplateRef<any>;
+	/**
+	 * Sets the invalid text.
+	 */
+	@Input() invalidText: string | TemplateRef<any>;
+	/**
+	 * Set to `true` for an invalid label component.
+	 */
+	@Input() invalid = false;
+	/**
+	  * Set to `true` to show a warning (contents set by warningText)
+	  */
+	@Input() warn = false;
+	/**
+	 * Sets the warning text
+	 */
+	@Input() warnText: string | TemplateRef<any>;
+	/**
+	 * Set the arialabel for label
+	 */
+	@Input() ariaLabel: string;
+
+	// @ts-ignore
+	@ViewChild("wrapper", { static: false }) wrapper: ElementRef<HTMLDivElement>;
+
+	// @ts-ignore
+	@ContentChild(TextArea, { static: false }) textArea: TextArea;
+
+	@HostBinding("class.bx--form-item") labelClass = true;
+
+	/**
+	 * Creates an instance of Label.
+	 */
+	constructor(protected changeDetectorRef: ChangeDetectorRef) {}
+
+	/**
+	 * Sets the id on the input item associated with the `Label`.
+	 */
+	ngAfterViewInit() {
+		if (this.wrapper) {
+			// Prioritize setting id to `input` & `textarea` over div
+			const inputElement = this.wrapper.nativeElement.querySelector("textarea");
+			if (inputElement) {
+				// avoid overriding ids already set by the user reuse it instead
+				if (inputElement.id) {
+					this.labelInputID = inputElement.id;
+					this.changeDetectorRef.detectChanges();
+				}
+				inputElement.setAttribute("id", this.labelInputID);
+				return;
+			}
+
+			const divElement = this.wrapper.nativeElement.querySelector("div");
+			if (divElement) {
+				if (divElement.id) {
+					this.labelInputID = divElement.id;
+					this.changeDetectorRef.detectChanges();
+				}
+				divElement.setAttribute("id", this.labelInputID);
+			}
+		}
+	}
+
+	public isTemplate(value) {
+		return value instanceof TemplateRef;
+	}
+}


### PR DESCRIPTION
#### Changelog

**New**

* New wrapper components 
  * ibm-text-label & ibm-textarea-label - With new features, the label component is starting to get bloated & it's become hard to add new features without over complicating the html with templates. This approach will allow us to ensure we can make independent changes to the component to make it easier to maintain & use.

**Changed**

* We still offer `ibm-label` component, but now the ibm-label will wrap around ibm-text-label & ibm-textarea-label depending on the directive used. The point of this is to prevent a breaking change & ensure QOL. However, this approach does result in prop drilling, so we recommend directly using the new wrapper components if possible.
