### PR TITLE
fix: add aria-describedby attribute to read out tooltip on focus

### DIFF
--- a/src/tooltip/definition-tooptip.component.ts
+++ b/src/tooltip/definition-tooptip.component.ts
@@ -30,9 +30,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			[attr.aria-expanded]="isOpen"
 			[attr.aria-describedby]="isOpen ? id : null"
 			(blur)="onBlur($event)"
-			(focus)="onClick($event)"
-			(mouseover)="onClick($event)"
-			(click)="onClick($event)"
+			(mousedown)="onClick($event)"
 			type="button">
 			<ng-content></ng-content>
 		</button>
@@ -65,6 +63,8 @@ export class TooltipDefinition extends PopoverContainer {
 	 */
 	@Input() templateContext: any;
 
+	@Input() openOnHover = false;
+
 	constructor(
 		protected elementRef: ElementRef,
 		protected ngZone: NgZone,
@@ -95,6 +95,18 @@ export class TooltipDefinition extends PopoverContainer {
 	@HostListener("mouseleave", ["$event"])
 	mouseleave(event) {
 		this.handleChange(false, event);
+	}
+
+	@HostListener("mouseenter", ["$event"])
+	mouseenter(event) {
+		if (this.openOnHover) {
+			this.handleChange(true, event);
+		}
+	}
+
+	@HostListener("focusin", ["$event"])
+	onFocus(event) {
+		this.handleChange(true, event);
 	}
 
 	public isTemplate(value) {

--- a/src/tooltip/definition-tooptip.component.ts
+++ b/src/tooltip/definition-tooptip.component.ts
@@ -28,7 +28,10 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			class="cds--definition-term"
 			[attr.aria-controls]="id"
 			[attr.aria-expanded]="isOpen"
+			[attr.aria-describedby]="isOpen ? id : null"
 			(blur)="onBlur($event)"
+			(focus)="onClick($event)"
+			(mouseover)="onClick($event)"
 			(click)="onClick($event)"
 			type="button">
 			<ng-content></ng-content>
@@ -37,9 +40,9 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			*ngIf="description"
 			class="cds--popover"
 			[id]="id"
-			[attr.aria-hidden]="isOpen"
+			[attr.aria-hidden]="!isOpen"
 			role="tooltip">
-			<span class="cds--popover-content cds--definition-tooltip">
+			<span class="cds--popover-content cds--definition-tooltip" aria-live="polite">
 				<ng-container *ngIf="!isTemplate(description)">{{description}}</ng-container>
 				<ng-template *ngIf="isTemplate(description)" [ngTemplateOutlet]="description" [ngTemplateOutletContext]="{ $implicit: templateContext }"></ng-template>
 				<span *ngIf="autoAlign" class="cds--popover-caret cds--popover--auto-align"></span>

--- a/src/tooltip/definition-tooptip.component.ts
+++ b/src/tooltip/definition-tooptip.component.ts
@@ -30,7 +30,7 @@ import { PopoverContainer } from "carbon-components-angular/popover";
 			[attr.aria-expanded]="isOpen"
 			[attr.aria-describedby]="isOpen ? id : null"
 			(blur)="onBlur($event)"
-			(mousedown)="onClick($event)"
+			(click)="onClick($event)"
 			type="button">
 			<ng-content></ng-content>
 		</button>

--- a/src/tooltip/definition-tooptip.stories.ts
+++ b/src/tooltip/definition-tooptip.stories.ts
@@ -62,6 +62,7 @@ const Template = (args) => ({
 				<p>Custom domains direct requests for your apps in this Cloud Foundry organization to a
 				<cds-tooltip-definition
 					[isOpen]="isOpen"
+					[openOnHover]="openOnHover"
 					[caret]="caret"
 					[align]="align"
 					(onOpen)="onOpen($event)"
@@ -101,6 +102,7 @@ const AutoAlignTemplate = (args) => ({
 				<p>Custom domains direct requests for your apps in this Cloud Foundry organization to a
 				<cds-tooltip-definition
 					[isOpen]="isOpen"
+					[openOnHover]="openOnHover"
 					[caret]="caret"
 					[align]="align"
 					[autoAlign]="true"


### PR DESCRIPTION
Allow definition tooltip popover to be read by screen reader

#### Changelog

**New**

* `openOnHover` input that allows the definition tooltip to on hover

**Changed**

* Added `aria-describedby` to to associate button with tooltip.
