### PR TITLE
fix: class format when using column directive's offsets

### DIFF
--- a/src/grid/column.directive.ts
+++ b/src/grid/column.directive.ts
@@ -114,7 +114,7 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 						 * These objects are used to position the column
 						 */
 						if (this.columnNumbers[key]["start"]) {
-							// col-start is simular equivalent of flex offset
+							// col-start is similar equivalent of flex offset
 							this._columnClasses.push(`cds--${key}:col-start-${this.columnNumbers[key].start}`);
 						}
 						if (this.columnNumbers[key]["end"]) {
@@ -129,7 +129,7 @@ export class ColumnDirective implements OnInit, OnChanges, OnDestroy {
 				});
 
 				Object.keys(this.offsets).forEach(key => {
-					this._columnClasses.push(`cds--${key}:col-start${this.offsets[key] + 1}`);
+					this._columnClasses.push(`cds--${key}:col-start-${this.offsets[key] + 1}`);
 				});
 			} else {
 				// Set column classes for flex grid


### PR DESCRIPTION
Closes [carbon-design-system/carbon-components-angular#3207
](https://github.com/carbon-design-system/carbon-components-angular/issues/3207)

Using offsets with column directive doesn't work

#### Changelog

**Changed**

* add dash in generating class name when using offsets
