### PR TITLE
fix: styles of context menu item content

### DIFF
--- a/src/context-menu/context-menu-item.component.ts
+++ b/src/context-menu/context-menu-item.component.ts
@@ -33,7 +33,11 @@ import { ItemClickEvent } from "./context-menu.types";
 	`,
 	styles: [`
 		:host {
-			grid-template-columns: 1rem 1fr max-content;
+			grid-template-columns: 1fr max-content;
+
+			&[icon], &[type="checkbox"], &[type="radio"] {
+				grid-template-columns: 1rem 1fr max-content;
+			}
 		}
 	`]
 })

--- a/src/context-menu/context-menu.component.ts
+++ b/src/context-menu/context-menu.component.ts
@@ -47,11 +47,6 @@ export class ContextMenuComponent implements OnChanges, AfterViewInit {
 	@HostBinding("attr.tabindex") tabindex = "-1";
 	@HostBinding("style.left.px") get leftPosition() { return this.position.left; }
 	@HostBinding("style.top.px") get topPosition() { return this.position.top; }
-
-	/**
-	 * @todo - convert to getter in v6, should resolve expression has changed
-	 * after switching to on OnPush Change Detection Strategy
-	 */
 	@HostBinding("class.cds--menu--with-icons") iconClass = false;
 
 	constructor(protected elementRef: ElementRef) { }
@@ -66,8 +61,8 @@ export class ContextMenuComponent implements OnChanges, AfterViewInit {
 		setTimeout(() => {
 			const nativeElement = this.elementRef.nativeElement;
 			if (nativeElement) {
-				this.iconClass = !!nativeElement
-					.querySelector(".cds--menu-item .cds--menu-item__icon svg");
+				this.iconClass = !!this.elementRef.nativeElement
+					.querySelectorAll(".cds--menu-item[icon], .cds--menu-item[type='checkbox'], .cds--menu-item[type='radio']").length;
 			}
 		});
 	}


### PR DESCRIPTION
Previously when no icons or only select icons are used the item name was diplayed with the 1rem icon width. This fix enables the correct use of context-menu-items with and without icons.

<img width="235" height="241" alt="Screenshot From 2025-11-25 11-40-25" src="https://github.com/user-attachments/assets/eaacf0d0-24e9-4445-befe-2c073366ee8c" />
<img width="235" height="241" alt="Screenshot From 2025-11-25 11-40-49" src="https://github.com/user-attachments/assets/9879a7c2-0163-40c9-a743-37e759c00abc" />



#### Changelog

**New**

**Changed**

* context-menu-item styles

**Removed**

