### PR TITLE
fix: use 'close' for modal tooltip text

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -45,7 +45,7 @@ export default {
 		"TITLE": "Loading"
 	},
 	"MODAL": {
-		"CLOSE": "Close modal"
+		"CLOSE": "Close"
 	},
 	"NOTIFICATION": {
 		"CLOSE_BUTTON": "Close alert notification"


### PR DESCRIPTION
Match modal `closeLabel` text to React

#### Changelog
**Changed**

* `Close modal` --> `Close`

