### PR TITLE
feat: add new placement option to  overflow menu

### DIFF
--- a/src/dialog/overflow-menu/overflow-menu.component.ts
+++ b/src/dialog/overflow-menu/overflow-menu.component.ts
@@ -96,7 +96,7 @@ export class OverflowMenu extends BaseIconButton {
 
 	@Input() flip = false;
 
-	@Input() placement: "bottom" | "top" = "bottom";
+	@Input() placement: "bottom" | "top" | "bottom,top" | "top,bottom" = "bottom";
 
 	@Input() open = false;
 


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#

Linked to issue [3158](https://github.com/carbon-design-system/carbon-components-angular/issues/3158)

The overflow menu uses the dialog underneath that allows other placement option

#### Changelog

**New**

* OverflowMenu: add two new option to switch display if there is not enough place in the desired direction

