### PR TITLE
fix(SearchComponent): fixed 2-way binding not updating the value on clear action

### DIFF
--- a/src/search/search.component.ts
+++ b/src/search/search.component.ts
@@ -212,13 +212,13 @@ export class Search implements ControlValueAccessor {
 	 */
 	clearSearch(): void {
 		this.value = "";
+		this.doValueChange();
 		this.clear.emit();
-		this.propagateChange(this.value);
 	}
 
 	doValueChange() {
-		this.valueChange.emit(this.value);
 		this.propagateChange(this.value);
+		this.valueChange.emit(this.value);
 	}
 
 	openSearch() {


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#3142

This change is fixing an issue you could experience when using 2-way binding on `value` property or using `ngModel`

#### Changelog

**Changed**

* `clearSearch` will now emit `valueChange` to correctly update 2-way binding
* `doValueChange` will now `propagateChanges` first and then emit the outputs so that `ngModel` is up to date at the time or running the output
