### PR TITLE
ci: use OIDC instead of token for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Publish package
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm run semantic-release
 
       # Push storybook build to gh-pages branch if pushed to `master` branch


### PR DESCRIPTION
Remove NPM_TOKEN and use OIDC Trusted Publishing