### PR TITLE
fix: track items in breadcrumbs by index instead of the identity

### DIFF
--- a/src/breadcrumb/breadcrumb.component.ts
+++ b/src/breadcrumb/breadcrumb.component.ts
@@ -62,7 +62,7 @@ const MINIMUM_OVERFLOW_THRESHOLD = 4;
 						triggerClass="cds--btn--icon-only"
 						[description]="description"
 						[autoAlign]="autoAlign">
-						@for (item of overflowItems; track item) {
+						@for (item of overflowItems; track $index) {
 							<li class="cds--overflow-menu-options__option">
 								<a class="cds--overflow-menu-options__btn"
 									href="{{item?.href}}"
@@ -105,7 +105,7 @@ const MINIMUM_OVERFLOW_THRESHOLD = 4;
 					}
 				</cds-breadcrumb-item>
 			} @else {
-				@for (item of items; track item) {
+				@for (item of items; track $index) {
 					<cds-breadcrumb-item
 						[href]="item.href"
 						[route]="item.route"


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#

tracks items in the for loops of the breadcrumbs by $index instead of the identity which removes the warning:
<img width="659" height="72" alt="image" src="https://github.com/user-attachments/assets/f26955d5-e986-444d-8f2b-ad5dd8328916" />


#### Changelog

**Changed**

* tracks items in the for loop in the breadcrumb-component by index
