### PR TITLE
fix(dropdown-list):  only updateIndex if there's no index yet

### DIFF
--- a/src/dropdown/list/dropdown-list.component.ts
+++ b/src/dropdown/list/dropdown-list.component.ts
@@ -508,7 +508,7 @@ export class DropdownList implements AbstractDropdownView, AfterViewInit, OnDest
 		const selected = this.getSelected();
 		if (selected.length) {
 			this.index = this.displayItems.indexOf(selected[0]);
-		} else if (this.hasNextElement()) {
+		} else if (this.index < 0 && this.hasNextElement()) {
 			this.getNextElement();
 		}
 	}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#3138

Upon creation of the dropdown-list, the `getUpdateIndex` and `getNextElement` get called 4 times, incrementing the `index` for the highlighted element to the 4th item. This is unwanted behavior and this MR fixes it

#### Changelog

**Changed**

* Check if there's no index set before changing it
