### PR TITLE
fix: No longer mark components as experimental

### DIFF
--- a/src/modal/modal-header.component.ts
+++ b/src/modal/modal-header.component.ts
@@ -5,7 +5,6 @@ import {
 	Input
 } from "@angular/core";
 import { I18n } from "carbon-components-angular/i18n";
-import { ExperimentalService } from "carbon-components-angular/experimental";
 
 /**
  * ***Inputs***
@@ -55,7 +54,7 @@ export class ModalHeader {
 	 */
 	@Output() closeSelect = new EventEmitter();
 
-	constructor(protected i18n: I18n, protected experimental: ExperimentalService) {}
+	constructor(protected i18n: I18n) {}
 
 	/**
 	 * Handles click for the close icon button within the `Modal`.

--- a/src/notification/toast.component.ts
+++ b/src/notification/toast.component.ts
@@ -7,7 +7,6 @@ import {
 
 import { ToastContent } from "./notification-content.interface";
 import { Notification } from "./notification.component";
-import { ExperimentalService } from "carbon-components-angular/experimental";
 import { NotificationDisplayService } from "./notification-display.service";
 import { I18n } from "carbon-components-angular/i18n";
 
@@ -85,10 +84,7 @@ export class Toast extends Notification implements OnInit {
 	@HostBinding("class.bx--toast-notification--warning") get isWarning() { return this.notificationObj["type"] === "warning"; }
 	@HostBinding("class.bx--toast-notification--low-contrast") get isLowContrast() { return this.notificationObj.lowContrast; }
 
-	constructor(
-		protected notificationDisplayService: NotificationDisplayService,
-		protected i18n: I18n,
-		protected experimental: ExperimentalService) {
+	constructor(protected notificationDisplayService: NotificationDisplayService, protected i18n: I18n) {
 		super(notificationDisplayService, i18n);
 		// disable inline notification styles
 		this.notificationClass = false;

--- a/src/progress-indicator/progress-indicator.component.ts
+++ b/src/progress-indicator/progress-indicator.component.ts
@@ -2,9 +2,10 @@ import {
 	Component,
 	Input,
 	Output,
-	EventEmitter, OnChanges, SimpleChanges
+	EventEmitter,
+	OnChanges,
+	SimpleChanges
 } from "@angular/core";
-import { ExperimentalService } from "carbon-components-angular/experimental";
 import { Step } from "./progress-indicator-step.interface";
 
 /**
@@ -82,8 +83,6 @@ export class ProgressIndicator implements OnChanges {
 		this._current = current;
 	}
 	private _current: number;
-
-	constructor(protected experimental: ExperimentalService) {}
 
 	ngOnChanges(changes: SimpleChanges) {
 		if (changes.steps || changes.current) {

--- a/src/progress-indicator/progress-indicator.module.ts
+++ b/src/progress-indicator/progress-indicator.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from "@angular/common";
 
 import { ProgressIndicator } from "./progress-indicator.component";
 import { DialogModule } from "carbon-components-angular/dialog";
-import { ExperimentalModule } from "carbon-components-angular/experimental";
 import { IconModule } from "carbon-components-angular/icon";
 
 @NgModule({
@@ -16,7 +15,6 @@ import { IconModule } from "carbon-components-angular/icon";
 	imports: [
 		CommonModule,
 		DialogModule,
-		ExperimentalModule,
 		IconModule
 	]
 })


### PR DESCRIPTION
#### Changelog

**Removed**

* `modal-header`, `toast`, & `progress-indicator` components are no longer marked as experimental. Hence, `ExperimentalService` are no longer injected in constructor. 
* This also means that you will not need to import ExperimentalService on a root level when using Notification service with standalone components!
