### PR TITLE
feat(IconService): added missing size fallback to support pictograms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@angular/platform-browser-dynamic": "14.3.0",
         "@angular/router": "14.3.0",
         "@babel/core": "7.9.6",
+        "@carbon/pictograms": "^12.69.0",
         "@carbon/styles": "1.88.0",
         "@carbon/themes": "11.24.0",
         "@commitlint/cli": "17.0.3",
@@ -3857,6 +3858,17 @@
       "version": "11.33.0",
       "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.33.0.tgz",
       "integrity": "sha512-ZfWSbIfYdjfgUPfFiPVE0cYjIHiQljAaxuOhElnLmFqNMhBZengnhLiIgKgAMZg1cy5Iog/0T4b+obCFmEuKeg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "node_modules/@carbon/pictograms": {
+      "version": "12.69.0",
+      "resolved": "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-12.69.0.tgz",
+      "integrity": "sha512-y4yrYyiZKDHHdbp8KtOK2w6CQl5NgJfYv/B+CECt9UvEP5xVZpq0qTinXA85R2JZBUDBEQEIEAVwz8pMCQ+uIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -39063,6 +39075,15 @@
       "version": "11.33.0",
       "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.33.0.tgz",
       "integrity": "sha512-ZfWSbIfYdjfgUPfFiPVE0cYjIHiQljAaxuOhElnLmFqNMhBZengnhLiIgKgAMZg1cy5Iog/0T4b+obCFmEuKeg==",
