### PR TITLE
fix: prevent content menu item click when disabled

### DIFF
--- a/src/combobox/stories/app-mock-query-search.component.ts
+++ b/src/combobox/stories/app-mock-query-search.component.ts
@@ -23,12 +23,12 @@ export class MockQueryCombobox {
 				{ content: `Random ${Math.random()}` },
 				{ content: `Random ${Math.random()}` },
 				{ content: `Random ${Math.random()}` },
-				{ content: `Random ${Math.random()}` },
+				{ content: `Random ${Math.random()}` }
 			];
 
 			// Include current selected in the list to avoid auto clear
 			if (this.currentlySelected) {
-				array.push(this.currentlySelected)
+				array.push(this.currentlySelected);
 			}
 			this.filterItems = array;
 		}, 1000);

--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -117,6 +117,9 @@ export class ContextMenuItemComponent implements OnInit, AfterContentInit, OnDes
 	@HostListener("click", ["$event"])
 	handleClick(event: MouseEvent & KeyboardEvent) {
 		event.stopPropagation();
+		if (this.disabled) {
+			return;
+		}
 		if (this.hasChildren) {
 			this.openSubMenu();
 			this.childContextMenu.focusMenu();

--- a/src/datepicker/datepicker.component.ts
+++ b/src/datepicker/datepicker.component.ts
@@ -510,8 +510,8 @@ export class DatePicker implements
 
 					const calendarContainer = this.flatpickrInstance.calendarContainer;
 					const dayElement = calendarContainer && calendarContainer.querySelector(".flatpickr-day[tabindex]");
-					const selectedDateElem = calendarContainer && calendarContainer.querySelector('.selected');
-					const todayDateElem = calendarContainer && calendarContainer.querySelector('.today');
+					const selectedDateElem = calendarContainer && calendarContainer.querySelector(".selected");
+					const todayDateElem = calendarContainer && calendarContainer.querySelector(".today");
 
 					if (dayElement) {
 						(todayDateElem || selectedDateElem || dayElement).focus();
@@ -593,7 +593,7 @@ export class DatePicker implements
 
 		// add day classes and special case the "today" element based on `this.value`
 		Array.from(dayContainer).forEach(element => {
-			element.setAttribute('role', 'button');
+			element.setAttribute("role", "button");
 			element.classList.add("cds--date-picker__day");
 			if (!this.value) {
 				return;


### PR DESCRIPTION
- When the content menu item is disabled the checkbox can be selected and de-selected. This has been fixed as part of this PR. 
- Fixes #3184 
- Fixed LINT errors