### PR TITLE
fix: IconSizeNotFoundError message not interpolated

### DIFF
--- a/src/icon/icon.service.ts
+++ b/src/icon/icon.service.ts
@@ -110,7 +110,7 @@ export class IconNameNotFoundError extends Error {
  */
 export class IconSizeNotFoundError extends Error {
 	constructor(size: string, name: string) {
-		super("Size ${size} for ${name} not found");
+		super(`Size ${size} for ${name} not found`);
 	}
 }
 


### PR DESCRIPTION
Closes [carbon-design-system/carbon-components-angular#3167](https://github.com/carbon-design-system/carbon-components-angular/issues/3167)

Error message does not inject variables

#### Changelog

**Changed**

* fix quotes in error message to display values