+      "dev": true,
+      "requires": {
+        "@ibm/telemetry-js": "^1.5.0"
+      }
+    },
+    "@carbon/pictograms": {
+      "version": "12.69.0",
+      "resolved": "https://registry.npmjs.org/@carbon/pictograms/-/pictograms-12.69.0.tgz",
+      "integrity": "sha512-y4yrYyiZKDHHdbp8KtOK2w6CQl5NgJfYv/B+CECt9UvEP5xVZpq0qTinXA85R2JZBUDBEQEIEAVwz8pMCQ+uIA==",
       "dev": true,
       "requires": {
         "@ibm/telemetry-js": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@angular/platform-browser-dynamic": "14.3.0",
     "@angular/router": "14.3.0",
     "@babel/core": "7.9.6",
+    "@carbon/pictograms": "^12.69.0",
     "@carbon/styles": "1.88.0",
     "@carbon/themes": "11.24.0",
     "@commitlint/cli": "17.0.3",

--- a/src/icon/icon.service.ts
+++ b/src/icon/icon.service.ts
@@ -195,8 +195,8 @@ export class IconService {
 	 * Registers an icon based on a uniqe name and metadata provided by `@carbon/icons`
 	 */
 	public registerAs(name: string, descriptor: object) {
-		const { size } = descriptor as IconDescriptor;
-		this.iconCache.set(name, size.toString(), descriptor);
+		let { size, attrs: { width } } = descriptor as IconDescriptor;
+		this.iconCache.set(name, (size ?? width).toString(), descriptor);
 	}
 
 	/**

--- a/src/icon/icon.stories.ts
+++ b/src/icon/icon.stories.ts
@@ -68,7 +68,8 @@ const AllPictogramsTemplate = (args) => ({
 	template: `
 		<!--
 			app-* components are for demo purposes only.
-			You can create your own implementation by using the component source as an example.
+			You can create your own implementation by using the component source found at:
+			https://github.com/IBM/carbon-components-angular/tree/master/src/icon/stories/pictograms-demo.component.ts
 		-->
 		<app-demo-many-pictograms></app-demo-many-pictograms>
 	`

--- a/src/icon/icon.stories.ts
+++ b/src/icon/icon.stories.ts
@@ -3,7 +3,8 @@
 
 import { moduleMetadata, Meta } from "@storybook/angular";
 import { IconModule, IconDirective } from "./";
-import { IconDemo, ManyIconDemo } from "./stories";
+import { GridModule } from '../grid';
+import { IconDemo, ManyIconDemo, ManyPictogramsDemo } from "./stories";
 
 export default {
 	title: "Components/Icon",
@@ -11,10 +12,12 @@ export default {
 		moduleMetadata({
 			declarations: [
 				IconDemo,
-				ManyIconDemo
+				ManyIconDemo,
+				ManyPictogramsDemo
 			],
 			imports: [
-				IconModule
+				IconModule,
+				GridModule
 			]
 		})
 	],
@@ -59,3 +62,15 @@ const AllIconTemplate = (args) => ({
 	`
 });
 export const AllIcon = AllIconTemplate.bind({});
+
+const AllPictogramsTemplate = (args) => ({
+	props: args,
+	template: `
+		<!--
+			app-* components are for demo purposes only.
+			You can create your own implementation by using the component source as an example.
+		-->
+		<app-demo-many-pictograms></app-demo-many-pictograms>
+	`
+});
+export const AllPictograms = AllPictogramsTemplate.bind({});

--- a/src/icon/stories/index.ts
+++ b/src/icon/stories/index.ts
@@ -1,3 +1,3 @@
 export * from "./icon-demo.component";
 export * from "./many-icons-demo.component";
-export * from "./pictograms.component";
+export * from "./pictograms-demo.component";

--- a/src/icon/stories/index.ts
+++ b/src/icon/stories/index.ts
@@ -1,2 +1,3 @@
 export * from "./icon-demo.component";
 export * from "./many-icons-demo.component";
+export * from "./pictograms.component";

--- a/src/icon/stories/pictograms-demo.component.ts
+++ b/src/icon/stories/pictograms-demo.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from "@angular/core";
 import * as Icons from "@carbon/pictograms";
 
-import { IconService } from "../";
+import { IconService } from "..";
 
 @Component({
 	selector: "app-demo-many-pictograms",
@@ -19,7 +19,6 @@ import { IconService } from "../";
 	styles: [
 		`
 			.pictogram {
-				white-space: nowrap;
 				padding: 1rem 0;
 			}
 		`
@@ -38,7 +37,6 @@ export class ManyPictogramsDemo implements OnInit {
 				if (!iconMap.has(descriptor["name"])) {
 					iconMap.set(descriptor["name"], descriptor);
 				}
-				// iconMap.get(descriptor["name"]).push(descriptor);
 			}
 		}
 		// Render after a delay to prevent page from freezing

--- a/src/icon/stories/pictograms.component.ts
+++ b/src/icon/stories/pictograms.component.ts
@@ -1,0 +1,49 @@
+import { Component, OnInit } from "@angular/core";
+import * as Icons from "@carbon/pictograms";
+
+import { IconService } from "../";
+
+@Component({
+	selector: "app-demo-many-pictograms",
+	template: `
+		<div cdsGrid>
+			<div cdsRow>
+				<div cdsCol [columnNumbers]="{'xl': 4, 'lg': 4, 'md': 4, 'sm': 2}" *ngFor="let icon of groupedIcons" class="pictogram">
+					<svg [cdsIcon]="icon.name" size="64"></svg>
+					<div>name: <code>{{icon.name}}</code></div>
+					<div>size: <code>64</code></div>
+				</div>
+			</div>
+		</div>
+	`,
+	styles: [
+		`
+			.pictogram {
+				white-space: nowrap;
+				padding: 1rem 0;
+			}
+		`
+	]
+})
+export class ManyPictogramsDemo implements OnInit {
+	groupedIcons: any = [];
+
+	constructor(protected iconService: IconService) { }
+
+	ngOnInit() {
+		const iconMap = new Map();
+		for (const descriptor of Object.values(Icons)) {
+			this.iconService.register(descriptor as any);
+			if (typeof descriptor === "object" && descriptor) {
+				if (!iconMap.has(descriptor["name"])) {
+					iconMap.set(descriptor["name"], descriptor);
+				}
+				// iconMap.get(descriptor["name"]).push(descriptor);
+			}
+		}
+		// Render after a delay to prevent page from freezing
+		setTimeout(() => {
+			this.groupedIcons = Array.from(iconMap.values());
+		}, 1000);
+	}
+}


### PR DESCRIPTION
Closes carbon-design-system/carbon-components-angular#3249

Added a fallback if the size property is missing as in `@carbon/pictograms`, so that they can be loaded and displayed correctly with the IconService and IconDirective

#### Changelog

**Changed**

* IconService now support pictograms from `@carbon/pictograms` as well
